### PR TITLE
Change cartridge_check_instance_started function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ to use the newest tag with new release
   now it is O(N). For 100 instances, it gives a 10x time reduction (60s -> 5s).
 - Refactored package installing. Getting package info is performed in a library module,
   all tasks except installing package itself are common for RPM and DEB.
+- Now `check_instance_started` function: check all instances, including the stateboard;
+  wait `Unconfigured` or `RolesConfigured` status instead `alive` state; check that
+  all buckets are discovered by routers if cluster was bootstrapped.
 
 ## [1.7.0] - 2020-11-24
 

--- a/library/cartridge_check_instance_started.py
+++ b/library/cartridge_check_instance_started.py
@@ -4,32 +4,108 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.helpers import ModuleRes, CartridgeException
 from ansible.module_utils.helpers import get_control_console
 
-
 argument_spec = {
     'control_sock': {'required': True, 'type': 'str'},
     'stateboard': {'required': True, 'type': 'bool'},
+    'expected_states': {'required': False, 'type': 'list', 'default': ['Unconfigured', 'RolesConfigured']},
+    'check_buckets_are_discovered': {'required': False, 'type': 'bool', 'default': True},
 }
 
 
-def check_instance_started(params):
+def check_stateboard_started(control_console):
+    box_status, err = control_console.eval_res_err('''
+        if type(box.cfg) == 'function' or box.cfg.listen == nil then
+            return nil, "box hasn't been configured"
+        end
+        return true
+    ''')
+    if not box_status:
+        return ModuleRes(success=False, msg="Stateboard is not running: %s" % err)
+
+    return ModuleRes(success=True)
+
+
+def check_instance_started(control_console, expected_states, check_buckets_are_discovered):
+    instance_state, err = control_console.eval_res_err('''
+        return require('cartridge.confapplier').get_state()
+    ''')
+    if not instance_state:
+        return ModuleRes(success=False, msg="Impossible to get state: %s" % err)
+    if instance_state not in expected_states:
+        return ModuleRes(
+            success=False,
+            msg="Instance is not in one of states: %s, it's in '%s' state" % (
+                expected_states,
+                instance_state,
+            ),
+        )
+
+    if check_buckets_are_discovered:
+        buckets_ok, err = control_console.eval_res_err('''
+            local vshard_utils = require('cartridge.vshard-utils')
+            local vshard_router = require('cartridge.roles.vshard-router')
+
+            local function check_group_buckets(group_name, group_opts)
+                if not group_opts.bootstrapped then
+                    return true
+                end
+
+                local router = vshard_router.get(group_name)
+                if router == nil then
+                    return true
+                end
+
+                local unknown_buckets = router:info().bucket.unknown
+                if unknown_buckets == 0 then
+                    return true
+                end
+
+                return nil, string.format(
+                    "%s out of %s buckets are not discovered in group '%s'",
+                    unknown_buckets,
+                    group_opts.bucket_count,
+                    group_name
+                )
+            end
+
+            local groups = vshard_utils.get_known_groups()
+            for group_name, group_opts in pairs(groups) do
+                local _, err = check_group_buckets(group_name, group_opts)
+                if err ~= nil then
+                    return nil, err
+                end
+            end
+
+            return true
+        ''')
+        if not buckets_ok:
+            return ModuleRes(success=False, msg=err)
+
+    return ModuleRes(success=True)
+
+
+def check_started(params):
     try:
         control_console = get_control_console(params['control_sock'])
-        instance_is_alive = True
-        if not params['stateboard']:
-            instance_is_alive, _ = control_console.eval_res_err('''
-                return require('membership').myself().status == 'alive'
-            ''')
+
+        if params['stateboard']:
+            return check_stateboard_started(control_console)
+        else:
+            return check_instance_started(
+                control_console,
+                params['expected_states'],
+                params['check_buckets_are_discovered'],
+            )
+
     except CartridgeException as e:
         return ModuleRes(success=False, msg=str(e))
-
-    return ModuleRes(success=instance_is_alive)
 
 
 def main():
     module = AnsibleModule(argument_spec=argument_spec)
 
     try:
-        res = check_instance_started(module.params)
+        res = check_started(module.params)
     except CartridgeException as e:
         module.fail_json(msg=str(e))
 

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -314,7 +314,7 @@ def check_stateboard(stateboard_vars):
     if stateboard_vars.get('expelled') is True:
         return '"expelled" flag can\'t be used for stateboard instance'
 
