### PR TITLE
Fix unit tests imports to run tests by file

### DIFF
--- a/unit/instance.py
+++ b/unit/instance.py
@@ -6,7 +6,7 @@ from subprocess import Popen
 
 import tenacity
 
-from os_mock import OsPathExistsMock, OsPathGetMTimeMock
+from unit.os_mock import OsPathExistsMock, OsPathGetMTimeMock
 
 script_abspath = os.path.realpath(
     os.path.join(

--- a/unit/test_bootstrap_vshard.py
+++ b/unit/test_bootstrap_vshard.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_bootstrap_vshard import bootstrap_vshard
 
 

--- a/unit/test_check_instance_state.py
+++ b/unit/test_check_instance_state.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_check_instance_state import check_state
 
 

--- a/unit/test_configure_app_config.py
+++ b/unit/test_configure_app_config.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_configure_app_config import config_app
 
 

--- a/unit/test_configure_auth.py
+++ b/unit/test_configure_auth.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_configure_auth import manage_auth
 
 

--- a/unit/test_configure_failover.py
+++ b/unit/test_configure_failover.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_configure_failover import manage_failover
 
 

--- a/unit/test_configure_failover_deprecated.py
+++ b/unit/test_configure_failover_deprecated.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_configure_failover import manage_failover
 
 

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -1,7 +1,7 @@
 import unittest
 
-from helpers import add_replicaset
-from instance import Instance
+from unit.helpers import add_replicaset
+from unit.instance import Instance
 from library.cartridge_edit_topology import edit_topology
 
 

--- a/unit/test_manage_instance.py
+++ b/unit/test_manage_instance.py
@@ -2,8 +2,8 @@ import unittest
 
 from parameterized import parameterized
 
-from helpers import set_box_cfg
-from instance import Instance
+from unit.helpers import set_box_cfg
+from unit.instance import Instance
 from library.cartridge_instance import manage_instance
 
 

--- a/unit/test_probe_instance.py
+++ b/unit/test_probe_instance.py
@@ -1,6 +1,6 @@
 import unittest
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_probe_instance import probe_server
 
 

--- a/unit/test_set_control_instance.py
+++ b/unit/test_set_control_instance.py
@@ -2,7 +2,7 @@ import unittest
 
 import os
 
-from instance import Instance
+from unit.instance import Instance
 from library.cartridge_set_control_instance import get_control_instance
 
 

--- a/unit/test_set_needs_restart.py
+++ b/unit/test_set_needs_restart.py
@@ -3,8 +3,8 @@ import unittest
 
 from parameterized import parameterized
 
-from helpers import set_box_cfg
-from instance import Instance
+from unit.helpers import set_box_cfg
+from unit.instance import Instance
 from library.cartridge_set_needs_restart import needs_restart
 
 


### PR DESCRIPTION
Before this patch running unit tests by `python3 -m unittest unit/test_smth.py` failed with import error.