### PR TITLE
CI: Stop Mono server before tests

### DIFF
--- a/.github/workflows/molecule-check.yml
+++ b/.github/workflows/molecule-check.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -72,6 +76,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
       - name: Setup python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Mono server starts unexpectedly on GitHub Actions.
It uses 8084 port that is needed for tests.
Since this patch Mono process is killed before running tests.