### PR TITLE
Fix needs_restart for non-bootstrapped instance

### DIFF
--- a/library/cartridge_instance.py
+++ b/library/cartridge_instance.py
@@ -4,6 +4,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.helpers import ModuleRes, CartridgeException, cartridge_errcodes
 from ansible.module_utils.helpers import get_control_console
 from ansible.module_utils.helpers import dynamic_box_cfg_params, memory_size_box_cfg_params
+from ansible.module_utils.helpers import box_cfg_was_called
 
 import os
 
@@ -35,12 +36,6 @@ def serialize_dict(d):
         parts.append("%s = %s" % (k, value_str))
 
     return '{ %s }' % ', '.join(parts)
-
-
-def box_cfg_was_called(control_console):
-    return control_console.eval('''
-        return type(box.cfg) ~= 'function'
-    ''')
 
 
 def get_box_cfg(control_console):

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -198,3 +198,9 @@ def is_expelled(host_vars):
 
 def is_stateboard(host_vars):
     return host_vars.get('stateboard') is True
+
+
+def box_cfg_was_called(control_console):
+    return control_console.eval('''
+        return type(box.cfg) ~= 'function'
+    ''')

--- a/unit/test_needs_restart.py
+++ b/unit/test_needs_restart.py
@@ -85,6 +85,39 @@ class TestNeedsRestart(unittest.TestCase):
         self.assertTrue(res.success, msg=res.msg)
         self.assertTrue(res.changed)
 
+    def test_box_cfg_is_function(self):
+        param_name = 'some-param'
+        old_value = 'old-value'
+        new_value = 'new-value'
+
+        self.instance.set_box_cfg_function()
+
+        self.instance.set_instance_config({
+            param_name: old_value,
+        })
+
+        # nothing changed
+        res = call_needs_restart(
+            control_sock=self.console_sock,
+            config={
+                param_name: old_value,
+            },
+        )
+
+        self.assertTrue(res.success, msg=res.msg)
+        self.assertTrue(res.changed)
+
+        # param was changed
+        res = call_needs_restart(
+            control_sock=self.console_sock,
+            config={
+                param_name: new_value,
+            },
+        )
+
+        self.assertTrue(res.success, msg=res.msg)
+        self.assertTrue(res.changed)
+
     def test_code_was_updated(self):
         # code was updated today, socket yesterday - needs restart
         self.instance.set_path_mtime(self.instance.APP_CODE_PATH, self.instance.DATE_TODAY)
@@ -290,7 +323,7 @@ class TestNeedsRestart(unittest.TestCase):
         ["memtx_memory"],
         ["vinyl_memory"],
     ])
-    def test_both_app_and_instance_memtx_memory_changed(self, memory_param_name):
+    def test_memory_size_changed(self, memory_param_name):
         current_memory_size = 100
         new_memory_size_instance = 200
         new_memory_size_app = 300


### PR DESCRIPTION
Before this patch needs_restart function didn't check if box.cfg was
called or not. But if box.cfg wasn't called we have to restart instance
if config was changed.

Closes #130 