### PR TITLE
Prevent error on control instance selection

### DIFF
--- a/filter_plugins/filter_hosts.py
+++ b/filter_plugins/filter_hosts.py
@@ -14,8 +14,19 @@ def one_not_expelled_instance_for_machine(hostvars, play_hosts):
     return res
 
 
+def one_not_expelled_instance(hostvars, play_hosts):
+    for i in play_hosts:
+        if 'expelled' in hostvars[i] and hostvars[i]['expelled']:
+            continue
+
+        return i
+
+    raise Exception('At least one play host should be non-expelled')
+
+
 class FilterModule(object):
     def filters(self):
         return {
             'one_not_expelled_instance_for_machine': one_not_expelled_instance_for_machine,
+            'one_not_expelled_instance': one_not_expelled_instance,
         }

--- a/tasks/install_rpm.yml
+++ b/tasks/install_rpm.yml
@@ -27,7 +27,7 @@
   vars:
     repository: 'tarantool/{{ tnt_version[0] }}_{{ tnt_version[1] }}'
     package_type: rpm
-  when: '"tarantool" in deplist.stdout and cartridge_enable_tarantool_repo'
+  when: 'cartridge_enable_tarantool_repo and "tarantool" in deplist.stdout'
 
 - name: Install RPM
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,9 +61,10 @@
 
 - name: Set one control instance to join replicasets
   cartridge_control_instance:
-    sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ inventory_hostname }}.control
+    sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ hostvars | one_not_expelled_instance(play_hosts) }}.control
   register: control_instance
   run_once: true
+  delegate_to: '{{ hostvars | one_not_expelled_instance(play_hosts) }}'
   tags: cartridge-replicasets
 
 - name: Get replicasets
@@ -93,10 +94,11 @@
 
 - name: Set one control instance to rule them all
   cartridge_control_instance:
-    sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ inventory_hostname }}.control
+    sock: /var/run/tarantool/{{ cartridge_app_name }}.{{ hostvars | one_not_expelled_instance(play_hosts) }}.control
     allow_empty: false
   register: control_instance
   run_once: true
+  delegate_to: '{{ hostvars | one_not_expelled_instance(play_hosts) }}'
   when: >-
     cartridge_auth is defined
     or cartridge_app_config is defined


### PR DESCRIPTION
Delegate selection control instance to non-expelled host
Add filter_plugin to select one non-expelled play host
Fix error on installing opensource Tarantool RPM with
cartridge_enable_tarantool_repo set to false