### PR TITLE
Speed up 'Place default config' task

### DIFF
--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -34,7 +34,9 @@
         owner: '{{ cartridge_app_user }}'
         group: '{{ cartridge_app_group }}'
         mode: '644'
-      when: not stateboard
+      when:
+        - not stateboard
+        - inventory_hostname in single_instances_for_each_machine
 
     - name: 'Place instance config'
       copy:


### PR DESCRIPTION
Closes #229

`Place default config` task put config unique for each machine,
but same for instances on same machine.
Before this path this task executed for all instances.

Now config placed once for each machine.
This sped up the task by `(number of instances) / (number of machines)` times.
On my cluster of 440 instances, this sped up the task 10x (from 70 seconds to 7).