### PR TITLE
Use cartridge 2.5.0 app in tests

### DIFF
--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  CARTRIDGE_CLI_VERSION: '2.6.0'
+  CARTRIDGE_CLI_VERSION: '2.7.1'
 
 jobs:
   molecule-tests-ce:
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk-version: ["2.6.1-0-gcfe0d1a55-r374"]
+        sdk-version: ["2.6.2-0-g34d504d7d-r388"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/create-packages.sh
+++ b/create-packages.sh
@@ -18,13 +18,14 @@ fi
 appname=myapp
 version=1.0.0-0
 
-pack_flags=''
-if [[ $(tarantool -V) == *"Target: Darwin"* ]]; then
-    pack_flags+=' --use-docker'
+pack_flags='--use-docker'
 
-    if [[ $(tarantool -V) == "Tarantool Enterprise"* && -z "${TARANTOOL_SDK_PATH}" ]]; then
+if [[ $(tarantool -V) == "Tarantool Enterprise"* && -z "${TARANTOOL_SDK_PATH}" ]]; then
+    if [[ $(tarantool -V) == *"Target: Darwin"* ]]; then
         echo "Set the path to Linux Tarantool SDK using the TARANTOOL_SDK_PATH environment variable!"
         exit 1
+    else
+        pack_flags+=' --sdk-local'
     fi
 fi
 


### PR DESCRIPTION
Updated Cartridge CLI to 2.7.1 in tests. It creates application with Cartridge 2.5.0.
Also create-package.sh is rewritten since applications with Cartridge 2.5.0 should
be packed in Docker (see https://github.com/tarantool/cartridge-cli/pull/503).