### PR TITLE
Prettify some things

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,12 @@ cartridge_package_path: null
 cartridge_defaults: {}
 cartridge_enable_tarantool_repo: true
 
+cartridge_bootstrap_vshard: false
+cartridge_app_config: null
+cartridge_auth: null
+cartridge_failover: null
+cartridge_failover_params: null
+
 restarted: null
 expelled: false
 stateboard: false

--- a/library/cartridge_check_instance_state.py
+++ b/library/cartridge_check_instance_state.py
@@ -12,7 +12,7 @@ argument_spec = {
 }
 
 
-def check_stateboard_started(control_console):
+def check_stateboard_state(control_console):
     box_status, err = control_console.eval_res_err('''
         if type(box.cfg) == 'function' or box.cfg.listen == nil then
             return nil, "box hasn't been configured"
@@ -25,7 +25,7 @@ def check_stateboard_started(control_console):
     return ModuleRes(success=True)
 
 
-def check_instance_started(control_console, expected_states, check_buckets_are_discovered):
+def check_instance_state(control_console, expected_states, check_buckets_are_discovered):
     instance_state, err = control_console.eval_res_err('''
         return require('cartridge.confapplier').get_state()
     ''')
@@ -84,14 +84,14 @@ def check_instance_started(control_console, expected_states, check_buckets_are_d
     return ModuleRes(success=True)
 
 
-def check_started(params):
+def check_state(params):
     try:
         control_console = get_control_console(params['console_sock'])
 
         if params['stateboard']:
-            return check_stateboard_started(control_console)
+            return check_stateboard_state(control_console)
         else:
-            return check_instance_started(
+            return check_instance_state(
                 control_console,
                 params['expected_states'],
                 params['check_buckets_are_discovered'],
@@ -105,7 +105,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec)
 
     try:
-        res = check_started(module.params)
+        res = check_state(module.params)
     except CartridgeException as e:
         module.fail_json(msg=str(e))
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
   tags: cartridge-instances
 
 - name: Wait for instance to be started
-  cartridge_check_instance_started:
+  cartridge_check_instance_state:
     console_sock: '{{ instance_info.console_sock }}'
     stateboard: '{{ stateboard }}'
   register: check_instance
@@ -169,8 +169,8 @@
   when: cartridge_bootstrap_vshard is defined and cartridge_bootstrap_vshard
   tags: cartridge-config
 
-- name: Wait for instance to be started and buckets are discovered
-  cartridge_check_instance_started:
+- name: Wait for buckets discovering
+  cartridge_check_instance_state:
     console_sock: '{{ instance_info.console_sock }}'
     stateboard: '{{ stateboard }}'
   register: check_instance

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,7 +145,7 @@
     console_sock: '{{ control_instance.console_sock }}'
   delegate_to: '{{ control_instance.name }}'
   run_once: true
-  when: cartridge_auth is defined
+  when: cartridge_auth is not none
   tags: cartridge-config
 
 - name: Application config
@@ -154,7 +154,7 @@
     console_sock: '{{ control_instance.console_sock }}'
   delegate_to: '{{ control_instance.name }}'
   run_once: true
-  when: cartridge_app_config is defined
+  when: cartridge_app_config is not none
   tags: cartridge-config
 
 - name: Bootstrap vshard
@@ -166,7 +166,7 @@
   until: not bootstrap_vshard.failed
   retries: 3
   delay: 5
-  when: cartridge_bootstrap_vshard is defined and cartridge_bootstrap_vshard
+  when: cartridge_bootstrap_vshard and not expelled
   tags: cartridge-config
 
 - name: Wait for buckets discovering
@@ -177,7 +177,7 @@
   until: not check_instance.failed
   retries: '{{ instance_start_timeout // 5 }}'
   delay: 5
-  when: not expelled and cartridge_bootstrap_vshard is defined and cartridge_bootstrap_vshard
+  when: cartridge_bootstrap_vshard and not expelled
   tags: cartridge-config
 
 - name: Manage failover
@@ -186,5 +186,5 @@
     console_sock: '{{ control_instance.console_sock }}'
   delegate_to: '{{ control_instance.name }}'
   run_once: true
-  when: cartridge_failover is defined or cartridge_failover_params is defined
+  when: cartridge_failover is not none or cartridge_failover_params is not none
   tags: cartridge-config

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -61,7 +61,7 @@ class TestTags(unittest.TestCase):
             'Cartridge auth',
             'Application config',
             'Bootstrap vshard',
-            'Wait for instance to be started and buckets are discovered',
+            'Wait for buckets discovering',
             'Manage failover',
         ])
 
@@ -115,7 +115,7 @@ class TestTags(unittest.TestCase):
             'Cartridge auth',
             'Application config',
             'Bootstrap vshard',
-            'Wait for instance to be started and buckets are discovered',
+            'Wait for buckets discovering',
             'Manage failover',
         ])
 


### PR DESCRIPTION
* Renamed `cartridge_check_instance_status` -> `cartridge_check_instance_state`, also changed task name.
* Added default values for `cartridge_bootstrap_vshard`, `cartridge_app_config`, `cartridge_auth`, `cartridge_failover` 
  and `cartridge_failover_params`.