### PR TITLE
Allow to run role without gathering facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 An Ansible role to easily deploy
 [Tarantool Cartridge](https://github.com/tarantool/cartridge) applications.
 
-This role can deploy and configure applications packed in RPM using
+This role can deploy and configure applications packed in RPM, DEB and TGZ using
 [`Cartridge CLI`](https://github.com/tarantool/cartridge-cli).
+
+Only `RedHat` and `Debian` OS families are supported.
 
 See the [getting started guide](/examples/getting-started-app/README.md)
 to learn how to set up topology using this role.
@@ -58,6 +60,7 @@ To deploy an application and set up this topology:
   become: true
   become_user: root
   any_errors_fatal: true
+  gather_facts: false
   tasks:
   - name: Import Tarantool Cartridge role
     import_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,3 +5,4 @@
     - role: ansible-cartridge
   become: true
   become_user: root
+  gather_facts: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,5 @@
 ---
 
-- name: 'Forced gathering facts'
-  setup:
-  when: module_setup is not defined
-  tags:
-    - cartridge-instances
-    - cartridge-replicasets
-    - cartridge-config
-
 - import_tasks: 'validate.yml'
   tags:
     - cartridge-instances

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -11,4 +11,6 @@
 - name: 'Validate OS Family'
   fail:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
-  when: ansible_os_family not in ["RedHat", "Debian"]
+  when:
+    - ansible_os_family is defined
+    - ansible_os_family not in ["RedHat", "Debian"]

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -51,7 +51,6 @@ class TestTags(unittest.TestCase):
     def test_without_tags(self):
         names = self.get_tasks_by_tags({})
         self.assertEqual(names, [
-            'Forced gathering facts',
             'Validate config',
             'Validate OS Family',
             "Set 'remote_user' for delegated tasks",
@@ -65,7 +64,6 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_instances(self):
         names = self.get_tasks_by_tags({'cartridge-instances'})
         self.assertEqual(names, [
-            'Forced gathering facts',
             'Validate config',
             'Validate OS Family',
             "Set 'remote_user' for delegated tasks",
@@ -79,7 +77,6 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_replicasets(self):
         names = self.get_tasks_by_tags({'cartridge-replicasets'})
         self.assertEqual(names, [
-            'Forced gathering facts',
             'Validate config',
             'Validate OS Family',
             "Set 'remote_user' for delegated tasks",
@@ -93,7 +90,6 @@ class TestTags(unittest.TestCase):
     def test_tag_cartridge_config(self):
         names = self.get_tasks_by_tags({'cartridge-config'})
         self.assertEqual(names, [
-            'Forced gathering facts',
             'Validate config',
             'Validate OS Family',
             "Set 'remote_user' for delegated tasks",


### PR DESCRIPTION
* Disable gathering facts in molecule test playbook.
* Remove task that checks OS (it used ansible_os_family fact).
* Add gather_facts: no in example playbook in README.

Closes #226 