### PR TITLE
Make failover_priority optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to use the newest tag with new release
 ### Changed
 
 - `any_errors_fatal: true` is set for package installation tasks
+- `falover_priority` parameter is optional
 
 ## [1.2.0] - 2020-04-08
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ all:
       vars:
         # replicaset configuration
         replicaset_alias: core-1
-        failover_priority:
-          - core-1  # leader
         roles:
           - 'app.roles.custom'
           - 'vshard-router'
@@ -176,7 +174,7 @@ Configuration format is described in detail in the
 * `expelled` (`boolean`, optional, default: `false`): boolean flag that indicates if instance must be expelled from topology;
 * `instance_start_timeout` (`number`, optional, default: 60): time in seconds to wait for instance to be started;
 * `replicaset_alias` (`string`, optional): replicaset alias, will be displayed in Web UI;
-* `failover_priority` (`list-of-string`, required if `replicaset_alias` specified): failover priority;
+* `failover_priority` (`list-of-string`): failover priority;
 * `roles` (`list-of-strings`, required if `replicaset_alias` specified): roles to be enabled on the replicaset;
 * `all_rw` (`boolean`, optional): indicates that that all servers in the replicaset should be read-write;
 * `weight` (`number`, optional): vshard replicaset weight (matters only if `vshard-storage` role is enabled.
@@ -332,7 +330,7 @@ You can find more details about replicasets and automatic failover in [Tarantool
 To configure replicasets you need to specify replicaset parameters for each instance in replicaset:
 
 * `replicaset_alias` (`string`, optional) - replicaset alias, will be displayed in Web UI;
-* `failover_priority` (`list-of-strings`, required if `replicaset_alias` specified) - failover prioriry order.
+* `failover_priority` (`list-of-strings`, optional) - failover prioriry order.
   First instance will be replicaset leader.
   It isn't required to specify all instances here, you can specify only one or more.
   Other instances will have lower priority;
@@ -380,7 +378,6 @@ cartridge.cfg({
         hot-storage:
       vars:
         replicaset_alias: hot-storage
-        failover_priority: [hot-storage]
         roles: [vshard-storage]
         vshard_group: hot
 ```

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -32,7 +32,7 @@ REPLICASET_PARAMS = [
     'weight',
     'vshard_group',
 ]
-REPLICASET_REQUIRED_PARAMS = ['failover_priority', 'roles']
+REPLICASET_REQUIRED_PARAMS = ['roles']
 
 CLUSTER_COOKIE_MAX_LEN = 256
 CLUSTER_COOKIE_FORBIDDEN_SYMBOLS_RGX = r'[^a-zA-Z0-9_.~-]+'

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -117,8 +117,6 @@ all:
 
           vars:
             replicaset_alias: core-1
-            failover_priority:
-              - core-1
             roles:
               - 'app.roles.custom'
               - 'vshard-router'
@@ -129,7 +127,5 @@ all:
 
           vars:
             replicaset_alias: core-2
-            failover_priority:
-              - core-2
             roles:
               - 'app.roles.custom'

--- a/molecule/default/tests/test_cartridge.py
+++ b/molecule/default/tests/test_cartridge.py
@@ -83,11 +83,11 @@ def get_configured_replicasets():
         if replicaset_alias not in replicasets:
             replicasets[replicaset_alias] = {
                 'instances': [],
-                'failover_priority': host_vars['failover_priority'],
+                'failover_priority': host_vars.get('failover_priority'),
                 'roles': host_vars['roles'],
-                'all_rw': host_vars['all_rw'] if 'all_rw' in host_vars else None,
-                'weight': host_vars['weight'] if 'weight' in host_vars else None,
-                'vshard_group': host_vars.get('vshard_group', None)
+                'all_rw': host_vars.get('all_rw'),
+                'weight': host_vars.get('weight'),
+                'vshard_group': host_vars.get('vshard_group')
             }
 
         replicasets[replicaset_alias]['instances'].append(instance)
@@ -257,8 +257,10 @@ def test_replicasets():
         started_replicaset_instances = [i['alias'] for i in started_replicaset['servers']]
         assert set(started_replicaset_instances) == set(configured_replicaset['instances'])
 
-        assert started_replicaset['master']['alias'] == configured_replicaset['failover_priority'][0]
-        assert aliases_in_priority_order(started_replicaset['servers']) == configured_replicaset['failover_priority']
+        if configured_replicaset['failover_priority'] is not None:
+            configured_failover_priority = configured_replicaset['failover_priority']
+            assert started_replicaset['master']['alias'] == configured_failover_priority[0]
+            assert aliases_in_priority_order(started_replicaset['servers']) == configured_failover_priority
 
         if configured_replicaset['all_rw'] is not None:
             assert started_replicaset['all_rw'] == configured_replicaset['all_rw']

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -243,7 +243,7 @@ class TestValidateConfig(unittest.TestCase):
             'roles': ['role-1'],
         }
 
-        replicaset_required_params = ['failover_priority', 'roles']
+        replicaset_required_params = ['roles']
 
         for p in replicaset_required_params:
             params = copy.deepcopy(instance_required_params)


### PR DESCRIPTION
`failover_priority` variable is optional since this patch
If it isn't specified, instances will be joined in a random order

Closes #75 