### PR TITLE
Remove temporary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to use the newest tag with new release
 - `instance_discover_buckets_timeout` parameter to configure time in seconds
   to wait for instance to discover buckets
 - `rotate_dists` step that allows to rotate application distributions
+- `cleanup` step to remove temporary files from specific list (#187)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ to use the newest tag with new release
 - `instance_discover_buckets_timeout` parameter to configure time in seconds
   to wait for instance to discover buckets
 - `rotate_dists` step that allows to rotate application distributions
-- `cleanup` step to remove temporary files from specific list (#187)
+- `cleanup` step to remove temporary files from specific list
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Common variables:
 * `cartridge_app_name` (`string`, required): application name;
 * `cartridge_cluster_cookie` (`string`, required): cluster cookie for all
   cluster instances;
+* `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`): indicates if temporary
+  files should be removed (more details in description of `cleanup` [step API](/doc/scenario.md#cleanup));
 
 Role scenario configuration:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+temporary_files: []
+cartridge_remove_temporary_files: false
+
 cartridge_package_path: null
 cartridge_defaults: {}
 cartridge_enable_tarantool_repo: true
@@ -44,6 +47,7 @@ cartridge_scenario:
   - configure_app_config
   - bootstrap_vshard
   - configure_failover
+  - cleanup
 
 cartridge_configure_systemd_unit_files: true
 cartridge_systemd_dir: /etc/systemd/system

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -445,8 +445,9 @@ Input facts (set by config):
 
 ### cleanup
 
-Remove temporary files from `temporary_files` list. By default, `temporary_files` is an empty list. The role, depending
-on the scenario, can add the following files to this list:
+Removes temporary files specified in `temporary_files` list.
+By default, `temporary_files` is an empty list. The role,
+depending on the scenario, can add the following files to this list:
 
 - path to delivered package (`delivered_package_path` variable value);
 - path to repository setup script.

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -25,6 +25,7 @@ In `cartridge_scenario` you should specify names of steps. The default scenario 
 - [configure_app_config](#configure_app_config)
 - [bootstrap_vshard](#bootstrap_vshard)
 - [configure_failover](#configure_failover)
+- [cleanup](#cleanup)
 
 There are additional steps that are not included in the default scenario, but can be used in a custom one:
 
@@ -441,6 +442,31 @@ Input facts (set by config):
 
 - [DEPRECATED] `cartridge_failover` - indicates if eventual failover should be enabled or disabled;
 - `cartridge_failover_params` - failover parameters.
+
+### cleanup
+
+Remove temporary files from `temporary_files` list. By default, `temporary_files` is an empty list. The role, depending
+on the scenario, can add the following files to this list:
+
+- path to delivered package (`delivered_package_path` variable value);
+- path to repository setup script.
+
+In addition, you can add any files to this list by specifying `temporary_files` in configuration or in any custom step.
+For example, you can make a step like this:
+
+```yaml
+- name: 'Add my temporary file'
+  set_fact:
+    temporary_files: "{{ temporary_files + ['/tmp/my_file'] }}"
+```
+
+Input facts (set by role):
+
+- `temporary_files` - list of temporary files to remove.
+
+Input facts (set by config):
+
+- `cartridge_remove_temporary_files` - indicates if temporary files should be removed.
 
 ### rotate_dists
 

--- a/tasks/steps/blocks/update_package.yml
+++ b/tasks/steps/blocks/update_package.yml
@@ -14,16 +14,20 @@
       get_url:
         url: 'https://tarantool.io/release/{{ package_info.tnt_version }}/installer.sh'
         dest: '/tmp/tarantool-installer.sh'
-      register: get_script
-      until: not get_script.failed
+      register: enable_repo_script
+      until: not enable_repo_script.failed
       retries: 3
       delay: 5
       any_errors_fatal: true
 
     - name: 'Run repository setup script'
       any_errors_fatal: true
-      command: bash /tmp/tarantool-installer.sh
+      command: bash {{ enable_repo_script.dest }}
       changed_when: false
+
+    - name: Add repository setup script to temporary files list
+      set_fact:
+        temporary_files: "{{ temporary_files + [enable_repo_script.dest] }}"
 
 - name: 'Install RPM or DEB'
   include_tasks: install_rpm_or_deb.yml

--- a/tasks/steps/cleanup.yml
+++ b/tasks/steps/cleanup.yml
@@ -7,4 +7,6 @@
   loop_control:
     loop_var: filepath
   with_items: '{{ temporary_files }}'
-  when: cartridge_remove_temporary_files
+  when:
+    - cartridge_remove_temporary_files
+    - inventory_hostname in single_instances_for_each_machine

--- a/tasks/steps/cleanup.yml
+++ b/tasks/steps/cleanup.yml
@@ -1,0 +1,10 @@
+---
+
+- name: 'Remove temporary files'
+  file:
+    path: '{{ filepath }}'
+    state: absent
+  loop_control:
+    loop_var: filepath
+  with_items: '{{ temporary_files }}'
+  when: cartridge_remove_temporary_files

--- a/tasks/steps/cleanup.yml
+++ b/tasks/steps/cleanup.yml
@@ -7,6 +7,4 @@
   loop_control:
     loop_var: filepath
   with_items: '{{ temporary_files }}'
-  when:
-    - cartridge_remove_temporary_files
-    - inventory_hostname in single_instances_for_each_machine
+  when: cartridge_remove_temporary_files

--- a/tasks/steps/deliver_package.yml
+++ b/tasks/steps/deliver_package.yml
@@ -15,3 +15,4 @@
     - name: 'Set delivered package path'
       set_fact:
         delivered_package_path: '{{ copied_package.dest }}'
+        temporary_files: "{{ temporary_files + [copied_package.dest] }}"


### PR DESCRIPTION
Closes #187

Now it's possible to remove temporary files (such as a delivered package) after use.
To do this, you should set the `cartridge_remove_temporary_files` flag to true.
Also, it's possible to add any files to `temporary_files` list by config or custom step.