### PR TITLE
Allow to set replicaset healthy timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ README.md and examples/getting-started-app/README.md
 to use the newest tag with new release
 -->
 
+### Added
+
+- `replicaset_healthy_timeout` parameter to wait for replicaset to be
+  healthy after editing it
+
 ## [1.6.0] - 2020-11-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Configuration format is described in detail in the
 * `stateboard` (`boolean`, optional, default: `false`): boolean flag that indicates
    that the instance is a [stateboard](#stateboard-instance);
 * `instance_start_timeout` (`number`, optional, default: 60): time in seconds to wait for instance to be started;
+* `replicaset_healthy_timeout` (`number`, optional, default: 30): time in seconds to wait for replicaset to be healthy after editing it;
 * `replicaset_alias` (`string`, optional): replicaset alias, will be displayed in Web UI;
 * `failover_priority` (`list-of-string`): failover priority;
 * `roles` (`list-of-strings`, required if `replicaset_alias` specified): roles to be enabled on the replicaset;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ restarted: null
 expelled: false
 stateboard: false
 instance_start_timeout: 60
+replicaset_healthy_timeout: 30

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -9,6 +9,8 @@ all:
         become: true
         become_user: root
 
+        replicaset_healthy_timeout: 10
+
         # common cartridge opts
         cartridge_app_name: myapp
         cartridge_cluster_cookie: secret-cookie

--- a/tasks/manage_replicaset.yml
+++ b/tasks/manage_replicaset.yml
@@ -3,5 +3,6 @@
   cartridge_manage_replicaset:
     replicaset: '{{ replicaset }}'
     control_sock: '{{ cartridge_app_name | get_instance_control_sock(join_host) }}'
+    healthy_timeout: '{{ replicaset_healthy_timeout }}'
   delegate_to: '{{ join_host }}'
   tags: cartridge-replicasets


### PR DESCRIPTION
Added replicaset_healthy_timeout option that is used to specify number
of seconds to wait for replicaset become healthy after editing it