-    for p in REPLICASET_PARAMS + ['replicaset_alias']:
+    for p in REPLICASET_PARAMS:
         if stateboard_vars.get(p) is not None:
             return '"{}" flag can\'t be used for stateboard instance'.format(p)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -182,7 +182,7 @@
 
 - name: Bootstrap vshard
   cartridge_bootstrap_vshard:
-    control_sock: '{{ control_sock}}'
+    control_sock: '{{ control_sock }}'
   delegate_to: '{{ control_host }}'
   run_once: true
   register: bootstrap_vshard
@@ -190,6 +190,17 @@
   retries: 3
   delay: 5
   when: cartridge_bootstrap_vshard is defined and cartridge_bootstrap_vshard
+  tags: cartridge-config
+
+- name: Wait for instance to be started and buckets are discovered
+  cartridge_check_instance_started:
+    control_sock: '{{ instance_control_sock }}'
+    stateboard: '{{ stateboard }}'
+  register: check_instance
+  until: not check_instance.failed
+  retries: '{{ instance_start_timeout // 5 }}'
+  delay: 5
+  when: not expelled and cartridge_bootstrap_vshard is defined and cartridge_bootstrap_vshard
   tags: cartridge-config
 
 - name: Manage failover

--- a/unit/test_check_instance_started.py
+++ b/unit/test_check_instance_started.py
@@ -1,27 +1,40 @@
 # Hack ansible.module_utils.helpers import
 import sys
+
 import module_utils.helpers as helpers
+
 sys.modules['ansible.module_utils.helpers'] = helpers
 
 import os
+
 sys.path.append(os.path.dirname(__file__))
 
 import unittest
 from instance import Instance
 
