### PR TITLE
Improve selecting control instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ to use the newest tag with new release
 
 - Role installation will be completely skipped
   if you specify a tag other than the tags for this role
+- Fixed selecting control instance that doesn't belong to cluster or isn't alive.
+  The following rules are currently used:
+  * Members are checked in lexicographic order by URIs
+  * Members not mentioned in hostvars aren't selected to be control
+  * Members with status not `alive` aren't selected to be control
 
 ### Added
 

--- a/library/cartridge_set_control_instance.py
+++ b/library/cartridge_set_control_instance.py
@@ -28,15 +28,23 @@ def get_control_instance(params):
         return require('membership').members()
     ''')
 
-    for uri, member in members.items():
+    for uri, member in sorted(members.items()):
         if 'payload' not in member or not member['payload']:
             return helpers.ModuleRes(failed=True, msg='Instance %s does not contain payload' % uri)
 
-        if member['payload'].get('uuid') is not None:
-            if member['payload'].get('alias') is None:
+        if member.get('status') != 'alive':
+            continue
+
+        member_payload = member['payload']
+        if member_payload.get('uuid') is not None:
+            if member_payload.get('alias') is None:
                 return helpers.ModuleRes(failed=True, msg='Instance %s payload does not contain alias' % uri)
 
-            control_instance_name = member['payload']['alias']
+            instance_name = member_payload['alias']
+            if instance_name not in hostvars:
+                continue
+
+            control_instance_name = instance_name
             break
 
     if control_instance_name is None:


### PR DESCRIPTION
* Membership instances are checked in lexicographic order by URIs
* Members not mentioned in hostvars aren't selected to be control
* Members with status not `alive` aren't selected to be control

Closes #161 