### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,10 @@
 An Ansible role to easily deploy
 [Tarantool Cartridge](https://github.com/tarantool/cartridge) applications.
 
-This role can deploy and configure applications packed in RPM, DEB and TGZ using
+This role can deploy and configure applications packed in `RPM`, `DEB` and `TGZ` using
 [`Cartridge CLI`](https://github.com/tarantool/cartridge-cli).
 
 Only `RedHat` and `Debian` OS families are supported.
-
-See the [getting started guide](/examples/getting-started-app/README.md)
-to learn how to set up topology using this role.
 
 ## Table of contents
 
@@ -35,7 +32,7 @@ First, you need to install this role using `ansible-galaxy`:
 $ ansible-galaxy install tarantool.cartridge,1.8.0
 ```
 
-## Quck start
+## Quick start
 
 You can start two virtual machines using example
 [Vagrantfile](/doc/files/Vagrantfile).
@@ -98,7 +95,7 @@ all:
           - storage-1-replica
 ```
 
-Write simple playbook that imports role:
+Write a simple playbook that imports role:
 
 ```yaml
 # playbook.yml
@@ -145,7 +142,7 @@ ansible-playbook -i hosts.yml playbook.yml --limit instance_1,instance_2
 ```
 
 You can also simply edit some replicaset.
-To do this define `cartridge_scenario` variable like this:
+To do this, define `cartridge_scenario` variable like this:
 
 ```yaml
 cartridge_scenario:
@@ -174,4 +171,4 @@ For more details about using scenario, see [scenario documentation](doc/scenario
 * [Configuring auth](/doc/auth.md)
 * [Configuring failover](/doc/failover.md)
 * [Configuring stateboard](/doc/stateboard.md)
-* [Application config](./app_config.md)
+* [Application config](/doc/app_config.md)

--- a/doc/failover.md
+++ b/doc/failover.md
@@ -1,6 +1,5 @@
 # Configuring failover
 
-
 [`cartridge_failover_params`](/doc/variables.md#cluster-configuration)
 is used to specify failover parameters:
 

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -9,21 +9,22 @@ Instances are identified by aliases that are set equal to Ansible host names.
 
 Instance is restarted only if it's required to apply changes
 (instance configuration was changed or package was updated).
-But instance restart can be forced or disabled by `restarted` flag.
+However, instance restart can be forced or disabled by `restarted` flag.
 If this flag isn't set, role decides if instance should be restarted.
 
 ## Expelling instances
 
-To expel instance from topology specify `expelled: true`.
-See [topology doc](/doc/topology.md#expelling-instances) for deatils
+To expel an instance from topology specify `expelled: true`.
+See [topology doc](/doc/topology.md#expelling-instances) for details
 
 ## Instance config
 
 Instance can be configured using the [`config`](/doc/variables.md#instances-configuration) variable.
-Fro specifying parameters that are common for all instances, use
-[`cartridge_defaults`](/doc/variables.md#instances-configuration) varieble.
-This variables describe instance parameters that would be passed to cartridge configuration.
-It can contain [cluster-specific](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_api/modules/cartridge.argparse/#cluster-opts) parameters or some application-specific parameters (can be parsed in application using the [`cartridge.argparse`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_api/modules/cartridge.argparse) module).
+For specifying parameters that are common for all instances, use
+[`cartridge_defaults`](/doc/variables.md#instances-configuration) variable.
+These variables describe instance parameters that would be passed to cartridge configuration.
+It can contain [cluster-specific](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_api/modules/cartridge.argparse/#cluster-opts)
+or some application-specific parameters (can be parsed in application using the [`cartridge.argparse`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_api/modules/cartridge.argparse) module).
 
 ### Required parameters
 

--- a/doc/multiversion.md
+++ b/doc/multiversion.md
@@ -2,20 +2,20 @@
 
 The default versioning approach for Tarantool Cartridge applications is quite simple:
 
-* only one version of application is installed on machine;
+* only one version of application is installed on a machine;
 * updating instance happens on instance restart.
 
 Such approach doesn't protect from accidental updating instance, that can lead to
-errors (for example, if router starts to use new schema earlier than storages).
+errors (for example, if router starts to use a new schema earlier than storages).
 The solution is using multiversion approach (currently it's fully supported only
 for [TGZ](/doc/tgz.md) packages).
 
 Multiversion approach:
 
-* several versions of application can be installed on machine;
+* several versions of application can be installed on a machine;
 * each instance uses fixed version - it is achieved by using symbolic links;
 * updating instance consists of:
-  * moving it's link to a newest version of application
+  * moving its link to the newest version of application
     (see [`update_instance` step](/doc/scenario.md#update_instance));
   * instance restart.
 
@@ -29,7 +29,7 @@ Symbolic links for instances are placed in
 `{{ cartridge_app_instances_dir }}/{{ cartridge_app_name }}.{{ instance-name }}`.
 
 For example, we deploy `myapp-1.0.0-0.tgz` and start `instance-1`, `instance-2`
-and statebord.
+and stateboard.
 
 * Application files are placed in `{{ cartridge_app_install_dir }}/myapp-1.0.0-0`:
   ```bash
@@ -46,7 +46,7 @@ and statebord.
     myapp-stateboard -> {{ cartridge_app_install_dir }}/myapp-1.0.0-0
   ```
 
-## Rotaing distributions
+## Rotating distributions
 
 Each new version is added to `cartridge_app_install_dir` and sometimes old version
 become redundant.
@@ -70,8 +70,8 @@ Let's imagine that we already have `myapp-1.0.0-0` installed:
   myapp.core-1 -> {{ cartridge_app_install_dir }}/myapp-1.0.0-0
 ```
 
-And now the day has come and we want to deploy next version: `myapp-2.0.0-0.tgz`.
-Let's write a playbook that installs new version and updates storages.
+Now the day has come, and we want to deploy next version: `myapp-2.0.0-0.tgz`.
+Let's write a playbook that installs a new version and updates storages.
 
 **Note**: it may be useful to specify hosts pattern, e.g. `hosts: *storage*`.
 

--- a/doc/package.md
+++ b/doc/package.md
@@ -1,10 +1,10 @@
 # Package
 
-This role can work with RPM, DEB and [TGZ](/doc/tgz.md) packages created by
+This role can work with `RPM`, `DEB` and [`TGZ`](/doc/tgz.md) packages created by
 Tarantool Cartridge CLI.
 
 You can specify a path to the application package `cartridge_package_path`.
-Note, that package path shuold be the same for instances on one machine.
+Note, that package path should be the same for instances on one machine.
 
 This role does not allow package downgrades because this may drive the cluster
 inoperative.

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -92,7 +92,7 @@ In addition to the default scenario (see [steps](#steps)), there are also the fo
   - [cleanup](#cleanup)
 
 To add new scenarios or replace the role scenarios with your own, you should use `cartridge_custom_scenarios` option
-(see [example](#add-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)).
+(see [example](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)).
 
 ## Examples
 
@@ -139,7 +139,7 @@ Let's take a look on it's [API](#deliver_package). It requires two variables:
 - `single_instances_for_each_machine` that allows us to run this task once per each machine.
 
 As a result of this module we should set `delivered_package_path` variable
-(a path of package on remote machine).
+(a path of package on a remote machine).
 
 Now, choose a directory where our custom steps are placed, for example `./custom_steps`.
 
@@ -183,7 +183,7 @@ Now there is a big problem on deploying huge clusters - [`connect_to_membership`
 long. Using scenario, we can solve this problem until it isn't solved in `cartridge`.
 
 In fact `connect_to_membership` is used in [`set_control_instance` step](#set_control_instance) to find some instance
-that is already in cluster. This instance should be used for joining other instances (otherwise two different clusters
+that is already in a cluster. This instance should be used for joining other instances (otherwise two different clusters
 are created). This instance is called `control_instance` and is used for editing topology and configuring cluster (auth,
 config and so on). Generally, `connect_to_membership` step can be skipped if you definitely know some instance that is
 already joined to cluster. The solution is to set `cartridge_control_instance` fact manually and
@@ -204,7 +204,7 @@ remove `connect_to_membership` step from scenario:
     - tarantool.cartridge
 ```
 
-### Add custom scenario to gradually update to a new version of TGZ
+### Add a custom scenario to gradually update to a new version of TGZ
 
 If you are using multiversion, then most likely you are upgrading to the new version of the package gradually:
 first storages, then routers, etc. To do this, the same scenario to update the package version is used several times.
@@ -343,7 +343,7 @@ Input facts (set by config):
 - `cartridge_conf_dir` - path to directory of instances application configs;
 - `cartridge_app_install_dir` - path to directory with application distributions;
 - `cartridge_app_instances_dir` - path to directory with instances links to
-  distributions (see [multiversion approach doc](/doc/multiversion.doc)).
+  distributions (see [multiversion approach doc](/doc/multiversion.md)).
 
 Output facts:
 
@@ -411,13 +411,13 @@ Input facts (set by role):
 
 Input facts (set by config):
 
-- `config` - instance configuration ([more details here](/README.md#instances));
+- `config` - instance configuration ([more details here](/doc/instances.md));
 - `restarted` - if instance should be restarted or not (user forced decision);
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_app_name` - application name;
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
-- `cartridge_defaults` - default configuration parameters values for instancesж
+- `cartridge_defaults` - default configuration parameters values for instances;
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
 
@@ -440,7 +440,7 @@ Input facts (set by config):
 
 ### wait_instance_started
 
-Wait until instance is fully started.
+Wait until an instance is fully started.
 
 Input facts (set by role):
 
@@ -455,7 +455,7 @@ Input facts (set by config):
 
 ### connect_to_membership
 
-Connect instance to membership.
+Connect an instance to membership.
 
 Input facts (set by role):
 
@@ -466,7 +466,7 @@ Input facts (set by config):
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_app_name` - application name;
-- `config` - instance configuration ([more details here](/README.md#instances)).
+- `config` - instance configuration ([more details here](/doc/instances.md)).
 
 ### set_control_instance
 
@@ -616,7 +616,7 @@ Input facts (set by config):
 
 Rotate application distributions.
 
-When [multiversion approcah](/doc/multiversion.md) is used, each new application
+When [multiversion approach](/doc/multiversion.md) is used, each new application
 version is added to `cartridge_app_install_dir`.
 This step removes redundant distribution.
 

--- a/doc/tgz.md
+++ b/doc/tgz.md
@@ -5,8 +5,8 @@ It requires additional actions such as configuring systemd units.
 All these actions can be disabled.
 
 Using TGZ package allows to use [multiversion approach](/doc/multiversion.md)
-that can be helpful to perform rolling update correclty.
-This approach uses links to specify version of application that is used by each
+that can be helpful to perform rolling update correctly.
+This approach uses links to specify a version of application that is used by each
 instance.
 
 All TGZ-specific variables are described [here](/doc/variables.md#TGZ-specific-configuration)
@@ -20,13 +20,13 @@ By default, it is unpacked to `cartridge_app_install_dir` directory according to
 ### Installing Tarantool
 
 If package doesn't contain `tarantool` binary, opensource Tarantool is installed.
-It's version is described in `VERSION` file that is created by Cartridge CLI
+Its version is described in `VERSION` file that is created by Cartridge CLI
 on application packing.
 
 Use `cartridge_install_tarantool_for_tgz` flag to disable installation
 of Tarantool.
 
-### Application user ang group
+### Application user and group
 
 Application user that owns all application files and instances processes
 can be configured using `cartridge_app_user` and `cartridge_app_group` variables.
@@ -44,7 +44,7 @@ To configure them use
 * `cartridge_conf_dir` - path to instances configuration;
 * `cartridge_app_install_dir` - directory where application distributions are placed;
 * `cartridge_app_instances_dir` directory where instances distributions are placed in
-  case of [multiversion approcah](/doc/multiversion.md).
+  case of [multiversion approach](/doc/multiversion.md).
 
 ### `systemd` unit files
 

--- a/doc/topology.md
+++ b/doc/topology.md
@@ -117,7 +117,7 @@ It is possible to change the advertise URIs of the servers. However, this should
 You can read about manually changing the URIs in the [troubleshooting doc](
 https://tarantool.io/en/doc/latest/book/cartridge/troubleshooting/#i-want-to-run-an-instance-with-a-new-advertise-uri).
 
-The main problem that arises when changing URIs: after restart, the instance tries
+The main problem that arises when changing URIs: after a restart, the instance tries
 to connect to all its replicas and remains in the `ConnectingFullmesh` state until it succeeds.
 If it can’t (due to replica URI unavailability or for any other reason) – it’s stuck forever.
 

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -1,9 +1,5 @@
 # Role variables
 
-
-Configuration format is described in detail in the
-[configuration format](#configuration-format) section.
-
 Role variables are used to configure started instances, cluster topology,
 vshard bootstrapping, and failover.
 
@@ -23,11 +19,11 @@ vshard bootstrapping, and failover.
 For more details see [scenario documentation](/doc/scenario.md).
 
 * `cartridge_scenario` (`list-of-strings`): list of steps to be launched
-  (see [change scenario](#using-scenario) for more details)
+  (see [change scenario](/README.md#using-scenario) for more details)
 * `cartridge_custom_steps_dir` (`string`, default: `null`): path to directory
-  containing YAML files of custom steps (see [change scenario](#using-scenario) for more details)
+  containing YAML files of custom steps (see [change scenario](/README.md#using-scenario) for more details)
 * `cartridge_custom_steps` (`list-of-dicts`, default: `[]`): list of custom steps
-  (see [change scenario](#using-scenario) for more details)
+  (see [change scenario](/README.md#using-scenario) for more details)
 
 ## Application package configuration
 
@@ -36,7 +32,7 @@ For more details see [scenario documentation](/doc/scenario.md).
   indicates if the Tarantool repository should be enabled (for packages with
   open-source Tarantool dependency);
 
-## TGZ-specific configuration:
+## TGZ specific configuration
 
 * `cartridge_multiversion` (`boolean`, default: `false`): use [multiversion
   approach](/doc/multiversion.md) for TGZ package.
@@ -61,7 +57,7 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `cartridge_app_install_dir` (`string`, default: `/usr/share/tarantool`): directory
   where application distributions are placed;
 * `cartridge_app_instances_dir` (`string`, default: `/usr/share/tarantool`): directory
-  where instances distributions are placed in case of multiversion approcah.
+  where instances distributions are placed in case of multiversion approach.
 
 * `cartridge_configure_systemd_unit_files` (`boolean`, default: `true`): flag indicates that
   systemd unit files should be configured;
@@ -71,11 +67,11 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `cartridge_configure_tmpfiles` (`boolean`, default: `true`): flag indicates that tmpfiles
   config should be configured for application run dir;
 * `cartridge_tmpfiles_dir` (`string`, default: `/usr/lib/tmpfiles.d/`): a directory where
-  tmpfile sonfiguration should be placed;
+  tmpfile configuration should be placed;
 
-## Instances configuration:
+## Instances configuration
 
-* `config` (`dict`, required): [instance configuration](#instances);
+* `config` (`dict`, required): [instance configuration](/doc/instances.md);
 * `zone` (`string`): instance zone (available since
   [Cartridge 2.4.0](https://github.com/tarantool/cartridge/releases/tag/2.4.0));
 * `cartridge_defaults` (`dict`, default: `{}`): default configuration
@@ -83,11 +79,11 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `restarted` (`boolean`): flag indicates if instance should be
   restarted or not (if this flag isn't specified, instance will be restarted if
   it's needed to apply configuration changes);
-* `expelled` (`boolean`, default: `false`): boolean flag that indicates if instance must be expelled from topology;
-* `stateboard` (`boolean`, default: `false`): boolean flag that indicates
-   that the instance is a [stateboard](#stateboard-instance);
+* `expelled` (`boolean`, default: `false`): a boolean flag that indicates if instance must be expelled from topology;
+* `stateboard` (`boolean`, default: `false`): a boolean flag that indicates
+   that the instance is a [stateboard](/doc/stateboard.md);
 * `instance_start_timeout` (`number`, default: 60): time in seconds to wait for instance to be started;
-* `cartridge_wait_buckets_discovery` (`boolean`, default: `true`): boolean
+* `cartridge_wait_buckets_discovery` (`boolean`, default: `true`): a boolean
   flag that indicates if routers should wait for buckets discovery after vshard bootstrap;
 * `instance_discover_buckets_timeout` (`number`, default: 60): time in seconds
   to wait for instance to discover buckets;
@@ -99,15 +95,15 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `roles` (`list-of-strings`, required if `replicaset_alias` specified): roles to be enabled on the replicaset;
 * `all_rw` (`boolean`): indicates that that all servers in the replicaset should be read-write;
 * `weight` (`number`): vshard replicaset weight (matters only if `vshard-storage` role is enabled);
-* `edit_topology_timeout` (`number`, default: `60`): time in seconds to wait until cluster become
+* `edit_topology_timeout` (`number`, default: `60`): time in seconds to wait until a cluster become
   healthy after editing topology;
 
 ## Cluster configuration
 
-* `cartridge_bootstrap_vshard` (`boolean`, default: `false`): boolean
+* `cartridge_bootstrap_vshard` (`boolean`, default: `false`): a boolean
   flag that indicates if vshard should be bootstrapped;
 * `cartridge_app_config` (`dict`): application config sections to patch;
-* `cartridge_auth`: (`dict`): [authorization configuration](#cartridge-authorization);
-* `cartridge_failover_params` (`dict`): [failover](#failover) parameters;
-* [DEPRECATED] `cartridge_failover` (`boolean`): boolean flag that
+* `cartridge_auth`: (`dict`): [authorization configuration](/doc/auth.md);
+* `cartridge_failover_params` (`dict`): [failover](/doc/failover.md) parameters;
+* [DEPRECATED] `cartridge_failover` (`boolean`): a boolean flag that
   indicates if eventual failover should be enabled or disabled;


### PR DESCRIPTION
Thank for patch #256.

Fixed all the errors in the documentation that the linter found.