### PR TITLE
Make `ModuleRes` class from helpers more usable

### DIFF
--- a/library/cartridge_bootstrap_vshard.py
+++ b/library/cartridge_bootstrap_vshard.py
@@ -4,7 +4,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.helpers import ModuleRes, CartridgeException
 from ansible.module_utils.helpers import get_control_console
 
-
 argument_spec = {
     'console_sock': {'required': True, 'type': 'str'},
 }
@@ -17,7 +16,7 @@ def bootstrap_vshard(params):
     ''')
 
     if not can_bootstrap:
-        return ModuleRes(success=True, changed=False)
+        return ModuleRes(changed=False)
 
     ok, err = control_console.eval_res_err('''
         return require('cartridge.admin').bootstrap_vshard()
@@ -25,9 +24,9 @@ def bootstrap_vshard(params):
 
     if not ok:
         errmsg = 'Vshard bootstrap failed: {}'.format(err)
-        return ModuleRes(success=False, msg=errmsg)
+        return ModuleRes(failed=True, msg=errmsg)
 
-    return ModuleRes(success=True, changed=True)
+    return ModuleRes()
 
 
 def main():
@@ -35,12 +34,8 @@ def main():
     try:
         res = bootstrap_vshard(module.params)
     except CartridgeException as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_check_instance_state.py
+++ b/library/cartridge_check_instance_state.py
@@ -20,9 +20,9 @@ def check_stateboard_state(control_console):
         return true
     ''')
     if not box_status:
-        return ModuleRes(success=False, msg="Stateboard is not running: %s" % err)
+        return ModuleRes(failed=True, msg="Stateboard is not running: %s" % err)
 
-    return ModuleRes(success=True)
+    return ModuleRes(changed=False)
 
 
 def check_instance_state(control_console, expected_states, check_buckets_are_discovered):
@@ -30,10 +30,10 @@ def check_instance_state(control_console, expected_states, check_buckets_are_dis
         return require('cartridge.confapplier').get_state()
     ''')
     if not instance_state:
