### PR TITLE
Add manual gathering facts task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Forced facts gathering
+  setup:
+  when: ansible_os_family is not defined
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
 - name: Check distribution
   fail:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -41,6 +41,7 @@ class TestTags(unittest.TestCase):
     def test_without_tags(self):
         names = self.get_tasks_by_tags({})
         self.assertEqual(names, [
+            'Forced facts gathering',
             'Check distribution',
             'Set remote_user for delegated tasks',
             'Validate config',
@@ -65,6 +66,7 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_instances(self):
         names = self.get_tasks_by_tags({'cartridge-instances'})
         self.assertEqual(names, [
+            'Forced facts gathering',
             'Check distribution',
             'Set remote_user for delegated tasks',
             'Validate config',
@@ -79,6 +81,7 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_replicasets(self):
         names = self.get_tasks_by_tags({'cartridge-replicasets'})
         self.assertEqual(names, [
+            'Forced facts gathering',
             'Check distribution',
             'Set remote_user for delegated tasks',
             'Validate config',
@@ -96,6 +99,7 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_config(self):
         names = self.get_tasks_by_tags({'cartridge-config'})
         self.assertEqual(names, [
+            'Forced facts gathering',
             'Check distribution',
             'Set remote_user for delegated tasks',
             'Validate config',


### PR DESCRIPTION
Closes #170

Before the patch, if you run the playbook with the -t 'cartridge-instances' option,
you get an error like this: `'ansible_os_family' is undefined`.

Added facts gathering task will be executed if the facts were not
gathered earlier and one of our tags is specified.