### PR TITLE
Fix Gitlab CI tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN set -x \
         docker python3-dev py3-pip docker \
         gcc git curl build-base autoconf automake py3-cryptography linux-headers \
         musl-dev libffi-dev openssl-dev openssh bash \
-    && pip3 install --upgrade ansible molecule docker flake8 testinfra
+    && pip3 install --upgrade ansible molecule==3.0.2 docker flake8 testinfra


### PR DESCRIPTION
In molecule version 3.0.3 docker network is recreated on `create`
It discards MTU settings for `cartridge-network` created manually
