### PR TITLE
[2pt] Add some default scenarios and availability to define custom scenarios

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,21 +34,44 @@ cartridge_app_group: tarantool
 
 cartridge_custom_steps: []
 cartridge_custom_steps_dir: null
-cartridge_scenario:
-  - deliver_package
-  - update_package
-  - update_instance
-  - configure_instance
-  - restart_instance
-  - wait_instance_started
-  - connect_to_membership
-  - edit_topology
-  - cleanup_expelled
-  - configure_auth
-  - configure_app_config
-  - bootstrap_vshard
-  - configure_failover
-  - cleanup
+cartridge_scenario: null
+
+cartridge_scenario_name: 'default'
+cartridge_custom_scenarios: {}
+cartridge_role_scenarios:
+  default:
+    - deliver_package
+    - update_package
+    - update_instance
+    - configure_instance
+    - restart_instance
+    - wait_instance_started
+    - connect_to_membership
+    - edit_topology
+    - cleanup_expelled
+    - configure_auth
+    - configure_app_config
+    - bootstrap_vshard
+    - configure_failover
+  configure_instances:
+    - deliver_package
+    - update_package
+    - update_instance
+    - configure_instance
+    - restart_instance
+    - wait_instance_started
+    - cleanup
+  configure_topology:
+    - connect_to_membership
+    - edit_topology
+    - cleanup_expelled
+    - cleanup
+  configure_app:
+    - configure_auth
+    - configure_app_config
+    - bootstrap_vshard
+    - configure_failover
+    - cleanup
 
 cartridge_configure_systemd_unit_files: true
 cartridge_systemd_dir: /etc/systemd/system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,12 @@
     - cartridge-replicasets
     - cartridge-config
 
+- import_tasks: 'prepare_scenario.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
 - name: 'Include steps by scenario'
   include_tasks: "{{ item.path }}"
   loop_control:

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -37,13 +37,3 @@
   run_once: true
   delegate_to: localhost
   become: false
-
-- name: 'Collect scenario steps'
-  cartridge_set_scenario_steps:
-    scenario: '{{ cartridge_scenario }}'
-    role_path: '{{ role_path }}'
-    custom_steps_dir: '{{ cartridge_custom_steps_dir }}'
-    custom_steps: '{{ cartridge_custom_steps }}'
-  run_once: true
-  delegate_to: localhost
-  become: false

--- a/tasks/prepare_scenario.yml
+++ b/tasks/prepare_scenario.yml
@@ -1,0 +1,29 @@
+---
+
+- run_once: true
+  delegate_to: localhost
+  become: false
+  when: cartridge_scenario is none
+  block:
+    - name: 'Collect scenarios'
+      set_fact:
+        cartridge_scenarios: "{{ cartridge_role_scenarios | combine(cartridge_custom_scenarios) }}"
+
+    - name: 'Check scenario name'
+      fail:
+        msg: "Unknown scenario name '{{ cartridge_scenario_name }}'"
+      when: cartridge_scenario_name not in cartridge_scenarios
+
+    - name: 'Collect names of scenario steps'
+      set_fact:
+        cartridge_scenario: "{{ cartridge_scenarios[cartridge_scenario_name] }}"
+
+- name: 'Collect tasks for scenario steps'
+  cartridge_set_scenario_steps:
+    scenario: '{{ cartridge_scenario }}'
+    role_path: '{{ role_path }}'
+    custom_steps_dir: '{{ cartridge_custom_steps_dir }}'
+    custom_steps: '{{ cartridge_custom_steps }}'
+  run_once: true
+  delegate_to: localhost
+  become: false

--- a/unit/test_tags.py
+++ b/unit/test_tags.py
@@ -57,7 +57,10 @@ class TestTags(unittest.TestCase):
             'Collect instance info',
             'Select one instance for each physical machine',
             'Select one not expelled instance',
-            'Collect scenario steps',
+            'Collect scenarios',
+            'Check scenario name',
+            'Collect names of scenario steps',
+            'Collect tasks for scenario steps',
             'Include steps by scenario',
         ])
 
@@ -70,7 +73,10 @@ class TestTags(unittest.TestCase):
             'Collect instance info',
             'Select one instance for each physical machine',
             'Select one not expelled instance',
-            'Collect scenario steps',
+            'Collect scenarios',
+            'Check scenario name',
+            'Collect names of scenario steps',
+            'Collect tasks for scenario steps',
             'Include steps by scenario',
         ])
 
@@ -83,7 +89,10 @@ class TestTags(unittest.TestCase):
             'Collect instance info',
             'Select one instance for each physical machine',
             'Select one not expelled instance',
-            'Collect scenario steps',
+            'Collect scenarios',
+            'Check scenario name',
+            'Collect names of scenario steps',
+            'Collect tasks for scenario steps',
             'Include steps by scenario',
         ])
 
@@ -96,7 +105,10 @@ class TestTags(unittest.TestCase):
             'Collect instance info',
             'Select one instance for each physical machine',
             'Select one not expelled instance',
-            'Collect scenario steps',
+            'Collect scenarios',
+            'Check scenario name',
+            'Collect names of scenario steps',
+            'Collect tasks for scenario steps',
             'Include steps by scenario',
         ])
 


### PR DESCRIPTION
Closes #217

Before scenarios were added, tags were used to partially run of role.
Now, with the scenarios added, you can decide for yourself which steps you want to start.
But sometimes new steps can be added to the default script.
If a step is added to an existing logical group of steps
(for example, a new step for configuring an application),
then those users who use their scenarios (for example, for configuring an application)
will not have this step and they will have to add this step manually.

Let's make some default scripts (for example, "package update", "topology configuration", "application configuration").
And the user will be able to choose one of the supported scenarios.