### PR TITLE
Fix prepare scenario

### DIFF
--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -291,7 +291,7 @@ List of facts:
   - `name` - instance name (Ansible host);
   - `console_sock` - path to control socket of instance;
 - `cartridge_scenarios` - finally dictionary with scenarios (combination of role and user scenarios);
-- `cartridge_scenario` - steps of selected scenario (if not previously defined);
+- `scenario_steps_names` - names of scenario steps;
 - `scenario_steps` - description of scenario steps. It's a dictionary with fields:
   - `name` - name of step;
   - `path` - path to YAML file of step.

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -290,9 +290,9 @@ List of facts:
 - `not_expelled_instance` - information about one not expelled instance. It's a dictionary with fields:
   - `name` - instance name (Ansible host);
   - `console_sock` - path to control socket of instance;
-- `cartridge_scenarios` - finally dictionary with scenarios (combination of role and user scenarios);
+- `scenarios` - finally dictionary with scenarios (combination of role and user scenarios). Is set only when `cartridge_scenario` isn't specified;
 - `scenario_steps_names` - names of scenario steps;
-- `scenario_steps` - description of scenario steps. It's a dictionary with fields:
+- `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
   - `name` - name of step;
   - `path` - path to YAML file of step.
 

--- a/library/cartridge_set_scenario_steps.py
+++ b/library/cartridge_set_scenario_steps.py
@@ -7,7 +7,7 @@ else:
     import module_utils.helpers as helpers
 
 argument_spec = {
-    'scenario': {'required': True, 'type': 'list'},
+    'scenario_steps_names': {'required': True, 'type': 'list'},
     'role_path': {'required': True, 'type': 'str'},
     'custom_steps_dir': {'required': True, 'type': 'str'},
     'custom_steps': {'required': True, 'type': 'list'},
@@ -54,7 +54,7 @@ def get_scenario_steps(params):
     }
 
     scenario_steps = []
-    for step_name in params['scenario']:
+    for step_name in params['scenario_steps_names']:
         if step_name not in steps_paths:
             return helpers.ModuleRes(failed=True, msg=f"Unknown step '{step_name}'")
 

--- a/tasks/prepare_scenario.yml
+++ b/tasks/prepare_scenario.yml
@@ -1,5 +1,15 @@
 ---
 
+# We should store scenario in separated variable to
+# avoid conflicts between plays.
+- name: 'Collect names of custom scenario steps'
+  set_fact:
+    scenario_steps_names: '{{ cartridge_scenario }}'
+  when: cartridge_scenario is not none
+  run_once: true
+  delegate_to: localhost
+  become: false
+
 - run_once: true
   delegate_to: localhost
   become: false
@@ -7,20 +17,20 @@
   block:
     - name: 'Collect scenarios'
       set_fact:
-        cartridge_scenarios: "{{ cartridge_role_scenarios | combine(cartridge_custom_scenarios) }}"
+        scenarios: "{{ cartridge_role_scenarios | combine(cartridge_custom_scenarios) }}"
 
     - name: 'Check scenario name'
       fail:
         msg: "Unknown scenario name '{{ cartridge_scenario_name }}'"
-      when: cartridge_scenario_name not in cartridge_scenarios
+      when: cartridge_scenario_name not in scenarios
 
     - name: 'Collect names of scenario steps'
       set_fact:
-        cartridge_scenario: "{{ cartridge_scenarios[cartridge_scenario_name] }}"
+        scenario_steps_names: "{{ scenarios[cartridge_scenario_name] }}"
 
 - name: 'Collect tasks for scenario steps'
   cartridge_set_scenario_steps:
-    scenario: '{{ cartridge_scenario }}'
+    scenario_steps_names: '{{ scenario_steps_names }}'
     role_path: '{{ role_path }}'
     custom_steps_dir: '{{ cartridge_custom_steps_dir }}'
     custom_steps: '{{ cartridge_custom_steps }}'

--- a/unit/test_set_scenario_steps.py
+++ b/unit/test_set_scenario_steps.py
@@ -36,9 +36,9 @@ class TestSetSteps(unittest.TestCase):
         os.listdir = test_listdir
 
     @staticmethod
-    def call_get_tasks_paths(scenario, role_path, custom_steps_dir=None, custom_steps=None):
+    def call_get_tasks_paths(steps_names, role_path, custom_steps_dir=None, custom_steps=None):
         return get_scenario_steps({
-            'scenario': scenario,
+            'scenario_steps_names': steps_names,
             'role_path': role_path,
             'custom_steps_dir': custom_steps_dir,
             'custom_steps': custom_steps,
@@ -46,7 +46,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_role_path(self):
         tasks = self.call_get_tasks_paths(
-            scenario=['task_1', 'task_2', 'task_3'],
+            steps_names=['task_1', 'task_2', 'task_3'],
             role_path=self.role_path,
         )
         self.assertEqual(tasks.facts['scenario_steps'], [
@@ -57,7 +57,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_custom_steps_dir(self):
         tasks = self.call_get_tasks_paths(
-            scenario=['task_1', 'task_2', 'task_3', 'task_4', 'task_5'],
+            steps_names=['task_1', 'task_2', 'task_3', 'task_4', 'task_5'],
             role_path=self.role_path,
             custom_steps_dir=self.custom_steps_dir,
         )
@@ -71,7 +71,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_custom_steps(self):
         tasks = self.call_get_tasks_paths(
-            scenario=['task_1', 'task_2', 'task_3', 'task_5', 'task_6'],
+            steps_names=['task_1', 'task_2', 'task_3', 'task_5', 'task_6'],
             role_path=self.role_path,
             custom_steps=[
                 {'name': 'task_3', 'file': '/custom_steps/task_3.yml'},
@@ -89,7 +89,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_all(self):
         tasks = self.call_get_tasks_paths(
-            scenario=['task_1', 'task_2', 'task_3', 'task_4', 'task_5', 'task_6'],
+            steps_names=['task_1', 'task_2', 'task_3', 'task_4', 'task_5', 'task_6'],
             role_path=self.role_path,
             custom_steps_dir=self.custom_steps_dir,
             custom_steps=[
@@ -109,7 +109,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_rewrite(self):
         tasks = self.call_get_tasks_paths(
-            scenario=['task_2'],
+            steps_names=['task_2'],
             role_path=self.role_path,
         )
         self.assertEqual(tasks.facts['scenario_steps'], [
@@ -117,7 +117,7 @@ class TestSetSteps(unittest.TestCase):
         ])
 
         tasks = self.call_get_tasks_paths(
-            scenario=['task_2'],
+            steps_names=['task_2'],
             role_path=self.role_path,
             custom_steps_dir=self.custom_steps_dir,
         )
@@ -126,7 +126,7 @@ class TestSetSteps(unittest.TestCase):
         ])
 
         tasks = self.call_get_tasks_paths(
-            scenario=['task_2'],
+            steps_names=['task_2'],
             role_path=self.role_path,
             custom_steps_dir=self.custom_steps_dir,
             custom_steps=[
@@ -139,7 +139,7 @@ class TestSetSteps(unittest.TestCase):
 
     def test_task_not_found(self):
         res = self.call_get_tasks_paths(
-            scenario=['unknown_task'],
+            steps_names=['unknown_task'],
             role_path=self.role_path,
         )
         self.assertEqual(res.msg, "Unknown step 'unknown_task'")


### PR DESCRIPTION
Before this patch cartridge_scenario variable was changed
on computing scenario by cartridge_scenario_name.
This variable was passed to next plays, so if cartridge_scenario
wasn't specified, the value computed before was used instead of
computing scenario by cartridge_scenario_name.