### PR TITLE
Fix error on configuring auth without users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to use the newest tag with new release
   * Members not mentioned in hostvars aren't selected to be control
   * Members with status not `alive` aren't selected to be control
 - Fixed setting `needs_restart` when configuration files don't exist
+- Fixed error on configuring auth without users specified
 
 ### Added
 

--- a/library/cartridge_configure_auth.py
+++ b/library/cartridge_configure_auth.py
@@ -167,7 +167,8 @@ def manage_auth(params):
 
     # Manage auth params
     common_auth_params = auth_params.copy()
-    del common_auth_params['users']
+    if 'users' in common_auth_params:
+        del common_auth_params['users']
 
     current_auth_params = get_cluster_auth_params(control_console)
 

--- a/unit/test_configure_auth.py
+++ b/unit/test_configure_auth.py
@@ -13,14 +13,18 @@ def remove_trailing_nones(specified_list):
 
 def call_manage_auth(console_sock, enabled=None, cookie_max_age=None,
                      cookie_renew_age=None, users=None):
+    auth = {}
+    if enabled is not None:
+        auth['enabled'] = enabled
+    if cookie_max_age is not None:
+        auth['cookie_max_age'] = cookie_max_age
+    if cookie_renew_age is not None:
+        auth['cookie_renew_age'] = cookie_renew_age
+    if users is not None:
+        auth['users'] = users
     return manage_auth({
         'console_sock': console_sock,
-        'auth': {
-            'enabled': enabled,
-            'cookie_max_age': cookie_max_age,
-            'cookie_renew_age': cookie_renew_age,
-            'users': users,
-        }
+        'auth': auth,
     })
 
 


### PR DESCRIPTION
Before this patch `configure_auth` step failed if user didn't specify `auth.users`.