### PR TITLE
Provide cartridge upgrade compatibility

### DIFF
--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -125,6 +125,64 @@ jobs:
       - name: Molecule tests
         run: molecule test -s tasks_from
 
+  molecule-tests-ce-update-cartridge:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tarantool-version: ["2.5"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install molecule requirements
+        run: |
+          pip3 install --upgrade -r requirements.txt
+
+      - name: Cache test packages
+        id: cache-packages
+        uses: actions/cache@v2
+        with:
+          path: 'packages'
+          key: ce-${{ matrix.tarantool-version }}-${{ env.CARTRIDGE_CLI_VERSION }}-${{ hashFiles('./create-packages.sh') }}
+
+      - name: Install Tarantool
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool-version }}'
+
+      - name: Create test packages
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+
+          sudo apt-get -y install git gcc make cmake unzip
+          git config --global user.email "test@tarantool.io" \
+            && git config --global user.name "Tar Antool"
+
+          curl -L https://tarantool.io/release/${{ matrix.tarantool-version }}/installer.sh | sudo -E bash -s
+          sudo apt-get install -y cartridge-cli ${{ env.CARTRIDGE_CLI_VERSION }}
+
+          tarantool --version
+          cartridge version
+
+          ./create-packages.sh
+
+      - name: Molecule tests
+        run: molecule test -s update_cartridge
+
   molecule-tests-ee:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ to use the newest tag with new release
   after editing topology
 - availability to specify instance `memtx_dir`, `vinyl_dir` and `wal_dir` params
   by `cartridge_memtx_dir_parent`, `cartridge_vinyl_dir_parent`, `cartridge_wal_dir_parent` variables.
+- Control instance is selected considering two-phase commit version of instances.
+  The reason is that all operations that modify cluster-wide config should be performed via instance
+  that has lowest Cartridge version (in fact, only two-phase commit version matters).
 
 ### Changed
 

--- a/create-packages.sh
+++ b/create-packages.sh
@@ -15,9 +15,6 @@ if [ -d "${packages_dirname}" ]; then
     rm -rf ${packages_dirname}
 fi
 
-appname=myapp
-version=1.0.0-0
-
 pack_flags='--use-docker'
 
 if [[ $(tarantool -V) == "Tarantool Enterprise"* && -z "${TARANTOOL_SDK_PATH}" ]]; then
@@ -32,6 +29,12 @@ fi
 mkdir ${packages_dirname}
 pushd ${packages_dirname}
 
+# default test scenario
+appname=myapp
+version=1.0.0-0
+
+echo "Create packages for default test scenario"
+
 cartridge create --name ${appname}
 
 awk '{gsub(/cartridge.cfg\({/, "&\n    vshard_groups = { hot = { bucket_count = 20000 } },")}1' \
@@ -41,6 +44,32 @@ mv ${appname}/temp.lua ${appname}/init.lua
 cartridge pack tgz --version ${version} ${pack_flags} ${appname}
 cartridge pack rpm --version ${version} ${pack_flags} ${appname}
 cartridge pack deb --version ${version} ${pack_flags} ${appname}
+
+rm -rf ${appname}
+
+# update_cartridge test scenario
+appname=myapp
+
+echo "Create packages for update_cartridge test scenario"
+
+cartridge create --name ${appname}
+
+version=1  # myapp X version uses Cartridge 2.X.0 version
+for cartridge_version in '2.1.2' '2.2.0' '2.3.0' '2.4.0' '2.5.0'
+do
+    awk -v cartridge_dep_str="cartridge == ${cartridge_version}-1" \
+        '{gsub(/cartridge == [0-9.-]+/, cartridge_dep_str);}1' \
+        ${appname}/${appname}-scm-1.rockspec >${appname}/temp.rockspec
+    mv ${appname}/temp.rockspec ${appname}/${appname}-scm-1.rockspec
+
+    cartridge pack tgz \
+        --version ${version} \
+        --suffix with-c-${cartridge_version} \
+        ${pack_flags} \
+        ${appname}
+
+    ((version++))
+done
 
 rm -rf ${appname}
 

