### PR TITLE
Use Cartridge tags for all tasks in playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ README.md and examples/getting-started-app/README.md
 to use the newest tag with new release
 -->
 
+### Fixed
+
+- Role installation will be completely skipped
+  if you specify a tag other than the tags for this role
+
 ### Added
 
 - `cartridge-replicasets` tag to the membership stage

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,19 @@
   fail:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
   when: ansible_os_family not in ["RedHat", "Debian"]
-  tags: always
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
 
 - name: Set remote_user for delegated tasks
   set_fact:
     remote_user: '{{ ansible_user }}'
   when: remote_user is not defined and ansible_user is defined
-  tags: always
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
 
 - name: Validate config
   cartridge_validate_config:
@@ -18,7 +24,10 @@
   delegate_to: localhost
   become: false
   run_once: true
-  tags: always
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
 
 - name: Set instance facts
   set_fact:
@@ -28,7 +37,10 @@
     instance_conf_section: '{{ cartridge_app_name | get_instance_conf_section(inventory_hostname, stateboard) }}'
     instance_work_dir: '{{ cartridge_app_name | get_instance_work_dir(inventory_hostname, stateboard) }}'
     instance_systemd_service: '{{ cartridge_app_name | get_instance_systemd_service(inventory_hostname, stateboard) }}'
-  tags: always
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
 
 # Rewrites cartridge_app_name from package info
 - name: Install package
@@ -43,8 +55,9 @@
   when: not expelled
   tags: cartridge-instances
 
-# Restart instances and reload systemd-daemon if required
-- meta: flush_handlers
+- name: Restart instances and reload systemd-daemon
+  meta: flush_handlers
+  tags: cartridge-instances
 
 - name: Wait for instance to be started
   cartridge_check_instance_started:

--- a/unit/os_mock.py
+++ b/unit/os_mock.py
@@ -1,4 +1,4 @@
-class OsPathExistsMock():
+class OsPathExistsMock:
     def __init__(self):
         self.existent_paths = set()
 
@@ -12,7 +12,7 @@ class OsPathExistsMock():
         self.existent_paths.discard(path)
 
 
-class OsPathGetMtimeMock():
+class OsPathGetMtimeMock:
     def __init__(self):
         self.known_mtimes = dict()
 

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+from ansible.inventory.manager import InventoryManager
+from ansible.parsing.dataloader import DataLoader
+from ansible.playbook.play import Play
+from ansible.vars.manager import VariableManager
+
+
+class TestTags(unittest.TestCase):
+    def setUp(self):
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader, sources='localhost,')
+        variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        self.play = Play().load({
+            'name': "Deploy Cartridge",
+            'tasks': [{
+                'name': 'Import Cartridge Role',
+                'import_role': {
+                    'name': str(Path(__file__).parent.parent),
+                },
+            }],
+        }, loader=loader, variable_manager=variable_manager)
+        self.all_vars = variable_manager.get_vars(play=self.play)
+
+    def get_tasks_by_tags(self, tags_set):
+        self.play.only_tags = tags_set
+        tasks = self.play.get_tasks()[0]
+        self.assertTrue(len(tasks) == 1, 'Expected one task in playbook with role import!')
+        tasks = tasks[0].filter_tagged_tasks(self.all_vars).block
+
+        names = []
+        for task in tasks:
+            _, name = task.get_name().split(' : ')
+            names.append(name)
+        return names
+
+    def test_without_tags(self):
+        names = self.get_tasks_by_tags({})
+        self.assertEqual(names, [
+            'Check distribution',
+            'Set remote_user for delegated tasks',
+            'Validate config',
+            'Set instance facts',
+            'Install package',
+            'Start instance',
+            'Restart instances and reload systemd-daemon',
+            'Wait for instance to be started',
+            'Connect instance to membership',
+            'Select one not expelled instance',
+            'Set one control instance to join replicasets',
+            'Get replicasets',
+            'Manage replicasets',
+            'Expel instance',
+            'Set one control instance to rule them all',
+            'Set control instance facts',
+            'Cartridge auth',
+            'Application config',
+            'Bootstrap vshard',
+            'Manage failover',
+        ])
+
+    def test_tag_cartridge_instances(self):
+        names = self.get_tasks_by_tags({'cartridge-instances'})
+        self.assertEqual(names, [
+            'Check distribution',
+            'Set remote_user for delegated tasks',
+            'Validate config',
+            'Set instance facts',
+            'Install package',
+            'Start instance',
+            'Restart instances and reload systemd-daemon',
+            'Wait for instance to be started',
+            'Connect instance to membership',
+        ])
+
+    def test_tag_cartridge_replicasets(self):
+        names = self.get_tasks_by_tags({'cartridge-replicasets'})
+        self.assertEqual(names, [
+            'Check distribution',
+            'Set remote_user for delegated tasks',
+            'Validate config',
+            'Set instance facts',
+            # TODO: Remove 'Restart instances and reload systemd-daemon' when Ansible will be updated to 2.11 or higher
+            # Ref: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/meta_module.html#notes
+            'Restart instances and reload systemd-daemon',
+            'Connect instance to membership',
+            'Select one not expelled instance',
+            'Set one control instance to join replicasets',
+            'Get replicasets',
+            'Manage replicasets',
+            'Expel instance',
+        ])
+
+    def test_tag_cartridge_config(self):
+        names = self.get_tasks_by_tags({'cartridge-config'})
+        self.assertEqual(names, [
+            'Check distribution',
+            'Set remote_user for delegated tasks',
+            'Validate config',
+            'Set instance facts',
+            # TODO: Remove 'Restart instances and reload systemd-daemon' when Ansible will be updated to 2.11 or higher
+            # Ref: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/meta_module.html#notes
+            'Restart instances and reload systemd-daemon',
+            'Select one not expelled instance',
+            'Set one control instance to rule them all',
+            'Set control instance facts',
+            'Cartridge auth',
+            'Application config',
+            'Bootstrap vshard',
+            'Manage failover',
+        ])
+
+    def test_not_cartridge_tag(self):
+        names = self.get_tasks_by_tags({'test'})
+        self.assertEqual(names, [
+            # TODO: Remove 'Restart instances and reload systemd-daemon' when Ansible will be updated to 2.11 or higher
+            # Ref: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/meta_module.html#notes
+            'Restart instances and reload systemd-daemon',
+        ])


### PR DESCRIPTION
Closes #156

Before the patch, if you run the playbook with the `-t some-tag` option, some tasks (that have the `always` tag) will run. This made it difficult to skip the role installation.

Now role installation will be completely skipped if you specify a tag other than the tags for this role.