### PR TITLE
Refactor args serialization

### DIFF
--- a/library/cartridge_bootstrap_vshard.py
+++ b/library/cartridge_bootstrap_vshard.py
@@ -12,23 +12,19 @@ argument_spec = {
 
 def bootstrap_vshard(params):
     control_console = get_control_console(params['control_sock'])
-    can_bootstrap = control_console.eval('''
+    can_bootstrap, _ = control_console.eval_res_err('''
         return require('cartridge.vshard-utils').can_bootstrap()
     ''')
 
     if not can_bootstrap:
         return ModuleRes(success=True, changed=False)
 
-    res = control_console.eval('''
-        local ok, err = require('cartridge.admin').bootstrap_vshard()
-        return {
-            ok = ok or box.NULL,
-            err = err and err.err or box.NULL
-        }
+    ok, err = control_console.eval_res_err('''
+        return require('cartridge.admin').bootstrap_vshard()
     ''')
 
-    if not res['ok']:
-        errmsg = 'Vshard bootstrap failed: {}'.format(res['err'])
+    if not ok:
+        errmsg = 'Vshard bootstrap failed: {}'.format(err)
         return ModuleRes(success=False, msg=errmsg)
 
     return ModuleRes(success=True, changed=True)

--- a/library/cartridge_check_instance_started.py
+++ b/library/cartridge_check_instance_started.py
@@ -14,15 +14,15 @@ argument_spec = {
 def check_instance_started(params):
     try:
         control_console = get_control_console(params['control_sock'])
-        ok = True
+        instance_is_alive = True
         if not params['stateboard']:
-            ok = control_console.eval('''
+            instance_is_alive, _ = control_console.eval_res_err('''
                 return require('membership').myself().status == 'alive'
             ''')
     except CartridgeException as e:
         return ModuleRes(success=False, msg=str(e))
 
-    return ModuleRes(success=ok)
+    return ModuleRes(success=instance_is_alive)
 
 
 def main():

--- a/library/cartridge_control_instance.py
+++ b/library/cartridge_control_instance.py
@@ -14,7 +14,7 @@ def get_control_instance(params):
     control_console = get_control_console(params['control_sock'])
     control_instance = ''
 
-    members = control_console.eval('''
+    members, _ = control_console.eval_res_err('''
         return require('membership').members()
     ''')
 

--- a/library/cartridge_probe_instance.py
+++ b/library/cartridge_probe_instance.py
@@ -25,16 +25,16 @@ def probe_server(params):
         if is_expelled(instance_vars) or is_stateboard(instance_vars):
             continue
 
-        res = control_console.eval('''
-            local ok, err = require('cartridge').admin_probe_server('{}')
-            return {{
-                ok = ok and true or false,
-                err = err and err.err or box.NULL
-            }}
-        '''.format(instance_vars['config']['advertise_uri']))
+        advertise_uri = instance_vars['config']['advertise_uri']
+        func_body = '''
+            local advertise_uri = ...
+            return require('cartridge').admin_probe_server(advertise_uri)
+        '''
 
-        if not res['ok'] and i in play_hosts:
-            return ModuleRes(success=False, msg=res['err'])
+        ok, err = control_console.eval_res_err(func_body, advertise_uri)
+
+        if not ok and i in play_hosts:
+            return ModuleRes(success=False, msg=err)
 
     return ModuleRes(success=True)
 

--- a/unit/test_expel.py
+++ b/unit/test_expel.py
@@ -98,7 +98,7 @@ class TestExpelInstance(unittest.TestCase):
 
         res = call_expel_intstance(self.console_sock, 'r1-master')
         self.assertFalse(res.success)
-        self.assertIn('Failed to expel instance', res.msg)
+        self.assertIn('Failed to expel', res.msg)
 
     def tearDown(self):
         self.instance.stop()

--- a/unit/test_manage_failover.py
+++ b/unit/test_manage_failover.py
@@ -291,7 +291,6 @@ class TestFailover(unittest.TestCase):
         self.assertEqual(calls[0], {
             'mode': 'stateful',
             'state_provider': 'etcd2',
-            'etcd2_params': [],
         })
 
         # stateful failover enabled - params aren't changed
@@ -380,6 +379,7 @@ class TestFailover(unittest.TestCase):
             'mode': 'stateful',
             'state_provider': 'tarantool',
             'tarantool_params': STATEBOARD_PARAMS,
+            'etcd2_params': ETCD2_PARAMS,
         })
 
         # failover disabled -> enable etcd2
@@ -398,6 +398,7 @@ class TestFailover(unittest.TestCase):
         self.assertEqual(calls[0], {
             'mode': 'stateful',
             'state_provider': 'etcd2',
+            'tarantool_params': STATEBOARD_PARAMS,
             'etcd2_params': ETCD2_PARAMS,
         })
 
@@ -406,6 +407,7 @@ class TestFailover(unittest.TestCase):
             'mode': 'stateful',
             'state_provider': 'tarantool',
             'tarantool_params': STATEBOARD_PARAMS,
+            'etcd2_params': ETCD2_PARAMS,
         })
         self.instance.clear_calls('failover_set_params')
 
@@ -421,6 +423,7 @@ class TestFailover(unittest.TestCase):
         self.assertEqual(calls[0], {
             'mode': 'stateful',
             'state_provider': 'etcd2',
+            'tarantool_params': STATEBOARD_PARAMS,
             'etcd2_params': ETCD2_PARAMS,
         })
 


### PR DESCRIPTION
`control_console.eval` is rewritten to accept any args and use them in function as `...`
just like connectors do.
Also added `control_console.eval_res_err` function to correctly accept `return res, err`.
As a result - code that serialises data passed to instance is removed. 

Closes #157 