### PR TITLE
Set `any_errors_fatal: true` for package installation tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ README.md and examples/getting-started-app/README.md
 to use the newest tag with new release
 -->
 
+### Changed
+
+- `any_errors_fatal: true` is set for package installation tasks
+
 ## [1.2.0] - 2020-04-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To deploy an application and set up this topology:
   hosts: all
   become: true
   become_user: root
+  any_errors_fatal: true
   tasks:
   - name: Import Tarantool Cartridge role
     import_role:

--- a/examples/getting-started-app/README.md
+++ b/examples/getting-started-app/README.md
@@ -301,6 +301,7 @@ and import the Tarantool Cartridge role.
   hosts: all
   become: true
   become_user: root
+  any_errors_fatal: true
   tasks:
   - name: Import Tarantool Cartridge role
     import_role:

--- a/tasks/enable_tarantool_repo.yml
+++ b/tasks/enable_tarantool_repo.yml
@@ -7,7 +7,9 @@
   until: not get_script.failed
   retries: 3
   delay: 5
+  any_errors_fatal: true
 
 - name: Run repository setup script
   command: bash /tmp/script.{{ package_type }}.sh
   changed_when: false
+  any_errors_fatal: true

--- a/tasks/install_deb.yml
+++ b/tasks/install_deb.yml
@@ -3,10 +3,12 @@
   copy:
     src: '{{ cartridge_package_path }}'
     dest: /tmp/
+  any_errors_fatal: true
 
 - name: Set DEB filename
   set_fact:
     deb_filename: '{{ cartridge_package_path | basename }}'
+  any_errors_fatal: true
 
 - name: Get deb info
   command: 'dpkg -I /tmp/{{ deb_filename }}'
@@ -14,10 +16,12 @@
     warn: false
   register: deb_info
   changed_when: false
+  any_errors_fatal: true
 
 - name: Get package name
   set_fact:
     package_name: "{{ deb_info.stdout | regex_search('Package\\s*:\\s*(.*)\\s+', '\\1') | first }}"
+  any_errors_fatal: true
 
 - name: Fail if cartridge_app_name isn't equal to package name
   fail:
@@ -27,16 +31,19 @@
         'Found cartridge_app_name: "%s", package name: "%s"' | format(cartridge_app_name, package_name)
       }}
   when: cartridge_app_name != package_name
+  any_errors_fatal: true
 
 - name: Get deplist
   set_fact:
     deplist: "{{ deb_info.stdout | regex_search('Depends\\s*:\\s*(.*)', '\\1') | first }}"
+  any_errors_fatal: true
 
 # Get tarantool dependency <major>.<minor> version
 - name: Get tarantool dependency version
   set_fact:
     tnt_version: "{{ deplist | regex_search('tarantool\\s+\\(\\s*>=\\s*([0-9]+).([0-9]+)', '\\1', '\\2') }}"
   when: cartridge_enable_tarantool_repo
+  any_errors_fatal: true
 
 - name: Enable Tarantool repo
   include_tasks: enable_tarantool_repo.yml
@@ -51,3 +58,4 @@
     update_cache: true
   notify:
     - reload-systemd-daemon
+  any_errors_fatal: true

--- a/tasks/install_rpm.yml
+++ b/tasks/install_rpm.yml
@@ -3,10 +3,12 @@
   copy:
     src: '{{ cartridge_package_path }}'
     dest: /tmp/
+  any_errors_fatal: true
 
 - name: Set RPM filename
   set_fact:
     rpm_filename: '{{ cartridge_package_path | basename }}'
+  any_errors_fatal: true
 
 - name: Get RPM info  # noqa 301 303
   command: 'rpm -qip /tmp/{{ rpm_filename }}'
@@ -14,10 +16,12 @@
     warn: false
   register: rpm_info
   changed_when: false
+  any_errors_fatal: true
 
 - name: Get package name
   set_fact:
     package_name: "{{ rpm_info.stdout | regex_search('Name\\s*:\\s*(.*)\\s+', '\\1') | first }}"
+  any_errors_fatal: true
 
 - name: Fail if cartridge_app_name isn't equal to package name
   fail:
@@ -27,6 +31,7 @@
         'Found cartridge_app_name: "%s", package name: "%s"' | format(cartridge_app_name, package_name)
       }}
   when: cartridge_app_name != package_name
+  any_errors_fatal: true
 
 - name: Get RPM deplist
   command: 'rpm -qpR /tmp/{{ rpm_filename }}'
@@ -35,12 +40,14 @@
   register: deplist
   changed_when: false
   when: cartridge_enable_tarantool_repo
+  any_errors_fatal: true
 
 # Get tarantool dependency <major>.<minor> version
 - name: Get tarantool dependency version
   set_fact:
     tnt_version: "{{ deplist.stdout | regex_search('tarantool >= ([0-9]+).([0-9]+)', '\\1', '\\2') }}"
   when: cartridge_enable_tarantool_repo
+  any_errors_fatal: true
 
 - name: Enable Tarantool repo
   include_tasks: enable_tarantool_repo.yml
@@ -58,3 +65,4 @@
   failed_when: install_rpm.rc != 0 and "does not update installed package" not in install_rpm.results[0]
   notify:
     - reload-systemd-daemon
+  any_errors_fatal: true


### PR DESCRIPTION
Package installation tasks are running once for all instances on one physical machine.
It mean that when this task is failed, all play should fail immediately.

Closes #79 
