### PR TITLE
Fix Tarantool installation in GitHub Actions

### DIFF
--- a/.github/workflows/molecule-check.yml
+++ b/.github/workflows/molecule-check.yml
@@ -33,16 +33,22 @@ jobs:
           path: 'packages'
           key: ce-${{ matrix.tarantool-version }}-${{ env.CARTRIDGE_CLI_VERSION }}
 
+      - name: Install Tarantool
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool-version }}'
+
       - name: Create test packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: |
-          sudo apt -y update
-          sudo apt -y install git gcc make cmake unzip
+          sudo apt-get update
+
+          sudo apt-get -y install git gcc make cmake unzip
           git config --global user.email "test@tarantool.io" \
             && git config --global user.name "Tar Antool"
 
-          curl -L https://tarantool.io/release/${{ matrix.tarantool-version }}/installer.sh | bash
-          sudo apt install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
+          sudo apt-get install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
 
           tarantool --version
           cartridge version

--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -37,16 +37,22 @@ jobs:
           path: 'packages'
           key: ce-${{ matrix.tarantool-version }}-${{ env.CARTRIDGE_CLI_VERSION }}
 
+      - name: Install Tarantool
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool-version }}'
+
       - name: Create test packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: |
-          sudo apt -y update
-          sudo apt -y install git gcc make cmake unzip
+          sudo apt-get update
+
+          sudo apt-get -y install git gcc make cmake unzip
           git config --global user.email "test@tarantool.io" \
             && git config --global user.name "Tar Antool"
 
-          curl -L https://tarantool.io/release/${{ matrix.tarantool-version }}/installer.sh | bash
-          sudo apt install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
+          sudo apt-get install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
 
           tarantool --version
           cartridge version
@@ -85,8 +91,9 @@ jobs:
       - name: Create test packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: |
-          sudo apt -y update
-          sudo apt -y install git gcc make cmake unzip
+          sudo apt-get update
+
+          sudo apt-get -y install git gcc make cmake unzip
           git config --global user.email "test@tarantool.io" \
             && git config --global user.name "Tar Antool"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,8 +11,10 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
     runs-on: ubuntu-latest
-    env:
-      TARANTOOL_VERSION: '1.10'
+    strategy:
+      matrix:
+        tarantool-version: ["1.10"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
 
@@ -21,9 +23,13 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install requirements
+      - name: Install Tarantool
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool-version }}'
+
+      - name: Install Python requirements
         run: |
-          curl -L https://tarantool.io/JRceXH/release/2.4/installer.sh | bash
           pip3 install --upgrade -r requirements.txt
 
       - name: Run linter


### PR DESCRIPTION
The `installer.sh` script no longer installs Tarantool.
It's necessary to install Tarantool separately.

It was decided to use a ready-made solution for installing Tarantool.