--- a/molecule/update_cartridge/Dockerfile.j2
+++ b/molecule/update_cartridge/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/update_cartridge/converge.yml
+++ b/molecule/update_cartridge/converge.yml
@@ -1,0 +1,91 @@
+---
+- name: Bootstrap cluster with Cartridge 2.1.2 on all instances
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_enable_tarantool_repo: true
+    cartridge_configure_systemd_unit_files: true
+    cartridge_configure_tmpfiles: true
+    cartridge_install_tarantool_for_tgz: true
+    cartridge_package_path: ./packages/myapp-1.0.0-0-with-c-2.1.2.tar.gz
+
+- name: Update storage-with-c-2.2.0 to Cartridge 2.2.0
+  hosts: storage-with-c-2.2.0
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_tgz
+    cartridge_package_path: ./packages/myapp-2.0.0-0-with-c-2.2.0.tar.gz
+
+- name: Update storage-with-c-2.3.0 to Cartridge 2.3.0
+  hosts: storage-with-c-2.3.0
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_tgz
+    cartridge_package_path: ./packages/myapp-3.0.0-0-with-c-2.3.0.tar.gz
+
+- name: Update storage-with-c-2.4.0 to Cartridge 2.4.0
+  hosts: storage-with-c-2.4.0
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_tgz
+    cartridge_package_path: ./packages/myapp-4.0.0-0-with-c-2.4.0.tar.gz
+
+- name: Update storage-with-c-2.5.0 to Cartridge 2.5.0
+  hosts: storage-with-c-2.5.0
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_tgz
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+# This play affects two-phase commmit
+# We need to be sure that role selects such control instance
+# that two-phase commit doesn't fail for that
+- name: Configure application
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: configure_app
+    cartridge_app_config:
+      my-section:
+        body:
+          some-section: some-other-value
+    cartridge_failover_params:
+      mode: eventual
+    cartridge_auth:
+      enabled: true
+      cookie_max_age: 1000
+
+- name: Update all instances to Cartridge 2.5.0
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+    cartridge_scenario_name: update_tgz

--- a/molecule/update_cartridge/hosts.yml
+++ b/molecule/update_cartridge/hosts.yml
@@ -1,0 +1,108 @@
+---
+cluster:
+  vars:
+    # common connection opts
+    ansible_user: root
+    ansible_connection: docker
+    become: true
+    become_user: root
+
+    # common cartridge opts
+    cartridge_app_name: myapp
+    cartridge_cluster_cookie: secret-cookie
+
+    cartridge_enable_tarantool_repo: false
+    cartridge_configure_systemd_unit_files: false
+    cartridge_configure_tmpfiles: false
+    cartridge_install_tarantool_for_tgz: false
+
+    cartridge_bootstrap_vshard: true
+    cartridge_app_config:
+      my-section:
+        body:
+          some-section: some-value
+
+    cartridge_failover_params:
+      mode: disabled
+
+    cartridge_auth:
+      enabled: true
+      cookie_max_age: 500
+
+    cartridge_multiversion: true
+
+    cartridge_custom_scenarios:
+      bootstrap_cluster:
+        - deliver_package
+        - update_package
+        - update_instance
+        - configure_instance
+        - restart_instance
+        - wait_instance_started
+        - connect_to_membership
+        - edit_topology
+      update_tgz:
+        - deliver_package
+        - update_package
+        - update_instance
+        - restart_instance
+        - wait_instance_started
+
+  # instances
+  hosts:
+    # This test should check that we choose right control instance
+    # in case of different two-phase commit versions on instances.
+    # By default, instance with the URI that is first lexicographically
+    # is chosen. Here instance with newest Cartridge has lower URI
+    # to avoid passing this test accidentally.
+    storage-with-c-2.1.2:
+      config:
+        advertise_uri: 'vm1:3351'
+        http_port: 8081
+
+    storage-with-c-2.2.0:
+      config:
+        advertise_uri: 'vm1:3342'
+        http_port: 8082
+
+    storage-with-c-2.3.0:
+      config:
+        advertise_uri: 'vm1:3333'
+        http_port: 8083
+
+    storage-with-c-2.4.0:
+      config:
+        advertise_uri: 'vm1:3324'
+        http_port: 8084
+
+    storage-with-c-2.5.0:
+      config:
+        advertise_uri: 'vm1:3315'  # this URI is first lexicographically
+        http_port: 8085
+
+  children:
+    # group by hosts
+    machine_1:
+      vars:
+        ansible_host: vm1
+
+      hosts:
+        storage-with-c-2.1.2:
+        storage-with-c-2.2.0:
+        storage-with-c-2.3.0:
+        storage-with-c-2.4.0:
+        storage-with-c-2.5.0:
+
+    # group by replica sets
+    storage_replicaset:
+      hosts:
+        storage-with-c-2.1.2:
+        storage-with-c-2.2.0:
+        storage-with-c-2.3.0:
+        storage-with-c-2.4.0:
+        storage-with-c-2.5.0:
+      vars:
+        replicaset_alias: storage
+        roles:
+          - 'vshard-storage'
+          - 'vshard-router'