-from library.cartridge_check_instance_started import check_instance_started
+from library.cartridge_check_instance_started import check_started
 
 
-def call_check_instance_started(control_sock, stateboard=False):
-    return check_instance_started({
+def call_check_instance_started(control_sock, stateboard=False, check_buckets_are_discovered=False):
+    return check_started({
         'control_sock': control_sock,
         'stateboard': stateboard,
+        'expected_states': ['Unconfigured', 'RolesConfigured'],
+        'check_buckets_are_discovered': check_buckets_are_discovered,
     })
 
 
-def set_myself(instance, status):
-    instance.set_variable('membership_myself', {
-        'status': status
+def set_confapplier_state(instance, state):
+    instance.set_variable('cartridge_confapplier_state', state)
+
+
+def set_vshard_groups(instance, vshard_groups):
+    instance.set_variable('vshard_groups', vshard_groups)
+
+
+def set_vshard_router_unknown_buckets(instance, groups_unknown_buckets):
+    instance.set_variable('unknown_buckets', {
+        g[0]: g[1] for g in groups_unknown_buckets.items()
     })
 
 
@@ -45,43 +58,123 @@ class TestInstanceStarted(unittest.TestCase):
         self.instance.write_file(bad_socket_path)
 
         res = call_check_instance_started(bad_socket_path, stateboard)
-
         self.assertFalse(res.success)
         self.assertIn('Failed to connect to socket', res.msg)
-
-    def test_instance_not_started(self):
-        self.template_test_instance_not_started(stateboard=False)
 
     def test_stateboard_not_started(self):
         self.template_test_instance_not_started(stateboard=True)
 
-    def test_alive(self):
-        # not stateboard
-        # require('membership').myself().status is 'active'
-        set_myself(self.instance, status='alive')
-        self.instance.clear_calls('membership_myself')
-        res = call_check_instance_started(self.console_sock)
-        self.assertTrue(res.success, msg=res.msg)
+    def test_stateboard_not_box(self):
+        # box.cfg == function
 
-        calls = self.instance.get_calls('membership_myself')
-        self.assertEqual(len(calls), 1)
-
-        # stateboard
-        set_myself(self.instance, status='alive')
-        self.instance.clear_calls('membership_myself')
+        self.instance.set_box_cfg_function(True)
         res = call_check_instance_started(self.console_sock, stateboard=True)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.success)
+        self.assertIn("Stateboard is not running: box hasn't been configured", res.msg)
 
-        calls = self.instance.get_calls('membership_myself')
-        self.assertEqual(len(calls), 0)
+    def test_stateboard_not_listen(self):
+        # box.cfg.listen == nil
 
-    def test_dead(self):
-        # not stateboard
-        # require('membership').myself().status is 'dead'
-        set_myself(self.instance, status='dead')
-        self.instance.clear_calls('membership_myself')
+        self.instance.set_box_cfg({})
+        res = call_check_instance_started(self.console_sock, stateboard=True)
+        self.assertFalse(res.success)
+        self.assertIn("Stateboard is not running: box hasn't been configured", res.msg)
+
+    def test_stateboard_started(self):
+        # box.cfg.listen ~= nil
+
+        self.instance.set_box_cfg({'listen': 3333})
+        res = call_check_instance_started(self.console_sock, stateboard=True)
+        self.assertTrue(res.success)
+
+    def test_instance_not_started(self):
+        self.template_test_instance_not_started(stateboard=False)
+
+    def test_instance_operation_error(self):
+        # require('cartridge.confapplier').get_state() == 'OperationError'
+
+        set_confapplier_state(self.instance, 'OperationError')
         res = call_check_instance_started(self.console_sock)
         self.assertFalse(res.success)
+        self.assertIn("Instance is not in one of states: ['Unconfigured', 'RolesConfigured'], "
+                      "it's in 'OperationError' state", res.msg)
+
+    def test_instance_not_bootstrapped(self):
+        # groups not bootstrapped
+
+        set_confapplier_state(self.instance, 'RolesConfigured')
+        set_vshard_router_unknown_buckets(self.instance, {'hot': 1000, 'cold': 1000})
+
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': False},
+            'cold': {'bucket_count': 30000, 'bootstrapped': False},
+        })
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertTrue(res.success)
+
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': True},
+            'cold': {'bucket_count': 30000, 'bootstrapped': False},
+        })
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
+
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': False},
+            'cold': {'bucket_count': 30000, 'bootstrapped': True},
+        })
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
+
+    def test_instance_no_router(self):
+        # vshard_router.get(group_name) == nil
+
+        set_confapplier_state(self.instance, 'RolesConfigured')
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': True},
+            'cold': {'bucket_count': 30000, 'bootstrapped': True},
+        })
+
+        set_vshard_router_unknown_buckets(self.instance, {'hot': 1000})
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
+
+        set_vshard_router_unknown_buckets(self.instance, {'cold': 1000})
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
+
+    def test_instance_discovering(self):
+        # unknown_buckets > 0
+
+        set_confapplier_state(self.instance, 'RolesConfigured')
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': True},
+            'cold': {'bucket_count': 30000, 'bootstrapped': True},
+        })
+
+        set_vshard_router_unknown_buckets(self.instance, {'hot': 1000, 'cold': 0})
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
+
+        set_vshard_router_unknown_buckets(self.instance, {'hot': 0, 'cold': 1000})
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertFalse(res.success)
+        self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
+
+    def test_instance_bootstrapped(self):
+        set_confapplier_state(self.instance, 'RolesConfigured')
+        set_vshard_groups(self.instance, {
+            'hot': {'bucket_count': 2000, 'bootstrapped': True},
+            'cold': {'bucket_count': 30000, 'bootstrapped': True},
+        })
+        set_vshard_router_unknown_buckets(self.instance, {'cold': 0, 'hot': 0})
+        res = call_check_instance_started(self.console_sock, check_buckets_are_discovered=True)
+        self.assertTrue(res.success)
 
     def tearDown(self):
         self.instance.stop()

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -64,6 +64,7 @@ class TestTags(unittest.TestCase):
             'Cartridge auth',
             'Application config',
             'Bootstrap vshard',
+            'Wait for instance to be started and buckets are discovered',
             'Manage failover',
         ])
 
@@ -119,6 +120,7 @@ class TestTags(unittest.TestCase):
             'Cartridge auth',
             'Application config',
             'Bootstrap vshard',
+            'Wait for instance to be started and buckets are discovered',
             'Manage failover',
         ])
 


### PR DESCRIPTION
Closes #145

Thanks for a draft PR #138

Before this patch, it only checked that the instances are alive.
Moreover, the stateboard instance was not checked.

Changes:
- All instances are being checked now, including the stateboard.
- The instance is expected to be not only alive, but also in the
  Unconfigured or RolesConfigured status (you can set any list of
  expected statuses by `expected_states` option).
- For routers, added an optional check that all buckets are discovered
  if cluster was bootstrapped. Your can disable this check by
  `check_buckets_are_discovered` option.