-        return ModuleRes(success=False, msg="Impossible to get state: %s" % err)
+        return ModuleRes(failed=True, msg="Impossible to get state: %s" % err)
     if instance_state not in expected_states:
         return ModuleRes(
-            success=False,
+            failed=True,
             msg="Instance is not in one of states: %s, it's in '%s' state" % (
                 expected_states,
                 instance_state,
@@ -79,9 +79,9 @@ def check_instance_state(control_console, expected_states, check_buckets_are_dis
             return true
         ''')
         if not buckets_ok:
-            return ModuleRes(success=False, msg=err)
+            return ModuleRes(failed=True, msg=err)
 
-    return ModuleRes(success=True)
+    return ModuleRes(changed=False)
 
 
 def check_state(params):
@@ -98,7 +98,7 @@ def check_state(params):
             )
 
     except CartridgeException as e:
-        return ModuleRes(success=False, msg=str(e))
+        return ModuleRes(exception=e)
 
 
 def main():
@@ -107,12 +107,8 @@ def main():
     try:
         res = check_state(module.params)
     except CartridgeException as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_probe_instance.py
+++ b/library/cartridge_probe_instance.py
@@ -5,7 +5,6 @@ from ansible.module_utils.helpers import ModuleRes, CartridgeException
 from ansible.module_utils.helpers import get_control_console
 from ansible.module_utils.helpers import is_expelled, is_stateboard
 
-
 argument_spec = {
     'console_sock': {'required': True, 'type': 'str'},
     'hostvars': {'required': True, 'type': 'dict'},
@@ -34,9 +33,9 @@ def probe_server(params):
         ok, err = control_console.eval_res_err(func_body, advertise_uri)
 
         if not ok and i in play_hosts:
-            return ModuleRes(success=False, msg=err)
+            return ModuleRes(failed=True, msg=err)
 
-    return ModuleRes(success=True)
+    return ModuleRes(changed=False)
 
 
 def main():
@@ -45,12 +44,8 @@ def main():
     try:
         res = probe_server(module.params)
     except CartridgeException as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_set_instance_info.py
+++ b/library/cartridge_set_instance_info.py
@@ -3,11 +3,9 @@
 import os
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible.module_utils.helpers import ModuleRes
-from ansible.module_utils.helpers import get_instance_id
 from ansible.module_utils.helpers import get_instance_console_sock
-
+from ansible.module_utils.helpers import get_instance_id
 
 argument_spec = {
     'app_name': {'required': False, 'type': 'str'},
@@ -72,7 +70,7 @@ def get_instance_info(params):
     if package_type in ['rpm', 'deb']:
         instance_info['instance_code_dir'] = os.path.join(instance_vars['cartridge_dist_dir'], app_name)
     elif package_type is not None:
-        return ModuleRes(success=False, msg='Unknown package type: %s' % package_type)
+        return ModuleRes(failed=True, msg='Unknown package type: %s' % package_type)
 
     # app conf file, instance conf file, instance conf section
     instance_info['app_conf_file'] = get_app_conf_file(
@@ -104,7 +102,9 @@ def get_instance_info(params):
         app_name, instance_name, instance_vars['stateboard']
     )
 
-    return ModuleRes(success=True, meta=instance_info)
+    return ModuleRes(changed=False, facts={
+        'instance_info': instance_info
+    })
 
 
 def main():
@@ -112,12 +112,8 @@ def main():
     try:
         res = get_instance_info(module.params)
     except Exception as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_set_package_info.py
+++ b/library/cartridge_set_package_info.py
@@ -1,19 +1,16 @@
 #!/usr/bin/python
 
 import os
-import subprocess
 import re
+import subprocess
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible.module_utils.helpers import ModuleRes
-
 
 argument_spec = {
     'app_name': {'required': False, 'type': 'str'},
     'package_path': {'required': True, 'type': 'str'},
 }
-
 
 DEB = 'deb'
 RPM = 'rpm'
@@ -117,11 +114,13 @@ def get_package_info(params):
     if app_name and package_info['name'] != app_name:
         msg = 'cartridge_app_name value should be equal to package name. ' + \
               'Found cartridge_app_name: "%s", package name: "%s"' % (app_name, package_info['name'])
-        return ModuleRes(success=False, msg=msg)
+        return ModuleRes(failed=True, msg=msg)
 
     package_info['package_type'] = package_type
 
-    return ModuleRes(success=True, meta=package_info)
+    return ModuleRes(changed=False, facts={
+        'package_info': package_info,
+    })
 
 
 def main():
@@ -129,12 +128,8 @@ def main():
     try:
         res = get_package_info(module.params)
     except Exception as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_set_single_instances_for_each_machine.py
+++ b/library/cartridge_set_single_instances_for_each_machine.py
@@ -5,7 +5,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.helpers import ModuleRes
 from ansible.module_utils.helpers import is_expelled
 
-
 argument_spec = {
     'hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
@@ -37,8 +36,8 @@ def get_one_not_expelled_instance_for_machine(params):
             machine_hostnames.add(machine_hostname)
             instance_names.append(instance_name)
 
-    return ModuleRes(success=True, meta={
-        'names': instance_names,
+    return ModuleRes(changed=False, facts={
+        'single_instances_for_each_machine': instance_names,
     })
 
 
@@ -47,12 +46,8 @@ def main():
     try:
         res = get_one_not_expelled_instance_for_machine(module.params)
     except Exception as e:
-        module.fail_json(msg=str(e))
-
-    if res.success is True:
-        module.exit_json(changed=res.changed, **res.meta)
-    else:
-        module.fail_json(msg=res.msg)
+        res = ModuleRes(exception=e)
+    res.exit(module)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tenacity~=6.3.1
 parameterized~=0.8.1
 ansible~=2.10.6
-testinfra~=6.0.0
+pytest-testinfra~=6.1.0
 flake8~=3.8.4
 molecule[docker,ansible]~=3.2.3

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -7,10 +7,9 @@
   register: copied_package
 
 - name: Get package meta info
-  cartridge_get_package_info:
+  cartridge_set_package_info:
     package_path: '{{ copied_package.dest }}'
     app_name: '{{ cartridge_app_name }}'
-  register: package_info
   any_errors_fatal: true
 
 - name: Set cartridge_app_name from package info

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     - cartridge-config
 
 - name: Collect instance info
-  cartridge_get_instance_info:
+  cartridge_set_instance_info:
     app_name: '{{ cartridge_app_name }}'
     instance_name: '{{ inventory_hostname }}'
     instance_vars:
@@ -48,17 +48,15 @@
       cartridge_run_dir: '{{ cartridge_run_dir }}'
       cartridge_data_dir: '{{ cartridge_data_dir }}'
       stateboard: '{{ stateboard }}'
-  register: instance_info
   tags:
     - cartridge-instances
     - cartridge-replicasets
     - cartridge-config
 
 - name: Get one instance from each physical machine
-  cartridge_get_instance_from_each_machine:
+  cartridge_set_single_instances_for_each_machine:
     hostvars: '{{ hostvars }}'
     play_hosts: '{{ play_hosts }}'
-  register: single_instances_for_each_machine
   run_once: true
   tags: cartridge-instances
 
@@ -66,7 +64,7 @@
   include_tasks: install_package.yml
   when: >-
     cartridge_package_path is not none and
-    inventory_hostname in single_instances_for_each_machine.names
+    inventory_hostname in single_instances_for_each_machine
   tags: cartridge-instances
 
 - name: Start instance
@@ -104,20 +102,18 @@
     - cartridge-replicasets
 
 - name: Select one not expelled instance
-  cartridge_get_one_not_expelled_instance:
+  cartridge_set_one_not_expelled_instance:
     hostvars: '{{ hostvars }}'
     play_hosts: '{{ play_hosts }}'
-  register: not_expelled_instance
   tags:
     - cartridge-replicasets
     - cartridge-config
 
 - name: Select control instance to manage topology and configuration
-  cartridge_get_control_instance:
+  cartridge_set_control_instance:
     hostvars: '{{ hostvars }}'
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ not_expelled_instance.console_sock }}'
-  register: control_instance
   run_once: true
   check_mode: false
   delegate_to: '{{ not_expelled_instance.name }}'

--- a/unit/test_app_config.py
+++ b/unit/test_app_config.py
@@ -29,7 +29,7 @@ class TestAppConfig(unittest.TestCase):
 
     def test_empty_config(self):
         res = call_config_app(self.console_sock, {})
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def test_edit_system_sections(self):
@@ -46,7 +46,7 @@ class TestAppConfig(unittest.TestCase):
             res = call_config_app(self.console_sock, {
                 section: {}
             })
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn('Unable to patch config system section', res.msg)
 
             calls = self.instance.get_calls('config_patch_clusterwide')
@@ -65,7 +65,7 @@ class TestAppConfig(unittest.TestCase):
                 'body': SECTION_BODY,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -85,7 +85,7 @@ class TestAppConfig(unittest.TestCase):
                 'body': SECTION_BODY,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -110,7 +110,7 @@ class TestAppConfig(unittest.TestCase):
                 'deleted': True,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -131,7 +131,7 @@ class TestAppConfig(unittest.TestCase):
                 'deleted': True,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -151,7 +151,7 @@ class TestAppConfig(unittest.TestCase):
                 'body': SECTION1_BODY,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -181,7 +181,7 @@ class TestAppConfig(unittest.TestCase):
                 'body': SECTION2_BODY,
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('config_patch_clusterwide')
@@ -207,7 +207,7 @@ class TestAppConfig(unittest.TestCase):
                 'body': SECTION_NEW_BODY,
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Config patch failed', res.msg)
         self.assertIn('cartridge err', res.msg)
 

--- a/unit/test_auth.py
+++ b/unit/test_auth.py
@@ -46,7 +46,7 @@ class TestAuth(unittest.TestCase):
 
     def test_empty(self):
         res = call_manage_auth(self.console_sock)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def test_edit_params(self):
@@ -71,7 +71,7 @@ class TestAuth(unittest.TestCase):
             self.instance.clear_calls('auth_set_params')
 
             res = call_manage_auth(self.console_sock, **auth_patch)
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             self.assertFalse(res.changed)
 
             calls = self.instance.get_calls('auth_set_params')
@@ -84,7 +84,7 @@ class TestAuth(unittest.TestCase):
             self.instance.clear_calls('auth_set_params')
 
             res = call_manage_auth(self.console_sock, **auth_patch)
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             self.assertTrue(res.changed)
 
             calls = self.instance.get_calls('auth_set_params')
@@ -96,7 +96,7 @@ class TestAuth(unittest.TestCase):
         self.instance.set_variable('auth_params', {})
 
         res = call_manage_auth(self.console_sock, enabled=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('cartridge err', res.msg)
 
     def test_user_functions_implemented(self):
@@ -108,7 +108,7 @@ class TestAuth(unittest.TestCase):
         # no one operation is implemented
         self.instance.set_variable('webui_auth_params', {})
         res = call_manage_auth(self.console_sock, users=[USER])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('backend must implement all user management functions', res.msg)
 
         # check that all operations are required
@@ -123,7 +123,7 @@ class TestAuth(unittest.TestCase):
             })
 
             res = call_manage_auth(self.console_sock, users=[USER])
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn('backend must implement all user management functions', res.msg)
 
     def test_add_user(self):
@@ -148,7 +148,7 @@ class TestAuth(unittest.TestCase):
         self.instance.clear_calls('auth_remove_user')
 
         res = call_manage_auth(self.console_sock, users=[USER1, USER2])
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('auth_add_user')
@@ -169,7 +169,7 @@ class TestAuth(unittest.TestCase):
         self.instance.clear_calls('auth_remove_user')
 
         res = call_manage_auth(self.console_sock, users=[USER1, USER2])
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('auth_add_user')
@@ -188,7 +188,7 @@ class TestAuth(unittest.TestCase):
         self.instance.set_variable('users', [])
 
         res = call_manage_auth(self.console_sock, users=[USER1])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('cartridge err', res.msg)
 
     def test_edit_user(self):
@@ -220,7 +220,7 @@ class TestAuth(unittest.TestCase):
             }
 
             res = call_manage_auth(self.console_sock, users=[user_patch])
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             if param != 'password':
                 self.assertTrue(res.changed)
             else:
@@ -246,7 +246,7 @@ class TestAuth(unittest.TestCase):
         }
 
         res = call_manage_auth(self.console_sock, users=[user_patch])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('cartridge err', res.msg)
 
     def test_edit_user_no_version(self):
@@ -279,7 +279,7 @@ class TestAuth(unittest.TestCase):
             }
 
             res = call_manage_auth(self.console_sock, users=[user_patch])
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             if param != 'password':
                 self.assertTrue(res.changed)
             else:
@@ -305,7 +305,7 @@ class TestAuth(unittest.TestCase):
         }
 
         res = call_manage_auth(self.console_sock, users=[user_patch])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('cartridge err', res.msg)
 
     def test_delete_user(self):
@@ -333,7 +333,7 @@ class TestAuth(unittest.TestCase):
         deleted_user2['deleted'] = True
 
         res = call_manage_auth(self.console_sock, users=[USER1, deleted_user2])
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('auth_add_user')
@@ -357,7 +357,7 @@ class TestAuth(unittest.TestCase):
         deleted_user2['deleted'] = True
 
         res = call_manage_auth(self.console_sock, users=[USER1, deleted_user2])
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('auth_add_user')
@@ -378,7 +378,7 @@ class TestAuth(unittest.TestCase):
         deleted_user1['deleted'] = True
 
         res = call_manage_auth(self.console_sock, users=[deleted_user1])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('cartridge err', res.msg)
 
     def test_empty_users(self):
@@ -398,7 +398,7 @@ class TestAuth(unittest.TestCase):
         self.instance.clear_calls('auth_remove_user')
 
         res = call_manage_auth(self.console_sock, users=[])
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('auth_add_user')

--- a/unit/test_bootstrap_vshard.py
+++ b/unit/test_bootstrap_vshard.py
@@ -30,7 +30,7 @@ class TestBootstrapVshard(unittest.TestCase):
         self.instance.set_variable('can_bootstrap_vshard', False)
 
         res = call_bootstrap_vshard(self.console_sock)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         self.assertEqual(len(self.instance.get_calls('bootstrap_vshard')), 0)
@@ -39,7 +39,7 @@ class TestBootstrapVshard(unittest.TestCase):
         self.instance.set_variable('can_bootstrap_vshard', True)
 
         res = call_bootstrap_vshard(self.console_sock)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         self.assertEqual(len(self.instance.get_calls('bootstrap_vshard')), 1)
@@ -49,7 +49,7 @@ class TestBootstrapVshard(unittest.TestCase):
         self.instance.set_fail_on('bootstrap_vshard')
 
         res = call_bootstrap_vshard(self.console_sock)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Vshard bootstrap failed', res.msg)
         self.assertIn('cartridge err', res.msg)
 

--- a/unit/test_check_instance_state.py
+++ b/unit/test_check_instance_state.py
@@ -50,7 +50,7 @@ class TestInstanceStarted(unittest.TestCase):
         # console sock doesn't exists
         self.instance.remove_file(self.console_sock)
         res = call_check_instance_state(self.console_sock, stateboard)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Instance socket not found', res.msg)
 
         # cannot connect to console sock
@@ -58,7 +58,7 @@ class TestInstanceStarted(unittest.TestCase):
         self.instance.write_file(bad_socket_path)
 
         res = call_check_instance_state(bad_socket_path, stateboard)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed to connect to socket', res.msg)
 
     def test_stateboard_not_started(self):
@@ -69,7 +69,7 @@ class TestInstanceStarted(unittest.TestCase):
 
         self.instance.set_box_cfg_function(True)
         res = call_check_instance_state(self.console_sock, stateboard=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("Stateboard is not running: box hasn't been configured", res.msg)
 
     def test_stateboard_not_listen(self):
@@ -77,7 +77,7 @@ class TestInstanceStarted(unittest.TestCase):
 
         self.instance.set_box_cfg({})
         res = call_check_instance_state(self.console_sock, stateboard=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("Stateboard is not running: box hasn't been configured", res.msg)
 
     def test_stateboard_started(self):
@@ -85,7 +85,7 @@ class TestInstanceStarted(unittest.TestCase):
 
         self.instance.set_box_cfg({'listen': 3333})
         res = call_check_instance_state(self.console_sock, stateboard=True)
-        self.assertTrue(res.success)
+        self.assertFalse(res.failed)
 
     def test_instance_not_started(self):
         self.template_test_instance_not_started(stateboard=False)
@@ -95,7 +95,7 @@ class TestInstanceStarted(unittest.TestCase):
 
         set_confapplier_state(self.instance, 'OperationError')
         res = call_check_instance_state(self.console_sock)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("Instance is not in one of states: ['Unconfigured', 'RolesConfigured'], "
                       "it's in 'OperationError' state", res.msg)
 
@@ -110,14 +110,14 @@ class TestInstanceStarted(unittest.TestCase):
             'cold': {'bucket_count': 30000, 'bootstrapped': False},
         })
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertTrue(res.success)
+        self.assertFalse(res.failed)
 
         set_vshard_groups(self.instance, {
             'hot': {'bucket_count': 2000, 'bootstrapped': True},
             'cold': {'bucket_count': 30000, 'bootstrapped': False},
         })
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
 
         set_vshard_groups(self.instance, {
@@ -125,7 +125,7 @@ class TestInstanceStarted(unittest.TestCase):
             'cold': {'bucket_count': 30000, 'bootstrapped': True},
         })
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
 
     def test_instance_no_router(self):
@@ -139,12 +139,12 @@ class TestInstanceStarted(unittest.TestCase):
 
         set_vshard_router_unknown_buckets(self.instance, {'hot': 1000})
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
 
         set_vshard_router_unknown_buckets(self.instance, {'cold': 1000})
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
 
     def test_instance_discovering(self):
@@ -158,12 +158,12 @@ class TestInstanceStarted(unittest.TestCase):
 
         set_vshard_router_unknown_buckets(self.instance, {'hot': 1000, 'cold': 0})
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 2000 buckets are not discovered in group 'hot'", res.msg)
 
         set_vshard_router_unknown_buckets(self.instance, {'hot': 0, 'cold': 1000})
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("1000 out of 30000 buckets are not discovered in group 'cold'", res.msg)
 
     def test_instance_bootstrapped(self):
@@ -174,7 +174,7 @@ class TestInstanceStarted(unittest.TestCase):
         })
         set_vshard_router_unknown_buckets(self.instance, {'cold': 0, 'hot': 0})
         res = call_check_instance_state(self.console_sock, check_buckets_are_discovered=True)
-        self.assertTrue(res.success)
+        self.assertFalse(res.failed)
 
     def tearDown(self):
         self.instance.stop()

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -56,7 +56,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertFalse(res.success, msg=res.msg)
+        self.assertTrue(res.failed, msg=res.msg)
         self.assertEqual(res.msg, "Failed to edit topology: cartridge err")
 
         calls = self.instance.get_calls('edit_topology')
@@ -85,7 +85,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertFalse(res.success, msg=res.msg)
+        self.assertTrue(res.failed, msg=res.msg)
         self.assertEqual(res.msg, "Failed to edit failover priority: cartridge err")
 
         calls = self.instance.get_calls('edit_topology')
@@ -134,7 +134,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertFalse(res.success, msg=res.msg)
+        self.assertTrue(res.failed, msg=res.msg)
         self.assertIn("Some of replicaset instances aren't found in cluster: r2-replica", res.msg)
         self.assertEqual(len(self.instance.get_calls('edit_topology')), 0)
 
@@ -147,7 +147,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('edit_topology')
@@ -233,7 +233,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -254,7 +254,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -312,7 +312,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -372,7 +372,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -414,7 +414,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -460,7 +460,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
         calls = self.instance.get_calls('edit_topology')
 
@@ -540,7 +540,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('edit_topology')
@@ -615,7 +615,7 @@ class TestEditTopology(unittest.TestCase):
             self.console_sock,
             hostvars
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('edit_topology')

--- a/unit/test_manage_failover.py
+++ b/unit/test_manage_failover.py
@@ -41,7 +41,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='eventual')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -53,7 +53,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='eventual')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -64,7 +64,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='stateful')
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Stateful failover is supported since cartridge 2',
             res.msg
@@ -78,7 +78,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='disabled')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -90,7 +90,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='disabled')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -105,7 +105,7 @@ class TestFailover(unittest.TestCase):
         self.instance.set_fail_on('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='eventual')
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed admin_enable_failover', res.msg)
         self.assertIn('cartridge err', res.msg)
 
@@ -115,7 +115,7 @@ class TestFailover(unittest.TestCase):
         self.instance.set_fail_on('manage_failover')
 
         res = call_manage_failover(self.console_sock, mode='disabled')
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed admin_disable_failover', res.msg)
         self.assertIn('cartridge err', res.msg)
 
@@ -127,7 +127,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover(self.console_sock, mode='eventual')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -139,7 +139,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover(self.console_sock, mode='eventual')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -154,7 +154,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover(self.console_sock, mode='disabled')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -166,7 +166,7 @@ class TestFailover(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover(self.console_sock, mode='disabled')
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -188,7 +188,7 @@ class TestFailover(unittest.TestCase):
         res = call_manage_failover(self.console_sock, mode='stateful',
                                    state_provider='stateboard',
                                    stateboard_params=STATEBOARD_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -210,7 +210,7 @@ class TestFailover(unittest.TestCase):
         res = call_manage_failover(self.console_sock, mode='stateful',
                                    state_provider='stateboard',
                                    stateboard_params=STATEBOARD_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -236,7 +236,7 @@ class TestFailover(unittest.TestCase):
             res = call_manage_failover(self.console_sock, mode='stateful',
                                        state_provider='stateboard',
                                        stateboard_params=new_params)
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             self.assertTrue(res.changed)
 
             calls = self.instance.get_calls('failover_set_params')
@@ -265,7 +265,7 @@ class TestFailover(unittest.TestCase):
         res = call_manage_failover(self.console_sock, mode='stateful',
                                    state_provider='etcd2',
                                    etcd2_params=ETCD2_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -283,7 +283,7 @@ class TestFailover(unittest.TestCase):
         res = call_manage_failover(self.console_sock, mode='stateful',
                                    state_provider='etcd2',
                                    etcd2_params=None)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -304,7 +304,7 @@ class TestFailover(unittest.TestCase):
         res = call_manage_failover(self.console_sock, mode='stateful',
                                    state_provider='etcd2',
                                    etcd2_params=ETCD2_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -335,7 +335,7 @@ class TestFailover(unittest.TestCase):
             res = call_manage_failover(self.console_sock, mode='stateful',
                                        state_provider='etcd2',
                                        etcd2_params=new_params)
-            self.assertTrue(res.success, msg=res.msg)
+            self.assertFalse(res.failed, msg=res.msg)
             self.assertTrue(res.changed)
 
             calls = self.instance.get_calls('failover_set_params')
@@ -370,7 +370,7 @@ class TestFailover(unittest.TestCase):
                                    state_provider='stateboard',
                                    etcd2_params=ETCD2_PARAMS,
                                    stateboard_params=STATEBOARD_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -390,7 +390,7 @@ class TestFailover(unittest.TestCase):
                                    state_provider='etcd2',
                                    etcd2_params=ETCD2_PARAMS,
                                    stateboard_params=STATEBOARD_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -415,7 +415,7 @@ class TestFailover(unittest.TestCase):
                                    state_provider='etcd2',
                                    etcd2_params=ETCD2_PARAMS,
                                    stateboard_params=STATEBOARD_PARAMS)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')

--- a/unit/test_manage_failover_deprecated.py
+++ b/unit/test_manage_failover_deprecated.py
@@ -35,7 +35,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -47,7 +47,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -61,7 +61,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -73,7 +73,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('manage_failover')
@@ -88,7 +88,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.set_fail_on('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed admin_enable_failover', res.msg)
         self.assertIn('cartridge err', res.msg)
 
@@ -98,7 +98,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.set_fail_on('manage_failover')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed admin_disable_failover', res.msg)
         self.assertIn('cartridge err', res.msg)
 
@@ -110,7 +110,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -122,7 +122,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -137,7 +137,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -149,7 +149,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.clear_calls('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('failover_set_params')
@@ -165,7 +165,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.set_fail_on('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, True)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed to set failover params', res.msg)
         self.assertIn('cartridge err', res.msg)
 
@@ -175,7 +175,7 @@ class TestFailoverDeprecated(unittest.TestCase):
         self.instance.set_fail_on('failover_set_params')
 
         res = call_manage_failover_deprecated(self.console_sock, False)
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Failed to set failover params', res.msg)
         self.assertIn('cartridge err', res.msg)
 

--- a/unit/test_manage_instance.py
+++ b/unit/test_manage_instance.py
@@ -42,7 +42,7 @@ class TestManageInstance(unittest.TestCase):
             console_sock=self.console_sock
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
         self.assertEqual(len(self.instance.get_calls('box_cfg')), 0)
 
@@ -55,7 +55,7 @@ class TestManageInstance(unittest.TestCase):
             console_sock=bad_socket_path
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
         self.assertEqual(len(self.instance.get_calls('box_cfg')), 0)
 
@@ -67,7 +67,7 @@ class TestManageInstance(unittest.TestCase):
             console_sock=self.console_sock
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
         self.assertEqual(len(self.instance.get_calls('box_cfg')), 0)
 
@@ -87,7 +87,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_instance_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -103,7 +103,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_app_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -122,7 +122,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_app_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -145,7 +145,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: SMALL_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         self.assertEqual(len(self.instance.get_calls('box_cfg')), 0)
@@ -169,7 +169,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: INSTANCE_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -186,7 +186,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: APP_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -206,7 +206,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: APP_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -234,7 +234,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: INSTANCE_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -251,7 +251,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: APP_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -271,7 +271,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: APP_BIG_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -290,7 +290,7 @@ class TestManageInstance(unittest.TestCase):
                 'memtx_memory': BIG_MEMTX_MEMORY,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -314,7 +314,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_instance_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -331,7 +331,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_app_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -351,7 +351,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: new_app_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -368,7 +368,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: old_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')
@@ -385,7 +385,7 @@ class TestManageInstance(unittest.TestCase):
                 param_name: old_value,
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         calls = self.instance.get_calls('box_cfg')

--- a/unit/test_needs_restart.py
+++ b/unit/test_needs_restart.py
@@ -62,7 +62,7 @@ class TestNeedsRestart(unittest.TestCase):
             console_sock=self.console_sock,
             restarted=True
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
     def test_restart_disabled(self):
@@ -70,7 +70,7 @@ class TestNeedsRestart(unittest.TestCase):
             console_sock=self.console_sock,
             restarted=False
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def test_instance_not_started(self):
@@ -81,7 +81,7 @@ class TestNeedsRestart(unittest.TestCase):
             console_sock=self.console_sock
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # cannot connect to console sock
@@ -92,7 +92,7 @@ class TestNeedsRestart(unittest.TestCase):
             console_sock=bad_socket_path
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
     def test_box_cfg_is_function(self):
@@ -114,7 +114,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # param was changed
@@ -125,7 +125,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
         )
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
     def test_code_was_updated(self):
@@ -135,7 +135,7 @@ class TestNeedsRestart(unittest.TestCase):
 
         res = call_needs_restart(console_sock=self.console_sock)
 
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
     @parameterized.expand(
@@ -169,7 +169,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard,
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # param changed, memory size not
@@ -181,7 +181,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # param isn't changed
@@ -196,7 +196,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # param isn't changed
@@ -211,7 +211,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # param is changed
@@ -226,7 +226,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
     @parameterized.expand(
@@ -260,7 +260,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # param changed, memory size not
@@ -272,7 +272,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         if not stateboard:
             self.assertTrue(res.changed)
         else:
@@ -290,7 +290,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         if not stateboard:
             self.assertTrue(res.changed)
         else:
@@ -308,7 +308,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # param is changed
@@ -323,7 +323,7 @@ class TestNeedsRestart(unittest.TestCase):
             },
             stateboard=stateboard
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         if not stateboard:
             self.assertTrue(res.changed)
         else:
@@ -356,7 +356,7 @@ class TestNeedsRestart(unittest.TestCase):
                 memory_param_name: current_memory_size
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # memory size changed only in cartridge_defaults
@@ -369,7 +369,7 @@ class TestNeedsRestart(unittest.TestCase):
                 memory_param_name: new_memory_size_instance
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # memory size changed both in cartridge_defaults and config
@@ -382,7 +382,7 @@ class TestNeedsRestart(unittest.TestCase):
                 memory_param_name: new_memory_size_app
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # memory size changed both in cartridge_defaults and config
@@ -397,7 +397,7 @@ class TestNeedsRestart(unittest.TestCase):
                 memory_param_name: new_memory_size_app
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertTrue(res.changed)
 
         # memory size changed both in cartridge_defaults and config
@@ -412,7 +412,7 @@ class TestNeedsRestart(unittest.TestCase):
                 memory_param_name: new_memory_size_app
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def tearDown(self):

--- a/unit/test_probe_instance.py
+++ b/unit/test_probe_instance.py
@@ -54,7 +54,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 1)
@@ -73,7 +73,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 2)
@@ -93,7 +93,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 1)
@@ -112,7 +112,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertIn(len(calls), [1, 2])
@@ -137,7 +137,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 0)
@@ -156,7 +156,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 1)
@@ -176,7 +176,7 @@ class TestProbeInstance(unittest.TestCase):
                 }
             }
         )
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 1)
@@ -201,7 +201,7 @@ class TestProbeInstance(unittest.TestCase):
             },
             play_hosts=['instance-1']
         )
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
 
         calls = self.instance.get_calls('admin_probe_server')
         self.assertEqual(len(calls), 2)

--- a/unit/test_set_instance_info.py
+++ b/unit/test_set_instance_info.py
@@ -5,14 +5,14 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 
 import unittest
 
-from library.cartridge_get_instance_info import get_instance_info
-from library.cartridge_get_instance_info import get_instance_pid_file
-from library.cartridge_get_instance_info import get_instance_conf_file
-from library.cartridge_get_instance_info import get_app_conf_file
-from library.cartridge_get_instance_info import get_instance_conf_section
-from library.cartridge_get_instance_info import get_instance_work_dir
-from library.cartridge_get_instance_info import get_instance_systemd_service
-from library.cartridge_get_instance_info import get_package_type
+from library.cartridge_set_instance_info import get_instance_info
+from library.cartridge_set_instance_info import get_instance_pid_file
+from library.cartridge_set_instance_info import get_instance_conf_file
+from library.cartridge_set_instance_info import get_app_conf_file
+from library.cartridge_set_instance_info import get_instance_conf_section
+from library.cartridge_set_instance_info import get_instance_work_dir
+from library.cartridge_set_instance_info import get_instance_systemd_service
+from library.cartridge_set_instance_info import get_package_type
 
 from ansible.module_utils.helpers import get_instance_console_sock
 
@@ -96,8 +96,8 @@ class TestGetInstanceInfo(unittest.TestCase):
         }
 
         res = call_get_instance_info(app_name, instance_name, instance_vars)
-        self.assertTrue(res.success)
-        self.assertEqual(res.meta, {
+        self.assertFalse(res.failed)
+        self.assertEqual(res.facts, {'instance_info': {
             'package_type': 'rpm',
             'instance_code_dir': 'some/dist/dir/myapp',
             'app_conf_file': 'some/conf/dir/myapp.yml',
@@ -107,7 +107,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'pid_file': 'some/run/dir/myapp.instance-1.pid',
             'work_dir': 'some/data/dir/myapp.instance-1',
             'systemd_service': 'myapp@instance-1',
-        })
+        }})
 
     def test_get_stateboard_info(self):
         app_name = 'myapp'
@@ -122,8 +122,8 @@ class TestGetInstanceInfo(unittest.TestCase):
         }
 
         res = call_get_instance_info(app_name, instance_name, instance_vars)
-        self.assertTrue(res.success)
-        self.assertEqual(res.meta, {
+        self.assertFalse(res.failed)
+        self.assertEqual(res.facts, {'instance_info': {
             'package_type': 'rpm',
             'instance_code_dir': 'some/dist/dir/myapp',
             'app_conf_file': 'some/conf/dir/myapp.yml',
@@ -133,4 +133,4 @@ class TestGetInstanceInfo(unittest.TestCase):
             'pid_file': 'some/run/dir/myapp-stateboard.pid',
             'work_dir': 'some/data/dir/myapp-stateboard',
             'systemd_service': 'myapp-stateboard',
-        })
+        }})

--- a/unit/test_set_one_non_expelled_instance.py
+++ b/unit/test_set_one_non_expelled_instance.py
@@ -5,7 +5,7 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 
 import unittest
 
-from library.cartridge_get_one_not_expelled_instance import get_one_not_expelled_instance
+from library.cartridge_set_one_not_expelled_instance import get_one_not_expelled_instance
 
 
 def call_get_one_not_expelled_instance(hostvars, play_hosts=None):
@@ -39,18 +39,18 @@ class TestGetOneNotExpelledInstance(unittest.TestCase):
         res = call_get_one_not_expelled_instance(self.hostvars, [
             'expelled-1', 'my-stateboard', 'expelled-2',
         ])
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Not found any instance that is not expelled and is not a stateboard', res.msg)
 
     def test_instance_found(self):
         res = call_get_one_not_expelled_instance(self.hostvars, [
             'expelled-1', 'my-stateboard', 'expelled-2', 'instance-1', 'instance-2', 'instance-3',
         ])
-        self.assertTrue(res.success, res.msg)
+        self.assertFalse(res.failed, res.msg)
 
         possible_meta = [
             {'name': 'instance-1', 'console_sock': 'sock-1'},
             {'name': 'instance-2', 'console_sock': 'sock-2'},
         ]
 
-        self.assertIn(res.meta, possible_meta)
+        self.assertIn(res.facts['not_expelled_instance'], possible_meta)

--- a/unit/test_set_single_instances_for_each_machine.py
+++ b/unit/test_set_single_instances_for_each_machine.py
@@ -5,7 +5,7 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 
 import unittest
 
-from library.cartridge_get_instance_from_each_machine import get_one_not_expelled_instance_for_machine
+from library.cartridge_set_single_instances_for_each_machine import get_one_not_expelled_instance_for_machine
 
 
 def call_get_one_not_expelled_instance_for_machine(hostvars, play_hosts=None):
@@ -49,22 +49,23 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
         res = call_get_one_not_expelled_instance_for_machine(self.hostvars, [
             'expelled-1', 'expelled-2',
         ])
-        self.assertTrue(res.success, res.msg)
-        self.assertEqual(len(res.meta['names']), 0)
+        self.assertFalse(res.failed, res.msg)
+        self.assertEqual(len(res.facts['single_instances_for_each_machine']), 0)
 
     def test_stateboard_found(self):
         res = call_get_one_not_expelled_instance_for_machine(self.hostvars, [
             'expelled-1', 'expelled-2', 'stateboard-1', 'stateboard-2',
         ])
-        self.assertTrue(res.success, res.msg)
-        self.assertEqual(res.meta['names'], ['stateboard-1', 'stateboard-2'])
+        self.assertFalse(res.failed, res.msg)
+        self.assertEqual(res.facts['single_instances_for_each_machine'], ['stateboard-1', 'stateboard-2'])
 
     def test_instances_found(self):
         res = call_get_one_not_expelled_instance_for_machine(self.hostvars, [
             'expelled-1', 'expelled-2', 'instance-1', 'instance-2', 'stateboard-1', 'stateboard-2',
         ])
-        self.assertTrue(res.success, res.msg)
+        self.assertFalse(res.failed, res.msg)
 
-        self.assertEqual(len(res.meta['names']), 2)
-        self.assertTrue('instance-1' in res.meta['names'] or 'stateboard-1' in res.meta['names'])
-        self.assertTrue('instance-2' in res.meta['names'] or 'stateboard-2' in res.meta['names'])
+        single_instances = res.facts['single_instances_for_each_machine']
+        self.assertEqual(len(single_instances), 2)
+        self.assertTrue('instance-1' in single_instances or 'stateboard-1' in single_instances)
+        self.assertTrue('instance-2' in single_instances or 'stateboard-2' in single_instances)

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -144,7 +144,7 @@ class TestValidateConfig(unittest.TestCase):
         for t, params in params_by_types.items():
             for p in params:
                 res = call_validate_config({'instance-1': get_wrong_params(p)})
-                self.assertFalse(res.success)
+                self.assertTrue(res.failed)
                 self.assertIn("{} must be {}".format(p, t), res.msg)
 
     def test_instance_required_params(self):
@@ -159,7 +159,7 @@ class TestValidateConfig(unittest.TestCase):
             del params[p]
 
             res = call_validate_config({'instance-1': params})
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn('"{}" must be specified'.format(p), res.msg)
 
     def test_config_required_params(self):
@@ -170,7 +170,7 @@ class TestValidateConfig(unittest.TestCase):
                 'config': {}
             }
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Missed required parameter "advertise_uri" in "instance-1" config', res.msg)
 
         res = call_validate_config({
@@ -180,7 +180,7 @@ class TestValidateConfig(unittest.TestCase):
                 'config': {'advertise_uri': '3301'}
             }
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('Instance advertise_uri must be specified as "<host>:<port>" ("instance-1")', res.msg)
 
         res = call_validate_config({
@@ -190,7 +190,7 @@ class TestValidateConfig(unittest.TestCase):
                 'config': {'advertise_uri': 'localhost:3301'}
             }
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def test_forbidden_params(self):
@@ -207,7 +207,7 @@ class TestValidateConfig(unittest.TestCase):
             bad_params['instance-1']['config'][p] = 'I AM FORBIDDEN'
 
             res = call_validate_config(bad_params)
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn(
                 'Specified forbidden parameter "{}" in "instance-1" config'.format(p),
                 res.msg
@@ -222,7 +222,7 @@ class TestValidateConfig(unittest.TestCase):
                 'config': {'advertise_uri': 'localhost:3301'}
             }
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Cluster cookie must be specified in "cartridge_cluster_cookie", not in "cartridge_defaults"',
             res.msg
@@ -261,7 +261,7 @@ class TestValidateConfig(unittest.TestCase):
                 'instance-1': instance1_params,
                 'instance-2': instance2_params,
             })
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn('"{}" must be the same for all hosts'.format(p), res.msg)
 
             # passed only for one instance
@@ -276,7 +276,7 @@ class TestValidateConfig(unittest.TestCase):
                     'instance-1': instance1_params,
                     'instance-2': instance2_params,
                 })
-                self.assertFalse(res.success)
+                self.assertTrue(res.failed)
                 self.assertIn('"{}" must be the same for all hosts'.format(p), res.msg)
 
     def test_replicaset_required_params(self):
@@ -296,7 +296,7 @@ class TestValidateConfig(unittest.TestCase):
             del params[p]
 
             res = call_validate_config({'instance-1': params})
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn('Parameter "{}" is required for all replicasets'.format(p), res.msg)
 
     def test_replicaset_common_params(self):
@@ -343,7 +343,7 @@ class TestValidateConfig(unittest.TestCase):
                 'instance-12': instance12_params,
                 'instance-21': replicaset2_params,
             })
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             errmsg = 'Replicaset parameters must be the same for all instances within one replicaset ("replicaset-1")'
             self.assertIn(errmsg, res.msg)
 
@@ -360,7 +360,7 @@ class TestValidateConfig(unittest.TestCase):
                     'instance-12': instance12_params,
                     'instance-21': replicaset2_params,
                 })
-                self.assertFalse(res.success)
+                self.assertTrue(res.failed)
                 errmsg = 'Replicaset parameters must be the same for all instances within one replicaset ' + \
                     '("replicaset-1")'
                 self.assertIn(errmsg, res.msg)
@@ -374,7 +374,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_app_config': 42,
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn("cartridge_app_config must be <class 'dict'>", res.msg)
 
         res = call_validate_config({
@@ -385,7 +385,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_app_config': {},
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         res = call_validate_config({
@@ -396,7 +396,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_app_config': {'section-1': 42},
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('"cartridge_app_config.section-1" must be dict', res.msg)
 
         res = call_validate_config({
@@ -407,7 +407,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_app_config': {'section-1': {}},
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             '"cartridge_app_config.section-1" must have "body" or "deleted" subsection',
             res.msg
@@ -423,7 +423,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'cartridge_app_config.section-1" can contain only "body" or "deleted" subsections',
             res.msg
@@ -439,7 +439,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             '"cartridge_app_config.section-1" can contain only "body" or "deleted" subsections',
             res.msg
@@ -458,7 +458,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             '"cartridge_app_config.section-1" can contain only "body" or "deleted" subsections',
             res.msg
@@ -477,7 +477,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('"cartridge_app_config.section-1.deleted" must be bool', res.msg)
 
         res = call_validate_config({
@@ -490,7 +490,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn('"cartridge_app_config.section-1.body" is required', res.msg)
 
         res = call_validate_config({
@@ -503,7 +503,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         res = call_validate_config({
@@ -519,7 +519,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         res = call_validate_config({
@@ -532,7 +532,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
     def test_instance_states(self):
@@ -546,7 +546,7 @@ class TestValidateConfig(unittest.TestCase):
                 'restarted': True,
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # expelled
@@ -559,7 +559,7 @@ class TestValidateConfig(unittest.TestCase):
                 'expelled': True,
             },
         })
-        self.assertTrue(res.success, msg=res.msg)
+        self.assertFalse(res.failed, msg=res.msg)
         self.assertFalse(res.changed)
 
         # both expelled and restarted set to true
@@ -573,7 +573,7 @@ class TestValidateConfig(unittest.TestCase):
                 'restarted': True,
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Flags "expelled" and "restarted" cannot be set at the same time',
             res.msg
@@ -592,7 +592,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_failover': True,
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Only one of "cartridge_failover" and "cartridge_failover_params" can be specified',
             res.msg
@@ -609,7 +609,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             "Failover mode should be one of ['stateful', 'eventual', 'disabled']",
             res.msg
@@ -639,7 +639,7 @@ class TestValidateConfig(unittest.TestCase):
             })
 
             res = call_validate_config(params)
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn(
                 '"{}" failover parameter is allowed only for "stateful" mode'.format(p),
                 res.msg
@@ -666,7 +666,7 @@ class TestValidateConfig(unittest.TestCase):
             del params['instance-1']['cartridge_failover_params'][p]
 
             res = call_validate_config(params)
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn(
                 '"{}" failover parameter is required for "stateful" mode'.format(p),
                 res.msg
@@ -684,7 +684,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             "Stateful failover state provider should be one of ['stateboard', 'etcd2']",
             res.msg
@@ -703,7 +703,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'stateboard_params" is required for "stateboard" state provider',
             res.msg
@@ -735,7 +735,7 @@ class TestValidateConfig(unittest.TestCase):
             del params['instance-1']['cartridge_failover_params']['stateboard_params'][p]
 
             res = call_validate_config(params)
-            self.assertFalse(res.success)
+            self.assertTrue(res.failed)
             self.assertIn(
                 'stateboard_params.{}" is required for "stateboard" provider'.format(p),
                 res.msg
@@ -757,7 +757,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Stateboard URI must be specified as "<host>:<port>"',
             res.msg
@@ -779,7 +779,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'Stateboard password cannot contain symbols other than [a-zA-Z0-9_.~-]',
             res.msg
@@ -798,7 +798,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertTrue(res.success)
+        self.assertFalse(res.failed)
 
         res = call_validate_config({
             'instance-1': {
@@ -819,7 +819,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertFalse(res.success)
+        self.assertTrue(res.failed)
         self.assertIn(
             'etcd2 endpoints must be specified as "<host>:<port>"',
             res.msg
@@ -843,7 +843,7 @@ class TestValidateConfig(unittest.TestCase):
                 },
             },
         })
-        self.assertTrue(res.success)
+        self.assertFalse(res.failed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- add availability to set fact from library functions
- remove `meta` param
- change `success` flag to `failed` flag (as in AnsibleModule)