### PR TITLE
Fix and improve `needs_restart`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ cartridge_failover: null
 cartridge_failover_params: null
 cartridge_wait_buckets_discovery: true
 
+needs_restart: null
 restarted: null
 expelled: false
 stateboard: false

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -199,12 +199,15 @@ Install the delivered package on physical machines.
 
 Input facts (set by role):
 
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
 - `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine;
-- `delivered_package_path` - remote path to file of delivered package.
+- `delivered_package_path` - remote path to file of delivered package;
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
 Input facts (set by config):
 
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
+- `expelled` - indicates if instance must be expelled from topology;
+- `restarted` - if instance should be restarted or not (user forced decision);
 - `cartridge_app_name` - application name;
 - `cartridge_enable_tarantool_repo` - indicates if Tarantool repository should be enabled;
 - `cartridge_install_tarantool_for_tgz` - indicates if Tarantool should be enabled when use TGZ package;
@@ -239,7 +242,8 @@ Output facts:
   - `instance_entrypoint` - path to Lua entrypoint file of instance;
   - `stateboard_entrypoint` - path to Lua entrypoint file of stateboard;
   - `instance_tarantool_binary` - path Tarantool binary file of instance;
-  - `stateboard_tarantool_binary` - path Tarantool binary file of stateboard.
+  - `stateboard_tarantool_binary` - path Tarantool binary file of stateboard;
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
 ### update_instance
 
@@ -248,14 +252,21 @@ Update instance links for a new version of package (if
 
 Input facts (set by role):
 
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
 Input facts (set by config):
 
+- `expelled` - indicates if instance must be expelled from topology;
+- `restarted` - if instance should be restarted or not (user forced decision);
 - `cartridge_multiversion` - indicates that
   [multiversion approach](/doc/multiversion.md) is enabled;
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
+
+Output facts:
+
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
 ### configure_instance
 
@@ -263,7 +274,8 @@ Configure instance in runtime and change instance config.
 
 Input facts (set by role):
 
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
 Input facts (set by config):
 
@@ -333,13 +345,13 @@ Find some instance that is already in cluster. If there is no such instance, use
 Input facts (set by role):
 
 - `not_expelled_instance` - information about one not expelled instance ([more details here](#role-facts-descriptions)).
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
 
 Input facts (set by config):
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `replicaset_alias` - replicaset alias, will be displayed in Web UI;
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
 
 Output facts:
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -202,12 +202,15 @@ Input facts (set by role):
 - `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
 - `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine;
 - `delivered_package_path` - remote path to file of delivered package;
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+- `needs_restart` - if instance should be restarted to apply code or configuration changes
+  (to determine if it's should be checked if instance should be restarted).
 
 Input facts (set by config):
 
-- `expelled` - indicates if instance must be expelled from topology;
-- `restarted` - if instance should be restarted or not (user forced decision);
+- `expelled` - indicates if instance must be expelled from topology
+  (to determine if it's should be checked if instance should be restarted);
+- `restarted` - if instance should be restarted or not (user forced decision)
+  (to determine if it's should be checked if instance should be restarted);
 - `cartridge_app_name` - application name;
 - `cartridge_enable_tarantool_repo` - indicates if Tarantool repository should be enabled;
 - `cartridge_install_tarantool_for_tgz` - indicates if Tarantool should be enabled when use TGZ package;
@@ -253,7 +256,8 @@ Update instance links for a new version of package (if
 Input facts (set by role):
 
 - `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+- `needs_restart` - if instance should be restarted to apply code or configuration changes
