### PR TITLE
Optimize Molecule sequences and fix Ansible check step

### DIFF
--- a/.github/workflows/molecule-check.yml
+++ b/.github/workflows/molecule-check.yml
@@ -1,0 +1,56 @@
+---
+name: Molecule check
+
+on:
+  workflow_dispatch:
+
+env:
+  CARTRIDGE_CLI_VERSION: '2.6.0'
+
+jobs:
+  molecule-check:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tarantool-version: ["2.5"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install molecule requirements
+        run: |
+          pip3 install --upgrade -r requirements.txt
+
+      - name: Cache test packages
+        id: cache-packages
+        uses: actions/cache@v2
+        with:
+          path: 'packages'
+          key: ce-${{ matrix.tarantool-version }}-${{ env.CARTRIDGE_CLI_VERSION }}
+
+      - name: Create test packages
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        run: |
+          sudo apt -y update
+          sudo apt -y install git gcc make cmake unzip
+          git config --global user.email "test@tarantool.io" \
+            && git config --global user.name "Tar Antool"
+
+          curl -L https://tarantool.io/release/${{ matrix.tarantool-version }}/installer.sh | bash
+          sudo apt install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
+
+          tarantool --version
+          cartridge version
+
+          ./create-packages.sh
+
+      - name: Molecule check
+        run: molecule check

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -47,3 +47,27 @@ verifier:
   name: testinfra
   options:
     v: true
+
+scenario:
+  create_sequence:
+    - create
+  converge_sequence:
+    - create
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
+  check_sequence:
+    - destroy
+    - create
+    - converge
+    - check
+    - destroy

--- a/tasks/install_deb.yml
+++ b/tasks/install_deb.yml
@@ -16,6 +16,7 @@
     warn: false
   register: deb_info
   changed_when: false
+  check_mode: false
   any_errors_fatal: true
 
 - name: Get package name

--- a/tasks/install_rpm.yml
+++ b/tasks/install_rpm.yml
@@ -16,6 +16,7 @@
     warn: false
   register: rpm_info
   changed_when: false
+  check_mode: false
   any_errors_fatal: true
 
 - name: Get package name
@@ -40,6 +41,7 @@
   register: deplist
   changed_when: false
   when: cartridge_enable_tarantool_repo
+  check_mode: false
   any_errors_fatal: true
 
 # Get tarantool dependency <major>.<minor> version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,7 @@
     control_sock: '{{ cartridge_app_name | get_instance_control_sock(one_not_expelled_instance) }}'
   register: control_instance
   run_once: true
+  check_mode: false
   delegate_to: '{{ one_not_expelled_instance }}'
   tags: cartridge-replicasets
 
@@ -93,6 +94,7 @@
     control_host: '{{ control_instance.meta.host }}'
   register: replicasets
   run_once: true
+  check_mode: false
   tags: cartridge-replicasets
 
 - name: Manage replicasets
@@ -117,6 +119,7 @@
     allow_empty: false
   register: control_instance
   run_once: true
+  check_mode: false
   delegate_to: '{{ one_not_expelled_instance }}'
   when: >-
     cartridge_auth is defined


### PR DESCRIPTION
Before the patch:
- Molecule tried to execute unused steps and issued warnings when it could not find them;
- Molecule `check` step failed.

This patch includes:
- Custom Molecule sequences;
- Ansible scripts are fixed so the Molecule `check` step passes without errors;
- Molecule `check` step added to CI. 