### PR TITLE
Support changing advertise URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ to use the newest tag with new release
 - Control instance is selected considering two-phase commit version of instances.
   The reason is that all operations that modify cluster-wide config should be performed via instance
   that has lowest Cartridge version (in fact, only two-phase commit version matters).
+- Availability to change advertise URIs of any instance
 
 ### Changed
 

--- a/doc/topology.md
+++ b/doc/topology.md
@@ -123,7 +123,15 @@ To solve the problem, you should set the `replication_connect_quorum` option to 
 To do it, you should add the option to `cartridge_defaults` or to `config` section of instances
 from the replicasets that include instances with new URIs.
 
-After changing replication connect quorum, you can run `edit_topology` step to change URIs.
+So, after changing advertise URIs and `replication_connect_quorum` options in configuration files,
+you should run `configure_instance` and `restart_instance` steps to apply changes
+(`replication_connect_quorum` can be changed without restarting,
+but to change advertise URI you should restart instance).
+
+After changing replication connect quorum and advertise URIs,
+you can run `edit_topology` step to change URIs in cluster-wide config.
+
+Now you can reset replication connect quorum to default value.
 
 Example of playbook for URIs changing:
 
@@ -137,9 +145,6 @@ Example of playbook for URIs changing:
         - configure_instance
         - restart_instance
         - wait_instance_started
-      edit_topology:
-        - connect_to_membership
-        - edit_topology
   tasks:
     - name: Set quorum to zero
       import_role:
@@ -150,11 +155,12 @@ Example of playbook for URIs changing:
           # don't forget to add other options from your cartridge_defaults variable
           replication_connect_quorum: 0
 
-    - name: Change URIs
+    - name: Update advertise URIs in cluster-wide config
       import_role:
         name: tarantool.cartridge
       vars:
-        cartridge_scenario_name: "edit_topology"
+        cartridge_scenario:
+          - edit_topology
 
     - name: Reset quorum to default value
       import_role:

--- a/doc/topology.md
+++ b/doc/topology.md
@@ -114,8 +114,8 @@ are removed on [`cleanup_expelled`](/doc/scenario.md#cleanup_expelled) step.
 ## Advertise URIs changing
 
 It is possible to change the advertise URIs of the servers. However, this should be done carefully.
-You can read about manually changing the URIs here:
-https://tarantool.io/en/doc/latest/book/cartridge/troubleshooting/#i-want-to-run-an-instance-with-a-new-advertise-uri
+You can read about manually changing the URIs in the [troubleshooting doc](
+https://tarantool.io/en/doc/latest/book/cartridge/troubleshooting/#i-want-to-run-an-instance-with-a-new-advertise-uri).
 
 The main problem that arises when changing URIs: after restart, the instance tries
 to connect to all its replicas and remains in the `ConnectingFullmesh` state until it succeeds.
@@ -135,19 +135,7 @@ you can run `edit_topology` step to change URIs in cluster-wide config.
 
 Now you can reset replication connect quorum to default value.
 
-For example, add a config update scenario to your `hosts.yml` file:
-
-```yaml
-all:
-  vars:
-    cartridge_custom_scenarios:
-      update_config:
-        - configure_instance
-        - restart_instance
-        - wait_instance_started
-```
-
-After that create a playbook like this to change the URI:
+For example, you can create a playbook like this to change the URI:
 
 ```yaml
 - name: Set quorum to zero
@@ -155,7 +143,10 @@ After that create a playbook like this to change the URI:
   become: true
   gather_facts: no
   vars:
-    cartridge_scenario_name: "update_config"
+    cartridge_scenario:
+      - configure_instance
+      - restart_instance
+      - wait_instance_started
     cartridge_defaults:
       # don't forget to add other options from your cartridge_defaults variable
       replication_connect_quorum: 0
@@ -177,7 +168,8 @@ After that create a playbook like this to change the URI:
   become: true
   gather_facts: no
   vars:
-    cartridge_scenario_name: "update_config"
+    cartridge_scenario:
+      - configure_instance
   roles:
     - tarantool.cartridge
 ```

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -353,12 +353,8 @@ def get_server_params(instance_name, instance_params, cluster_instances):
     if instance_params.get('expelled') is True:
         server_params['expelled'] = True
     else:
-        add_server_param_if_required(
-            server_params, instance_params, cluster_instance, 'zone'
-        )
-        add_server_param_if_required(
-            server_params, instance_params, cluster_instance, 'uri'
-        )
+        for param_name in ['zone', 'uri']:
+            add_server_param_if_required(server_params, instance_params, cluster_instance, param_name)
 
     if len(server_params) == 1:
         # there are only `uuid`, all instance parameters are the same as configured

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -156,8 +156,12 @@ def get_instances_to_configure(hostvars, play_hosts):
 
         if helpers.is_expelled(instance_vars):
             instance['expelled'] = True
-        elif 'zone' in instance_vars:
-            instance['zone'] = instance_vars['zone']
+        else:
+            if 'zone' in instance_vars:
+                instance['zone'] = instance_vars['zone']
+            if 'config' in instance_vars:
+                if 'advertise_uri' in instance_vars['config']:
+                    instance['uri'] = instance_vars['config']['advertise_uri']
 
         if instance:
             instances[instance_name] = instance
@@ -352,6 +356,9 @@ def get_server_params(instance_name, instance_params, cluster_instances):
         add_server_param_if_required(
             server_params, instance_params, cluster_instance, 'zone'
         )
+        add_server_param_if_required(
+            server_params, instance_params, cluster_instance, 'uri'
+        )
 
     if len(server_params) == 1:
         # there are only `uuid`, all instance parameters are the same as configured
@@ -474,7 +481,7 @@ def edit_topology(params):
     #   In this case failover_priority isn't changed since
     #   new instances hasn't UUIDs before join.
     # * Expel instances.
-    # * Configure instances that are alredy joined.
+    # * Configure instances that are already joined.
     #   New instances aren't configured here since they don't have
     #   UUIDs before join.
     topology_params, err = get_topology_params(
@@ -519,8 +526,7 @@ def edit_topology(params):
 
     # Configure failover_priority and instances that were joined on previous call:
     # * Edit failover_priority of replicasets if it's needed.
-    # * Configure instances that weren't configurent on first
-    #   `edit_topology` call.
+    # * Configure instances that weren't configured on first `edit_topology` call.
     topology_params, err = get_replicasets_failover_priority_and_instances_params(
         replicasets, cluster_replicasets, instances, cluster_instances
     )

--- a/unit/test_edit_topology_helpers.py
+++ b/unit/test_edit_topology_helpers.py
@@ -112,7 +112,7 @@ class TestGetInstancesToConfigure(unittest.TestCase):
                 'replicaset_alias': 'replicaset-1',
                 'expelled': True,
             },
-            'instance-expelled-zone': {  # expelled, with zone
+            'instance-expelled-zone': {  # expelled, with zone, but zone will be skipped
                 'replicaset_alias': 'replicaset-1',
                 'expelled': True,
                 'zone': 'Hogwarts',

--- a/unit/test_edit_topology_helpers.py
+++ b/unit/test_edit_topology_helpers.py
@@ -1,8 +1,8 @@
 import unittest
 
 from library.cartridge_edit_topology import get_configured_replicasets
-from library.cartridge_edit_topology import get_replicaset_params
 from library.cartridge_edit_topology import get_instances_to_configure
+from library.cartridge_edit_topology import get_replicaset_params
 from library.cartridge_edit_topology import get_server_params
 
 
@@ -106,7 +106,7 @@ class TestGetConfiguredReplicasets(unittest.TestCase):
 
 
 class TestGetInstancesToConfigure(unittest.TestCase):
-    def get_instances_to_configure(self):
+    def test_get_instances_to_configure(self):
         hostvars = {
             'instance-expelled': {  # expelled
                 'replicaset_alias': 'replicaset-1',
@@ -127,6 +127,11 @@ class TestGetInstancesToConfigure(unittest.TestCase):
             'instance-2': {
                 'replicaset_alias': 'replicaset-1',
             },
+            'instance-3': {
+                'config': {
+                    'advertise_uri': '10.0.0.103:3301'
+                },
+            },
             'instance-stateboard': {  # stateboard
                 'expelled': True,
                 'stateboard': True,
@@ -140,8 +145,9 @@ class TestGetInstancesToConfigure(unittest.TestCase):
         instances = get_instances_to_configure(hostvars, play_hosts)
         self.assertEqual(instances, {
             'instance-expelled': {'expelled': True},
-            'instance-expelled-zone': {'expelled': True, 'zone': 'Hogwarts'},
+            'instance-expelled-zone': {'expelled': True},
             'instance-zone': {'zone': 'Narnia'},
+            'instance-3': {'uri': '10.0.0.103:3301'},
         })
 
         # not found instances to configure


### PR DESCRIPTION
Closes #208

Before this patch it was impossible to change advertise URI of any instance.

Now, you can do it by changing `advertise_uri` in `config` section.
Also you should set `replication_connect_quorum` to zero before changing URIs.