--- a/molecule/update_cartridge/molecule.yml
+++ b/molecule/update_cartridge/molecule.yml
@@ -1,0 +1,59 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: vm1
+    image: centos:7
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    published_ports:
+      - 8081-8090:8081-8090/tcp
+    networks:
+      - name: cartridge-network
+
+lint: |
+  set -xe
+  yamllint .
+  flake8 library molecule/update_cartridge/tests
+
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      hosts: hosts.yml
+
+verifier:
+  name: testinfra
+  options:
+    v: true
+
+scenario:
+  create_sequence:
+    - create
+  converge_sequence:
+    - create
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - converge
+    - verify
+    - destroy
+  check_sequence:
+    - destroy
+    - create
+    - converge
+    - check
+    - destroy

--- a/molecule/update_cartridge/tests/test_cartridge.py
+++ b/molecule/update_cartridge/tests/test_cartridge.py
@@ -1,0 +1,80 @@
+import os
+
+import testinfra.utils.ansible_runner
+import requests
+
+from ansible.inventory.manager import InventoryManager
+from ansible.vars.manager import VariableManager
+from ansible.parsing.dataloader import DataLoader
+
+ansible_runner = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+)
+testinfra_hosts = ansible_runner.get_hosts('all')
+
+APP_NAME = 'myapp'
+HOSTS_PATH = os.path.join('molecule', 'update_cartridge', 'hosts.yml')
+
+inventory = InventoryManager(loader=DataLoader(), sources=HOSTS_PATH)
+variable_manager = VariableManager(loader=DataLoader(), inventory=inventory)
+
+cluster_cookie = inventory.groups['cluster'].get_vars()['cartridge_cluster_cookie']
+
+__authorized_session = None
+__configured_instances = None
+
+
+def get_authorized_session(cluster_cookie):
+    global __authorized_session
+    if __authorized_session is None:
+        __authorized_session = requests.Session()
+        __authorized_session.auth = ('admin', cluster_cookie)
+
+    return __authorized_session
+
+
+def get_configured_instances():
+    global __configured_instances
+    if __configured_instances is None:
+        __configured_instances = {
+            inventory.hosts[i].get_vars()['inventory_hostname']: inventory.hosts[i].get_vars()
+            for i in inventory.hosts
+        }
+    return __configured_instances
+
+
+def get_any_instance_http_port(instances):
+    for _, instance_vars in instances.items():
+        return instance_vars['config']['http_port']
+    assert False
+
+
+def get_admin_api_url(instances):
+    admin_url = 'http://localhost:{}'.format(get_any_instance_http_port(instances))
+    admin_api_url = '{}/admin/api'.format(
+        admin_url
+    )
+
+    return admin_api_url
+
+
+def test_cluster_is_healthy():
+    configured_instances = get_configured_instances()
+
+    # Select one instance to be control
+    admin_api_url = get_admin_api_url(configured_instances)
+
+    # Get all started instances
+    query = '''
+        query {
+          replicasets {
+            status
+          }
+        }
+    '''
+    session = get_authorized_session(cluster_cookie)
+    response = session.post(admin_api_url, json={'query': query})
+    assert response.status_code == 200
+
+    replicasets = response.json()['data']['replicasets']
+    assert all([r['status'] == 'healthy' for r in replicasets])


### PR DESCRIPTION
Since this patch on selecting control instance two-phase commit
version of all candidates (instances that are already joined or all instances
that should be joined when bootstrapping from scratch) is checked and 
instance with the lowest version is selected.

There is one rule that allows to work with cluster that has instances 
with different versions of Tarantool: **all operations that modify 
clustar-wide config should be performed via instance that has lowest
Cartridge version**. In fact, only version of two-phase commit matters, 
e.g. Cartridge 2.5.0 has incompatible change of two-phase commit and
instance with new version can't correctly update config on instances 
that uses older versions. 

We can't simply get Cartridge versions that are
used by every instance since some projects use Cartridge scm-1.
Since https://github.com/tarantool/cartridge/pull/1327 `twophase.VERSION`
is available. For older Cartridge version we can simply check if 
`_G.__cartridge_upload_begin` exists. In this case twophase version is 2, 
otherwise - 1.

Closes #237 