### PR TITLE
Don't remove stateboard dir on `rotate_dists` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Fixed
+
+- Removing stateboard instance distribution directory on `rotate_dists` step
+
 ## [1.8.0] - 2021-03-23
 
 ### Fixed

--- a/library/cartridge_get_dist_dirs_to_remove.py
+++ b/library/cartridge_get_dist_dirs_to_remove.py
@@ -2,6 +2,7 @@
 
 import os
 import pkgutil
+import re
 
 if pkgutil.find_loader('ansible.module_utils.helpers'):
     import ansible.module_utils.helpers as helpers
@@ -20,13 +21,8 @@ def is_dist(filename, app_install_dir, app_name):
     if not os.path.isdir(os.path.join(app_install_dir, filename)):
         return False
 
-    if not filename.startswith('%s-' % app_name):
-        return False
-
-    if filename == helpers.get_instance_id(app_name, stateboard=True):
-        return False
-
-    return True
+    DIST_DIR_RGX = r'^%s-\d+\.\d+\.\d+-\d+(-\S+)?$' % app_name
+    return re.match(DIST_DIR_RGX, filename) is not None
 
 
 def get_dist_dirs_to_remove(params):

--- a/library/cartridge_get_dist_dirs_to_remove.py
+++ b/library/cartridge_get_dist_dirs_to_remove.py
@@ -23,6 +23,9 @@ def is_dist(filename, app_install_dir, app_name):
     if not filename.startswith('%s-' % app_name):
         return False
 
+    if filename == helpers.get_instance_id(app_name, stateboard=True):
+        return False
+
     return True
 
 

--- a/library/cartridge_get_dist_dirs_to_remove.py
+++ b/library/cartridge_get_dist_dirs_to_remove.py
@@ -21,8 +21,8 @@ def is_dist(filename, app_install_dir, app_name):
     if not os.path.isdir(os.path.join(app_install_dir, filename)):
         return False
 
-    DIST_DIR_RGX = r'^%s-\d+\.\d+\.\d+-\d+(-\S+)?$' % app_name
-    return re.match(DIST_DIR_RGX, filename) is not None
+    DIST_DIR_RGX = r'%s-\d+\.\d+\.\d+-\d+(-\S+)?' % app_name
+    return re.fullmatch(DIST_DIR_RGX, filename) is not None
 
 
 def get_dist_dirs_to_remove(params):

--- a/unit/test_get_dist_dirs_to_remove.py
+++ b/unit/test_get_dist_dirs_to_remove.py
@@ -38,6 +38,13 @@ class TestGetNeedsRestart(unittest.TestCase):
         # create app dist dir
         create_dir(os.path.join(self.app_install_dir, '%s-0.0.1-0' % APP_NAME))
 
+        # create stateboard dist dir - it shouldn't be removed
+        create_dir(os.path.join(self.app_install_dir, '%s-stateboard' % APP_NAME))
+
+        # create instances dist dirs - it shouldn't be removed
+        for instance_name in ['i-1', 'i-2', 'i-3']:
+            create_dir(os.path.join(self.app_install_dir, '%s.%s' % (APP_NAME, instance_name)))
+
         # create file with <app-name>-<version> name
         create_file(os.path.join(self.app_install_dir, '%s-0.1.0-0' % APP_NAME))
 

--- a/unit/test_get_dist_dirs_to_remove.py
+++ b/unit/test_get_dist_dirs_to_remove.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 from library.cartridge_get_dist_dirs_to_remove import get_dist_dirs_to_remove
+from module_utils.helpers import get_instance_id
 
 
 def call_get_dist_dirs_to_remove(app_name, app_install_dir, keep_num_latest_dists):
@@ -39,11 +40,11 @@ class TestGetNeedsRestart(unittest.TestCase):
         create_dir(os.path.join(self.app_install_dir, '%s-0.0.1-0' % APP_NAME))
 
         # create stateboard dist dir - it shouldn't be removed
-        create_dir(os.path.join(self.app_install_dir, '%s-stateboard' % APP_NAME))
+        create_dir(os.path.join(self.app_install_dir, get_instance_id(APP_NAME, stateboard=True)))
 
         # create instances dist dirs - it shouldn't be removed
         for instance_name in ['i-1', 'i-2', 'i-3']:
-            create_dir(os.path.join(self.app_install_dir, '%s.%s' % (APP_NAME, instance_name)))
+            create_dir(os.path.join(self.app_install_dir, get_instance_id(APP_NAME, instance_name)))
 
         # create file with <app-name>-<version> name
         create_file(os.path.join(self.app_install_dir, '%s-0.1.0-0' % APP_NAME))


### PR DESCRIPTION
Fix removing stateboard instance dist directory on rotate_dists step