+  (to determine if it's should be checked if instance should be restarted).
 
 Input facts (set by config):
 
@@ -275,7 +279,8 @@ Configure instance in runtime and change instance config.
 Input facts (set by role):
 
 - `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+- `needs_restart` - if instance should be restarted to apply code or configuration changes
+  (to determine if it's should be checked if instance should be restarted).
 
 Input facts (set by config):
 

--- a/library/cartridge_set_needs_restart.py
+++ b/library/cartridge_set_needs_restart.py
@@ -166,7 +166,7 @@ def set_needs_restart(params):
 
     # check if instance was not started yet
     if not os.path.exists(console_sock):
-        return helpers.ModuleRes(facts={'needs_restart': True})
+        return helpers.ModuleRes(changed=True, facts={'needs_restart': True})
 
     try:
         control_console = helpers.get_control_console(console_sock)
@@ -177,7 +177,7 @@ def set_needs_restart(params):
             helpers.cartridge_errcodes.INSTANCE_IS_NOT_STARTED_YET
         ]
         if e.code in allowed_errcodes:
-            return helpers.ModuleRes(facts={'needs_restart': True})
+            return helpers.ModuleRes(changed=True, facts={'needs_restart': True})
 
         raise e
 
@@ -186,14 +186,14 @@ def set_needs_restart(params):
         if err is not None:
             return helpers.ModuleRes(failed=True, msg=err)
         if needs_restart:
-            return helpers.ModuleRes(facts={'needs_restart': True})
+            return helpers.ModuleRes(changed=True, facts={'needs_restart': True})
 
     if params['check_config_updated']:
         needs_restart, err = check_needs_restart_to_update_config(params, control_console)
         if err is not None:
             return helpers.ModuleRes(failed=True, msg=err)
         if needs_restart:
-            return helpers.ModuleRes(facts={'needs_restart': True})
+            return helpers.ModuleRes(changed=True, facts={'needs_restart': True})
 
     return helpers.ModuleRes(changed=False, facts={'needs_restart': False})
 

--- a/library/cartridge_set_needs_restart.py
+++ b/library/cartridge_set_needs_restart.py
@@ -160,7 +160,7 @@ def check_needs_restart_to_update_config(params, control_console):
     return False, None
 
 
-def needs_restart(params):
+def set_needs_restart(params):
     instance_info = params['instance_info']
     console_sock = instance_info['console_sock']
 
@@ -182,21 +182,21 @@ def needs_restart(params):
         raise e
 
     if params['check_package_updated']:
-        res, err = check_needs_restart_to_update_package(params)
+        needs_restart, err = check_needs_restart_to_update_package(params)
         if err is not None:
             return helpers.ModuleRes(failed=True, msg=err)
-        if res:
+        if needs_restart:
             return helpers.ModuleRes(facts={'needs_restart': True})
 
     if params['check_config_updated']:
-        res, err = check_needs_restart_to_update_config(params, control_console)
+        needs_restart, err = check_needs_restart_to_update_config(params, control_console)
         if err is not None:
             return helpers.ModuleRes(failed=True, msg=err)
-        if res:
+        if needs_restart:
             return helpers.ModuleRes(facts={'needs_restart': True})
 
     return helpers.ModuleRes(changed=False, facts={'needs_restart': False})
 
 
 if __name__ == '__main__':
-    helpers.execute_module(argument_spec, needs_restart)
+    helpers.execute_module(argument_spec, set_needs_restart)

--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -8,9 +8,9 @@
         console_sock: '{{ instance_info.console_sock }}'
         config: '{{ config }}'
         cartridge_defaults: '{{ cartridge_defaults }}'
-      when: not restarted
+      when: (restarted == false) or (restarted is none and not needs_restart)
 
-    - name: 'Check if instance restart is forced or required to apply changes'
+    - name: 'Check if instance restart is required to use new config'
       cartridge_set_needs_restart:
         app_name: '{{ cartridge_app_name }}'
         config: '{{ config }}'
@@ -18,7 +18,10 @@
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
         stateboard: '{{ stateboard }}'
         instance_info: '{{ instance_info }}'
-      when: restarted is none
+        check_config_updated: true
+      when:
+        - restarted is none
+        - needs_restart is none
 
     - name: 'Place default config'
       copy:

--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -21,7 +21,7 @@
         check_config_updated: true
       when:
         - restarted is none
-        - needs_restart is none
+        - not needs_restart
 
     - name: 'Place default config'
       copy:

--- a/tasks/steps/restart_instance.yml
+++ b/tasks/steps/restart_instance.yml
@@ -5,5 +5,5 @@
     name: '{{ instance_info.systemd_service }}'
     state: restarted
     enabled: true
-  when: (restarted is not none and restarted) or (needs_restart is defined and needs_restart)
+  when: (restarted) or (restarted is none and needs_restart)
   tags: cartridge-instances

--- a/tasks/steps/update_instance.yml
+++ b/tasks/steps/update_instance.yml
@@ -1,11 +1,21 @@
 ---
 
-- name: 'Update instance'
-  file:
-    src: '{{ instance_info.dist_dir }}'
-    dest: '{{ instance_info.instance_dist_dir }}'
-    owner: '{{ cartridge_app_user }}'
-    group: '{{ cartridge_app_group }}'
-    state: link
-  when: cartridge_multiversion
+- when: cartridge_multiversion
   tags: cartridge-instances
+  block:
+    - name: 'Update instance link to application'
+      file:
+        src: '{{ instance_info.dist_dir }}'
+        dest: '{{ instance_info.instance_dist_dir }}'
+        owner: '{{ cartridge_app_user }}'
+        group: '{{ cartridge_app_group }}'
+        state: link
+
+    - name: 'Check if instance restart is required to use new package'
+      cartridge_set_needs_restart:
+        instance_info: '{{ instance_info }}'
+        check_package_updated: true
+      when:
+        - not expelled
+        - restarted is none
+        - needs_restart is none

--- a/tasks/steps/update_instance.yml
+++ b/tasks/steps/update_instance.yml
@@ -18,4 +18,4 @@
       when:
         - not expelled
         - restarted is none
-        - needs_restart is none
+        - not needs_restart

--- a/tasks/steps/update_package.yml
+++ b/tasks/steps/update_package.yml
@@ -1,8 +1,19 @@
 ---
 
-- name: 'BLOCK : Install package'
-  include_tasks: 'blocks/update_package.yml'
-  when:
-    - delivered_package_path is not none
-    - inventory_hostname in single_instances_for_each_machine
+- when: delivered_package_path is not none
   tags: cartridge-instances
+  block:
+    - name: 'BLOCK : Install package'
+      include_tasks: 'blocks/update_package.yml'
+      when:
+        - inventory_hostname in single_instances_for_each_machine
+
+    - name: 'Check if instance restart is required to use new package'
+      cartridge_set_needs_restart:
+        instance_info: '{{ instance_info }}'
+        check_package_updated: true
+      when:
+        - not cartridge_multiversion
+        - not expelled
+        - restarted is none
+        - needs_restart is none

--- a/tasks/steps/update_package.yml
+++ b/tasks/steps/update_package.yml
@@ -16,4 +16,4 @@
         - not cartridge_multiversion
         - not expelled
         - restarted is none
-        - needs_restart is none
+        - not needs_restart

--- a/unit/test_set_needs_restart.py
+++ b/unit/test_set_needs_restart.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 
 from unit.helpers import set_box_cfg
 from unit.instance import Instance
-from library.cartridge_set_needs_restart import needs_restart
+from library.cartridge_set_needs_restart import set_needs_restart
 
 
 def call_needs_restart(
@@ -46,7 +46,7 @@ def call_needs_restart(
         for key in keys_to_remove:
             del params[key]
 
-    return needs_restart(params)
+    return set_needs_restart(params)
 
 
 class TestSetNeedsRestart(unittest.TestCase):
@@ -143,7 +143,7 @@ class TestSetNeedsRestart(unittest.TestCase):
         self.assertTrue('needs_restart' in res.facts and res.facts['needs_restart'] is True)
 
     def test_code_was_updated(self):
-        # code was updated yesterday, socket today - needs restart
+        # code was updated yesterday, socket today - restart isn't needed
         self.instance.set_path_m_time(self.instance.APP_CODE_PATH, self.instance.DATE_YESTERDAY)
         self.instance.set_path_m_time(self.console_sock, self.instance.DATE_TODAY)
 

--- a/unit/test_set_needs_restart.py
+++ b/unit/test_set_needs_restart.py
@@ -143,6 +143,16 @@ class TestSetNeedsRestart(unittest.TestCase):
         self.assertTrue('needs_restart' in res.facts and res.facts['needs_restart'] is True)
 
     def test_code_was_updated(self):
+        # code was updated yesterday, socket today - needs restart
+        self.instance.set_path_m_time(self.instance.APP_CODE_PATH, self.instance.DATE_YESTERDAY)
+        self.instance.set_path_m_time(self.console_sock, self.instance.DATE_TODAY)
+
+        res = call_needs_restart(console_sock=self.console_sock, check_package_updated=True)
+        self.assertFalse(res.failed, msg=res.msg)
+        self.assertFalse(res.changed)
+        self.assertIsNotNone(res.facts)
+        self.assertTrue('needs_restart' not in res.facts or res.facts['needs_restart'] is False)
+
         # code was updated today, socket yesterday - needs restart
         self.instance.set_path_m_time(self.instance.APP_CODE_PATH, self.instance.DATE_TODAY)
         self.instance.set_path_m_time(self.console_sock, self.instance.DATE_YESTERDAY)


### PR DESCRIPTION
Closes #189

In the current realization `cartridge_needs_restart` is placed in `configure_instance` step.
It checks that instance code is newer that socket (package was updated after instance start)
AND
that instance configuration changes require instance restart to be applied.

This approach is wrong: in case of [update_instance, restart_instance] scenario
we skip this check and instance wouldn't be restarted.

Now `needs_restart` variable is recalculated on each step that can require instance restart:
- `update_package`
- `update_instance`
- `configure_instance`