### PR TITLE
Manage memtx_memory in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Increasing memtx_memory without instance restart
+* `restarted` flag to force instance restart
+
 ## [0.2.0] - 2019-11-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ all:
           config:
             advertise_uri: '172.19.0.2:3302'
             http_port: 8082
+          restarted: true  # force instance restart
 
     host2:
       vars:
@@ -152,6 +153,7 @@ Configuration format is described in detail in the
   indicates if the Tarantool repository should be enabled (for packages with
   open-source Tarantool dependency);
 * `config` (`dict`, required): instance configuration;
+* `restarted`(`boolean`, optional, default: `false`): indicates that instance must be restarted;
 * `replicaset_alias` (`string`, optional) - replicaset alias, will be displayed in Web UI;
 * `leader` (`string`, required if `replicaset_alias` specified) - name of leader instance;
 * `roles` (`list-of-strings`, required if `replicaset_alias` specified) - roles to be enabled on the replicaset.
@@ -287,6 +289,14 @@ Environment=TARANTOOL_CFG=/etc/tarantool/conf.d/
 Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${app_name}.{instance_name}.pid
 Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${app_name}.{instance_name}.control
 ```
+
+#### Increasing memtx_memory in runtime
+
+If you specified in `config.memtx_memory` value that increases current `memtx_memory`, this role will try to increase this value in runtime.
+In case of success instance wouldn't be restarted (if other parameters haven't been changed).
+
+**Note**, that if `restarted` flag is set, instance will be restarted anyway without changing `memtx_memory` in runtime.
+You can use this flag to force instance restarting.
 
 ### Replica sets
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Configuration format is described in detail in the
   indicates if the Tarantool repository should be enabled (for packages with
   open-source Tarantool dependency);
 * `config` (`dict`, required): instance configuration;
-* `restarted`(`boolean`, optional, default: `false`): indicates that instance must be restarted;
+* restarted`(`boolean, optional, default: `false`): indicates that instance must be forcedly restarted;
 * `replicaset_alias` (`string`, optional) - replicaset alias, will be displayed in Web UI;
 * `leader` (`string`, required if `replicaset_alias` specified) - name of leader instance;
 * `roles` (`list-of-strings`, required if `replicaset_alias` specified) - roles to be enabled on the replicaset.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 cartridge_defaults: {}
 cartridge_enable_tarantool_repo: true
+restarted: false

--- a/library/cartridge_instance.py
+++ b/library/cartridge_instance.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.helpers import ModuleRes, CartridgeException
+from ansible.module_utils.helpers import get_control_console
+
+import os
+
+
+argument_spec = {
+    'control_sock': {'required': True, 'type': 'str'},
+    'config': {'required': True, 'type': 'dict'},
+    'cartridge_defaults': {'required': True, 'type': 'dict'},
+}
+
+
+def manage_instance(params):
+    config = params['config']
+    cartridge_defaults = params['cartridge_defaults']
+    control_sock = params['control_sock']
+
+    # Check if memtx_memory parameter is specified
+    if 'memtx_memory' not in config and 'memtx_memory' not in cartridge_defaults:
+        return ModuleRes(success=True, changed=False)
+
+    new_memtx_memory = None
+    if 'memtx_memory' in config:
+        new_memtx_memory = config['memtx_memory']
+    else:
+        new_memtx_memory = cartridge_defaults['memtx_memory']
+
+    # Check if instance is started
+    if not os.path.exists(control_sock):
+        return ModuleRes(success=True, changed=False)
+
+    control_console = get_control_console(control_sock)
+
+    # Get current memtx memory
+    current_memtx_memory = control_console.eval('''
+        return type(box.cfg) ~= 'function' and box.cfg.memtx_memory or require('json').NULL
+    ''')
+
+    if new_memtx_memory <= current_memtx_memory:
+        return ModuleRes(success=True, changed=False)
+
+    # try to increase memtx_memory
+    increased = control_console.eval('''
+        local ok, err = pcall(function()
+            box.cfg {{ memtx_memory = {} }}
+        end)
+        if not ok then
+            if tostring(err):find("cannot decrease memory size at runtime") == nil then
+                error('failed to set memtx_memory: ' .. tostring(err))
+            end
+        end
+        return ok
+    '''.format(new_memtx_memory))
+
+    return ModuleRes(success=True, changed=increased)
+
+
+def main():
+    module = AnsibleModule(argument_spec=argument_spec)
+    try:
+        res = manage_instance(module.params)
+    except CartridgeException as e:
+        module.fail_json(msg=str(e))
+
+    if res.success is True:
+        module.exit_json(changed=res.changed, meta=res.meta)
+    else:
+        module.fail_json(msg=res.msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/cartridge_instance.py
+++ b/library/cartridge_instance.py
@@ -39,6 +39,9 @@ def manage_instance(params):
     current_memtx_memory = control_console.eval('''
         return type(box.cfg) ~= 'function' and box.cfg.memtx_memory or require('json').NULL
     ''')
+    if current_memtx_memory is None:
+        # box.cfg wasn't called
+        return ModuleRes(success=True, changed=False)
 
     if new_memtx_memory <= current_memtx_memory:
         return ModuleRes(success=True, changed=False)

--- a/library/cartridge_needs_restart.py
+++ b/library/cartridge_needs_restart.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.helpers import ModuleRes, CartridgeException
+from ansible.module_utils.helpers import get_control_console
+
+import os
+
+
+argument_spec = {
+    'restart_forced': {'required': True, 'type': 'bool'},
+    'control_sock': {'required': True, 'type': 'str'},
+    'appname': {'required': True, 'type': 'str'},
+    'instance_name': {'required': True, 'type': 'str'},
+    'cluster_cookie': {'required': True, 'type': 'str'},
+    'cartridge_defaults': {'required': True, 'type': 'dict'},
+    'config': {'required': True, 'type': 'dict'},
+}
+
+
+def read_yaml_file_section(filepath, control_console, section):
+    sections = control_console.eval('''
+        local file = require('fio').open('{}')
+        if file == nil then
+            error('Failed to open instance config file')
+        end
+
+        local buf = {{}}
+        while true do
+            local val = file:read(1024)
+            if val == nil then
+                error('Failed to read from instance config file')
+            elseif val == '' then
+                break
+            end
+            table.insert(buf, val)
+        end
+        file:close()
+
+        local data = table.concat(buf, '')
+        local ok, ret = pcall(require('yaml').decode, data)
+        if not ok then
+            error('Failed to decode instance config from YAML')
+        end
+        return ret
+    '''.format(filepath))
+
+    if section not in sections:
+        raise CartridgeException('Instance file does not contain required section')
+
+    return sections[section]
+
+
+def check_conf_updated(new_conf, old_conf, ignore_keys=[]):
+    # check new conf keys
+    for key, value in new_conf.items():
+        if key not in ignore_keys:
+            if key not in old_conf or old_conf[key] != value:
+                return True
+
+    # check old conf keys
+    for key, value in old_conf.items():
+        if key not in ignore_keys:
+            if key not in new_conf or new_conf[key] != value:
+                return True
+
+    return False
+
+
+def get_memtx_memory(control_console):
+    return control_console.eval('''
+        return type(box.cfg) ~= 'function' and box.cfg.memtx_memory or require('json').NULL
+    ''')
+
+
+def needs_restart(params):
+    restart_forced = params['restart_forced']
+    if restart_forced:
+        return ModuleRes(success=True, changed=True)
+
+    control_sock = params['control_sock']
+    appname = params['appname']
+    instance_name = params['instance_name']
+    new_default_conf = params['cartridge_defaults']
+    new_instance_conf = params['config']
+    cluster_cookie = params['cluster_cookie']
+
+    instance_conf_path = '/etc/tarantool/conf.d/{}.{}.yml'.format(appname, instance_name)
+    default_conf_path = '/etc/tarantool/conf.d/{}.yml'.format(appname)
+    app_code_path = '/usr/share/tarantool/{}'.format(appname)
+
+    # check if instance was not started yet
+    if not os.path.exists(control_sock):
+        return ModuleRes(success=True, changed=True)
+
+    last_restart_time = os.path.getmtime(control_sock)
+
+    # check if application code was updated
+    package_update_time = os.path.getmtime(app_code_path)
+    if last_restart_time < package_update_time:
+        return ModuleRes(success=True, changed=True)
+
+    control_console = get_control_console(control_sock)
+
+    # check if instance config was changed (except memtx_memory)
+    current_instance_conf = read_yaml_file_section(
+        instance_conf_path,
+        control_console,
+        '{}.{}'.format(appname, instance_name)
+    )
+    if check_conf_updated(new_instance_conf, current_instance_conf, ['memtx_memory']):
+        return ModuleRes(success=True, changed=True)
+
+    # check if default config was changed (except memtx_memory)
+    current_default_conf = read_yaml_file_section(
+        default_conf_path,
+        control_console,
+        appname
+    )
+    new_default_conf.update({'cluster_cookie': cluster_cookie})
+    if check_conf_updated(new_default_conf, current_default_conf, ['memtx_memory']):
+        return ModuleRes(success=True, changed=True)
+
+    new_memtx_memory = None
+    if 'memtx_memory' in new_instance_conf:
+        new_memtx_memory = new_instance_conf['memtx_memory']
+    elif 'memtx_memory' in new_default_conf:
+        new_memtx_memory = new_default_conf['memtx_memory']
+
+    # check if memtx_memory was changed in config but wasn't changed on instance
+    if new_memtx_memory is not None:
+        current_memtx_memory = get_memtx_memory(control_console)
+        if current_memtx_memory != new_memtx_memory:
+            return ModuleRes(success=True, changed=True)
+
+    return ModuleRes(success=True, changed=False)
+
+
+def main():
+    module = AnsibleModule(argument_spec=argument_spec)
+    try:
+        res = needs_restart(module.params)
+    except CartridgeException as e:
+        module.fail_json(msg=str(e))
+
+    if res.success is True:
+        module.exit_json(changed=res.changed, meta=res.meta)
+    else:
+        module.fail_json(msg=res.msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -73,6 +73,7 @@ def validate_types(vars):
         },
         'config': {
             'advertise_uri': str,
+            'memtx_memory': int,
         },
         'roles': [str],
         'leader': str,

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -91,6 +91,7 @@ all:
               config:
                 advertise_uri: 'vm2:3311'
                 http_port: 8091
+                memtx_memory: 268436000
 
             storage-1-replica-2:
               config:

--- a/tasks/start_instance.yml
+++ b/tasks/start_instance.yml
@@ -1,4 +1,24 @@
 ---
+- name: Manage instance parameters in runtime
+  cartridge_instance:
+    control_sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ inventory_hostname }}.control
+    config: '{{ config }}'
+    cartridge_defaults: '{{ cartridge_defaults }}'
+  when: >-
+    not restarted and
+    (config.memtx_memory is defined or cartridge_defaults.memtx_memory is defined )
+
+- name: Check if instance restart is forced or required to apply changes
+  cartridge_needs_restart:
+    restart_forced: '{{ restarted }}'
+    control_sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ inventory_hostname }}.control
+    appname: '{{ cartridge_app_name }}'
+    instance_name: '{{ inventory_hostname }}'
+    cluster_cookie: '{{ cartridge_cluster_cookie }}'
+    cartridge_defaults: '{{ cartridge_defaults }}'
+    config: '{{ config }}'
+  notify: restart-instance
+
 - name: Place default config
   copy:
     content: >-
@@ -22,30 +42,3 @@
     owner: tarantool
     group: tarantool
     mode: '644'
-  notify: restart-instance
-
-- name: Get package update time
-  stat:
-    path: /usr/share/tarantool/{{ cartridge_app_name }}
-    get_attributes: true
-  register: package_st
-
-- name: Get default config update time
-  stat:
-    path: /etc/tarantool/conf.d/{{ cartridge_app_name }}.yml
-    get_attributes: true
-  register: default_conf_st
-
-- name: Get service restart time
-  stat:
-    path: /var/run/tarantool/{{ cartridge_app_name }}.{{ inventory_hostname }}.control
-    get_attributes: true
-  register: socket_st
-
-- name: Check if instance restart is required
-  command: /bin/true
-  notify: restart-instance
-  changed_when: >-
-    not socket_st.stat.exists
-    or socket_st.stat.mtime < package_st.stat.mtime
-    or socket_st.stat.mtime < default_conf_st.stat.mtime


### PR DESCRIPTION
Try to increase memtx_memory without instance restart (using
`cartridge_instance` module)
Add `cartridge_needs_restart` module to check if instance restart is
required
Add `restarted` variable to specify that instance must be restarted
Describe changes in README