### PR TITLE
Add `failover_promote` step

### DIFF
--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -37,6 +37,7 @@ def main(event_name, repo_owner, review_state, ref):
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
         ce_matrix.append(get_ce_params(molecule_scenario='update_cartridge'))
         ce_matrix.append(get_ce_params(molecule_scenario='check_facts'))
+        ce_matrix.append(get_ce_params(molecule_scenario='rolling_update'))
         ce_matrix.append(get_ce_params(tarantool_version='1.10'))
         ce_matrix.append(get_ce_params(ansible_version='2.8.0'))
         ce_matrix.append(get_ce_params(ansible_version='2.9.0'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Added
+
+- `failover_promote` step to promote replicasets leaders
+
 ## [1.8.3] - 2021-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ ansible-playbook -i hosts.yml playbook.yml --limit replicaset_1_group,replicaset
 ```
 
 Moreover, scenario allows you to describe custom steps for configuring cluster.
-For more details about using scenario, see [scenario documentation](doc/scenario.md).
+For more details about using scenario and available steps, see
+[scenario documentation](doc/scenario.md).
 
 ## Documentation
 
@@ -172,3 +173,4 @@ For more details about using scenario, see [scenario documentation](doc/scenario
 * [Configuring failover](/doc/failover.md)
 * [Configuring stateboard](/doc/stateboard.md)
 * [Application config](/doc/app_config.md)
+* [Rolling update](/doc/rolling_update.md)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,6 +112,7 @@ cartridge_app_config: null
 cartridge_auth: null
 cartridge_failover: null
 cartridge_failover_params: null
+cartridge_failover_promote_params: null
 
 # Internal role facts that can be set by the user
 

--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -24,7 +24,7 @@ consistent switchover.
 ## Rolling update: Plan
 
 Imagine that you have a cluster with `myapp-1.0.0` deployed.
-And now you want to update your application to `myapp-2.0.0`.
+Now you want to update your application to `myapp-2.0.0`.
 
 The plan is quite simple:
 
@@ -39,7 +39,7 @@ The plan is quite simple:
 
 ## Rolling update: Playbook for TGZ + Multiversion
 
-[Multiversion approach](/doc/multiversion.md) allows updatig application
+[Multiversion approach](/doc/multiversion.md) allows updating application
 version that each instance uses with
 [`update_instance` step](/doc/scenario.md#update_instance).
 
@@ -174,7 +174,7 @@ The example rolling update playbook:
 
 ## Rolling update: Playbook for RPM or DEB
 
-In case of RPM and DEB (or TGZ without [multiversion approach](/doc/multiversion.md)
+In case of RPM and DEB (or TGZ without [multiversion approach](/doc/multiversion.md))
 all instances use a common version of the application.
 Updating the instance version of the application is performed when the instance is restarted.
 

--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -1,0 +1,283 @@
+# Rolling update
+
+Here is described rolling update for an application that uses
+TGZ package with [multiversion approach](/doc/multiversion.md) or
+usual RPM/DEB packages.
+
+## Requirements
+
+* `tarantool.cartridge` >= `1.9.0`
+
+## Leaders promotion
+
+[`failover_promote`](/doc/scenario.md#failover_promote) step can be used
+for leaders promotion only if stateful failover is enabled.
+
+To specify leaders that should be promoted `failover_promote_params` variable
+should be used. It's a dictionary with fields:
+
+- `replicaset_leaders` (`dict`): describes the mapping between replica sets
+and leaders aliases;
+- `force_inconsistency` (`bool`): make promotion forcefully, don't wait for the
+consistent switchover.
+
+## Rolling update: Plan
+
+Imagine that you have a cluster with `myapp-1.0.0` deployed.
+And now you want to update your application to `myapp-2.0.0`.
+
+The plan is quite simple:
+
+* deliver and install a new package on machines
+* update stateboard instance
+* update replicas instances of storages replica sets
+* promote storages leaders to current replicas
+* update leaders instances of storages replica sets
+* promote storages leaders back
+* update routers replica sets
+* rotate distributions (if TGZ + Multiversion is used)
+
+## Rolling update: Playbook for TGZ + Multiversion
+
+[Multiversion approach](/doc/multiversion.md) allows updatig application
+version that each instance uses with
+[`update_instance` step](/doc/scenario.md#update_instance).
+
+Additionally, there is [`rotate_dists` step](/doc/scenario.md#rotate_dists) that
+removes redundant distributions.
+
+Updating and restarting instance scenario can be persisted in inventory
+to be used by name in all plays:
+
+```yaml
+# hosts.yml
+
+all:
+  vars:
+    ...
+    cartridge_custom_scenarios:
+      update_and_restart_instance:
+        - update_instance
+        - restart_instance
+        - wait_instance_started
+    ...
+```
+
+**Note** that [`update_instance` step](/doc/scenario.md#update_instance) requires
+`cartridge_package_path` variable to set instance application link to unpacked
+distribution.
+
+The example rolling update playbook:
+
+```yaml
+# playbook.yml
+
+- name: Deliver and install myapp 2.0.0
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - deliver_package
+      - update_package
+    cartridge_package_path: ./myapp-2.0.0.tar.gz
+
+- name: Update stateboard application version
+  hosts: "my-stateboard"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./myapp-2.0.0.tar.gz
+
+- name: Update storages replicas application version
+  hosts: "*storage*replica*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./myapp-2.0.0.tar.gz
+
+- name: Promote storages leaders to replicas
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - failover_promote
+    cartridge_failover_promote_params:
+      replicasets_leaders:
+        storage-1: storage-1-replica
+        storage-2: storage-2-replica
+
+- name: Update storages leaders application version
+  hosts: "*storage*leader*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./myapp-2.0.0.tar.gz
+
+- name: Promote storages leaders back
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - failover_promote
+    cartridge_failover_promote_params:
+      replicasets_leaders:
+        storage-1: storage-1-leader
+        storage-2: storage-2-leader
+
+- name: Update routers application version
+  hosts: "*core*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./myapp-2.0.0.tar.gz
+
+- name: Remove old packages
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - rotate_dists
+    cartridge_keep_num_latest_dists: 1
+```
+
+## Rolling update: Playbook for RPM or DEB
+
+In case of RPM and DEB (or TGZ without [multiversion approach](/doc/multiversion.md)
+all instances use a common version of the application.
+Updating the instance version of the application is performed when the instance is restarted.
+
+Updating instance scenario can be persisted in inventory to be used by name in all plays:
+
+```yaml
+# hosts.yml
+
+all:
+  vars:
+    ...
+    cartridge_custom_scenarios:
+      restart_instance_to_update:
+        - restart_instance
+        - wait_instance_started
+    ...
+```
+
+The example rolling update playbook:
+
+```yaml
+# playbook.yml
+
+- name: Deliver and install myapp 2.0.0
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - deliver_package
+      - update_package
+    cartridge_package_path: ./myapp-2.0.0.rpm
+
+- name: Update stateboard application version
+  hosts: "my-stateboard"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: restart_instance_to_update
+
+- name: Update storages replicas application version
+  hosts: "*storage*replica*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: restart_instance_to_update
+
+- name: Promote storages leaders to replicas
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - failover_promote
+    cartridge_failover_promote_params:
+      replicasets_leaders:
+        storage-1: storage-1-replica
+        storage-2: storage-2-replica
+
+- name: Update storages leaders application version
+  hosts: "*storage*leader*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: restart_instance_to_update
+
+- name: Promote storages leaders back
+  hosts: all
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - failover_promote
+    cartridge_failover_promote_params:
+      replicasets_leaders:
+        storage-1: storage-1-leader
+        storage-2: storage-2-leader
+
+- name: Update routers application version
+  hosts: "*core*"
+  roles:
+    - tarantool.cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: restart_instance_to_update
+```

--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -37,7 +37,7 @@ The plan is quite simple:
 * update routers replica sets
 * rotate distributions (if TGZ + Multiversion is used)
 
-## Rolling update: Playbook for TGZ + Multiversion
+## Rolling update: Playbook for TGZ package + Multiversion
 
 [Multiversion approach](/doc/multiversion.md) allows updating application
 version that each instance uses with
@@ -172,7 +172,7 @@ The example rolling update playbook:
     cartridge_keep_num_latest_dists: 1
 ```
 
-## Rolling update: Playbook for RPM or DEB
+## Rolling update: Playbook for RPM or DEB packages
 
 In case of RPM and DEB (or TGZ without [multiversion approach](/doc/multiversion.md))
 all instances use a common version of the application.

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -44,6 +44,7 @@ There are additional steps that are not included in the default scenario, but ca
 
 - [set_control_instance](#set_control_instance)
 - [rotate_dists](#rotate_dists)
+- [failover_promote](#failover_promote)
 
 To replace the steps of the role with your own or add new steps, you should use `cartridge_custom_steps_dir`
 or `cartridge_custom_steps` options (see [examples](#examples)).
@@ -635,7 +636,7 @@ Rotate application distributions.
 
 When [multiversion approach](/doc/multiversion.md) is used, each new application
 version is added to `cartridge_app_install_dir`.
-This step removes redundant distribution.
+This step removes redundant distributions.
 
 Input facts (set by config):
 
@@ -648,3 +649,16 @@ Output facts:
 
 - `dists_dirs_to_remove` - list of distribution directories paths that
   were removed.
+
+### failover_promote
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts (set by role):
+
+- `control_instance` - information about control instance ([more details here](#set_control_instance));
+
+Input facts (set by config):
+
+- `cartridge_failover_promote_params` - promote leaders params. More details in
+  [rolling update doc](#/doc/rolling_update.md).

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -111,3 +111,4 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `cartridge_failover_params` (`dict`): [failover](/doc/failover.md) parameters;
 * [DEPRECATED] `cartridge_failover` (`boolean`): a boolean flag that
   indicates if eventual failover should be enabled or disabled;
+* `cartridge_failover_promote_params` (`dict`): [failover promote](/doc/rolling_update.md#leaders-promotion) params.

--- a/library/cartridge_failover_promote.py
+++ b/library/cartridge_failover_promote.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+
+from ansible.module_utils.helpers import Helpers as helpers
+
+argument_spec = {
+    'console_sock': {'required': True, 'type': 'str'},
+    'failover_promote_params': {'required': False, 'type': 'dict'},
+}
+
+
+def failover_promote(params):
+    console_sock = params['console_sock']
+
+    failover_promote_params = params.get('failover_promote_params')
+    if failover_promote_params is None:
+        return helpers.ModuleRes(changed=False)
+
+    specified_replicaset_leaders = failover_promote_params.get('replicaset_leaders')
+    force_inconsistency = failover_promote_params.get('force_inconsistency')
+
+    if not specified_replicaset_leaders:
+        return helpers.ModuleRes(changed=False)
+
+    control_console = helpers.get_control_console(console_sock)
+
+    cluster_instances = helpers.get_cluster_instances(control_console)
+    cluster_replicasets = helpers.get_cluster_replicasets(control_console)
+
+    failover_mode, _ = control_console.eval_res_err('''
+        local cartridge = require('cartridge')
+        if cartridge.failover_get_params == nil then
+            return nil
+        end
+
+        local failover_params = cartridge.failover_get_params()
+        return failover_params.mode
+    ''')
+
+    if failover_mode != 'stateful':
+        return helpers.ModuleRes(
+            failed=True,
+            msg="Leaders promotion is possible only when stateful failover is enabled"
+        )
+
+    active_leaders, _ = control_console.eval_res_err('''
+        return require('cartridge.failover').get_active_leaders()
+    ''')
+
+    replicaset_leaders = {}
+    for replicaset_alias, leader_alias in specified_replicaset_leaders.items():
+        cluster_replicaset = cluster_replicasets.get(replicaset_alias)
+        if cluster_replicaset is None:
+            return helpers.ModuleRes(
+                failed=True,
+                msg="Replicaset '%s' isn't found in cluster" % replicaset_alias
+            )
+
+        if leader_alias not in cluster_replicaset['instances']:
+            return helpers.ModuleRes(
+                failed=True,
+                msg="Instance '%s' isn't found in replicaset '%s'" % (leader_alias, replicaset_alias)
+            )
+
+        leader_instance = cluster_instances.get(leader_alias)
+        if leader_instance is None:
+            return helpers.ModuleRes(
+                failed=True,
+                msg="Instance '%s' isn't found in cluster" % leader_alias
+            )
+
+        leader_instance_uuid = leader_instance.get('uuid')
+        if not leader_instance_uuid:
+            return helpers.ModuleRes(
+                failed=True,
+                msg="Instance '%s' has no UUID" % leader_alias
+            )
+
+        replicaset_leaders.update({
+            cluster_replicaset['uuid']: leader_instance_uuid,
+        })
+
+    _, err = control_console.eval_res_err('''
+        return require('cartridge').failover_promote(...)
+    ''', replicaset_leaders, force_inconsistency)
+
+    if err is not None:
+        return helpers.ModuleRes(
+            failed=True,
+            msg="Failed to promote leaders: %s" % err
+        )
+
+    new_active_leaders, _ = control_console.eval_res_err('''
+        return require('cartridge.failover').get_active_leaders()
+    ''')
+
+    return helpers.ModuleRes(changed=active_leaders != new_active_leaders)
+
+
+if __name__ == '__main__':
+    helpers.execute_module(argument_spec, failover_promote)

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -31,6 +31,7 @@ FACTS_BY_TARGETS = {
         'cartridge_enable_tarantool_repo',
         'cartridge_failover',
         'cartridge_failover_params',
+        'cartridge_failover_promote_params',
         'cartridge_install_tarantool_for_tgz',
         'cartridge_keep_num_latest_dists',
         'cartridge_memtx_dir_parent',

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -494,7 +494,7 @@ def check_failover_promote_params(found_common_params):
     replicaset_leaders = failover_promote_params.get('replicaset_leaders')
     if replicaset_leaders is not None:
         if not all([isinstance(k, str) and isinstance(v, str) for k, v in replicaset_leaders.items()]):
-            return "'replicaset_leaders' should be a string -> string map"
+            return "Variable 'replicaset_leaders' should be of type map(string -> string)"
 
 
 def validate_config(params):

--- a/molecule/rolling_update/Dockerfile.j2
+++ b/molecule/rolling_update/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/rolling_update/converge.yml
+++ b/molecule/rolling_update/converge.yml
@@ -1,0 +1,102 @@
+---
+- name: Deploy cluster with myapp 4.0.0
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_enable_tarantool_repo: true
+    cartridge_configure_systemd_unit_files: true
+    cartridge_configure_tmpfiles: true
+    cartridge_install_tarantool_for_tgz: true
+    cartridge_package_path: ./packages/myapp-4.0.0-0-with-c-2.4.0.tar.gz
+
+- name: Deliver and install myapp 5.0.0
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - deliver_package
+      - update_package
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+- name: Update stateboard application version
+  hosts: my-stateboard
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+- name: Update storages replicas application version
+  hosts: "*storage*replica*"
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+- name: Promote a leaders
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - failover_promote
+    cartridge_failover_promote_params:
+      replicasets_leaders:
+        storage-1: storage-1-replica
+        storage-2: storage-2-replica
+
+# Note that leaders aren't promoted back.
+# It's done only to have a possibility to check that
+# leaders were promoted on `verify` stage.
+
+- name: Update storages leaders application version
+  hosts: "*storage*leader*"
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+- name: Update routers application version
+  hosts: "*core*"
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario_name: update_and_restart_instance
+    cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.5.0.tar.gz
+
+- name: Remove old package
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - rotate_dists
+    cartridge_keep_num_latest_dists: 1

--- a/molecule/rolling_update/converge.yml
+++ b/molecule/rolling_update/converge.yml
@@ -59,7 +59,7 @@
     cartridge_scenario:
       - failover_promote
     cartridge_failover_promote_params:
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-replica
         storage-2: storage-2-replica
 

--- a/molecule/rolling_update/hosts.yml
+++ b/molecule/rolling_update/hosts.yml
@@ -1,0 +1,115 @@
+---
+cluster:
+  vars:
+    # common connection opts
+    ansible_user: root
+    ansible_connection: docker
+    become: true
+    become_user: root
+
+    # common cartridge opts
+    cartridge_app_name: myapp
+    cartridge_cluster_cookie: secret-cookie
+
+    cartridge_multiversion: true
+
+    cartridge_enable_tarantool_repo: false
+    cartridge_configure_systemd_unit_files: false
+    cartridge_configure_tmpfiles: false
+    cartridge_install_tarantool_for_tgz: false
+
+    cartridge_bootstrap_vshard: true
+
+    cartridge_failover_params:
+      mode: stateful
+      state_provider: stateboard
+      stateboard_params:
+        uri: vm1:4001
+        password: secret-stateboard
+
+    cartridge_custom_scenarios:
+      update_and_restart_instance:
+        - update_instance
+        - restart_instance
+        - wait_instance_started
+
+  # instances
+  hosts:
+    core-1:
+      config:
+        advertise_uri: 'vm1:3101'
+        http_port: 8101
+
+    storage-1-leader:
+      config:
+        advertise_uri: 'vm1:3102'
+        http_port: 8102
+
+    storage-1-replica:
+      config:
+        advertise_uri: 'vm1:3103'
+        http_port: 8103
+
+    storage-2-leader:
+      config:
+        advertise_uri: 'vm1:3104'
+        http_port: 8104
+
+    storage-2-replica:
+      config:
+        advertise_uri: 'vm1:3105'
+        http_port: 8105
+
+    my-stateboard:
+      config:
+        listen: 0.0.0.0:4001
+        password: secret-stateboard
+      stateboard: true
+
+  children:
+    # group by hosts
+    machine_1:
+      vars:
+        ansible_host: vm1
+
+      hosts:
+        core-1:
+        storage-1-leader:
+        storage-1-replica:
+        storage-2-leader:
+        storage-2-replica:
+        my-stateboard:
+
+    # group by replica sets
+    core_1_replicaset:
+      hosts:
+        core-1:
+      vars:
+        replicaset_alias: core-1
+        roles:
+          - vshard-router
+          - failover-coordinator
+
+    storage_1_replicaset:
+      hosts:
+        storage-1-leader:
+        storage-1-replica:
+      vars:
+        replicaset_alias: storage-1
+        failover_priority:
+          - storage-1-leader
+          - storage-1-replica
+        roles:
+          - vshard-storage
+
+    storage_2_replicaset:
+      hosts:
+        storage-2-leader:
+        storage-2-replica:
+      vars:
+        replicaset_alias: storage-2
+        failover_priority:
+          - storage-2-leader
+          - storage-2-replica
+        roles:
+          - vshard-storage

--- a/molecule/rolling_update/molecule.yml
+++ b/molecule/rolling_update/molecule.yml
@@ -1,0 +1,59 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: vm1
+    image: centos:7
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    published_ports:
+      - 8100-8199:8100-8199/tcp
+    networks:
+      - name: cartridge-network
+
+lint: |
+  set -xe
+  yamllint .
+  flake8
+
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      hosts: hosts.yml
+
+verifier:
+  name: testinfra
+  options:
+    v: true
+
+scenario:
+  create_sequence:
+    - create
+  converge_sequence:
+    - create
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - converge
+    - verify
+    - destroy
+  check_sequence:
+    - destroy
+    - create
+    - converge
+    - check
+    - destroy

--- a/molecule/rolling_update/tests/test_cluster_is_healthy.py
+++ b/molecule/rolling_update/tests/test_cluster_is_healthy.py
@@ -1,0 +1,1 @@
+../../common/tests/test_cluster_is_healthy.py

--- a/molecule/rolling_update/tests/test_rolling_upgrade.py
+++ b/molecule/rolling_update/tests/test_rolling_upgrade.py
@@ -1,0 +1,118 @@
+import os
+import re
+
+import testinfra.utils.ansible_runner
+import requests
+
+from ansible.inventory.manager import InventoryManager
+from ansible.vars.manager import VariableManager
+from ansible.parsing.dataloader import DataLoader
+
+ansible_runner = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+)
+testinfra_hosts = ansible_runner.get_hosts('all')
+
+scenario_name = os.environ['MOLECULE_SCENARIO_NAME']
+
+APP_NAME = 'myapp'
+HOSTS_PATH = os.path.join('molecule', scenario_name, 'hosts.yml')
+
+inventory = InventoryManager(loader=DataLoader(), sources=HOSTS_PATH)
+variable_manager = VariableManager(loader=DataLoader(), inventory=inventory)
+
+cluster_cookie = inventory.groups['cluster'].get_vars()['cartridge_cluster_cookie']
+
+__authorized_session = None
+__configured_instances = None
+
+
+def get_authorized_session(cluster_cookie):
+    global __authorized_session
+    if __authorized_session is None:
+        __authorized_session = requests.Session()
+        __authorized_session.auth = ('admin', cluster_cookie)
+
+    return __authorized_session
+
+
+def get_configured_instances():
+    global __configured_instances
+    if __configured_instances is None:
+        __configured_instances = {
+            inventory.hosts[i].get_vars()['inventory_hostname']: inventory.hosts[i].get_vars()
+            for i in inventory.hosts
+        }
+    return __configured_instances
+
+
+def get_any_instance_http_port(instances):
+    for _, instance_vars in instances.items():
+        return instance_vars['config']['http_port']
+    assert False
+
+
+def get_admin_api_url(instances):
+    admin_url = 'http://localhost:{}'.format(get_any_instance_http_port(instances))
+    admin_api_url = '{}/admin/api'.format(
+        admin_url
+    )
+
+    return admin_api_url
+
+
+def get_instance_id(app_name, instance_name=None, stateboard=False):
+    if stateboard:
+        return '%s-stateboard' % app_name
+
+    if instance_name is None:
+        raise Exception("instance_name should be not none for non-stateboard instance")
+
+    return '%s.%s' % (app_name, instance_name)
+
+
+def test_active_leaders():
+    configured_instances = get_configured_instances()
+
+    # Select one instance to be control
+    admin_api_url = get_admin_api_url(configured_instances)
+
+    # Get all started instances
+    query = '''
+        query {
+          replicasets {
+            alias
+            active_master {
+                alias
+            }
+          }
+        }
+    '''
+    session = get_authorized_session(cluster_cookie)
+    response = session.post(admin_api_url, json={'query': query})
+    assert response.status_code == 200
+
+    replicasets = response.json()['data']['replicasets']
+    active_leaders = {
+        rpl['alias']: rpl['active_master']['alias']
+        for rpl in replicasets
+    }
+
+    assert active_leaders == {
+        'core-1': 'core-1',
+        'storage-1': 'storage-1-replica',
+        'storage-2': 'storage-2-replica',
+    }
+
+
+def test_dists_rotated(host):
+    app_install_dir = host.file('/usr/share/tarantool')
+
+    DIST_DIR_RGX = r'^%s-\d+\.\d+\.\d+-\d+(-\S+)?$' % APP_NAME
+
+    dists = list(filter(
+        lambda filename: re.match(DIST_DIR_RGX, filename) is not None,
+        app_install_dir.listdir()
+    ))
+
+    assert dists == ['myapp-5.0.0-0-with-c-2.5.0']

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -82,6 +82,7 @@
       cartridge_auth: '{{ cartridge_auth }}'
       cartridge_failover: '{{ cartridge_failover }}'
       cartridge_failover_params: '{{ cartridge_failover_params }}'
+      cartridge_failover_promote_params: '{{ cartridge_failover_promote_params }}'
 
       # Internal role facts that can be set by the user
 

--- a/tasks/step_failover_promote.yml
+++ b/tasks/step_failover_promote.yml
@@ -1,0 +1,9 @@
+---
+
+- import_tasks: 'prepare.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
+- import_tasks: 'steps/failover_promote.yml'

--- a/tasks/steps/failover_promote.yml
+++ b/tasks/steps/failover_promote.yml
@@ -1,0 +1,14 @@
+---
+
+- tags:
+    - cartridge-config
+  block:
+    - import_tasks: 'blocks/set_control_instance.yml'
+      when: not control_instance
+
+    - name: 'Failover promote'
+      cartridge_failover_promote:
+        failover_promote_params: '{{ cartridge_failover_promote_params }}'
+        console_sock: '{{ control_instance.console_sock }}'
+      run_once: true
+      delegate_to: '{{ control_instance.name }}'

--- a/unit/mock/cartridge.lua
+++ b/unit/mock/cartridge.lua
@@ -16,6 +16,10 @@ package.loaded['cartridge.webui.api-auth'] = cartridge_webui_auth
 local cartridge_admin = {}
 package.loaded['cartridge.admin'] = cartridge_admin
 
+-- local cartridge_failover_lib = require('cartridge.failover')
+local cartridge_failover= {}
+package.loaded['cartridge.failover'] = cartridge_failover
+
 local membership = {}
 package.loaded['membership'] = membership
 
@@ -349,6 +353,10 @@ cartridge.config_patch_clusterwide = wrap_func(
 
 -- * -------------------------- Failover --------------------------
 
+cartridge_failover.get_active_leaders = function()
+    return vars.active_leaders or {}
+end
+
 local lua_api_failover = require('cartridge.lua-api.failover')
 
 cartridge.failover_get_params = lua_api_failover.get_params
@@ -366,6 +374,15 @@ end
 
 cartridge.failover_set_params = wrap_func(
     'failover_set_params', lua_api_failover.set_params
+)
+
+cartridge.failover_promote = wrap_func(
+    'failover_promote', function(replicaset_leaders)
+        vars.active_leaders = vars.active_leaders or {}
+        for rpl_uuid, instannce_uuid in pairs(replicaset_leaders) do
+            vars.active_leaders[rpl_uuid] = instannce_uuid
+        end
+    end
 )
 
 -- * ---------------- Module cartridge.vshard-utils ---------------

--- a/unit/test_failover_promote.py
+++ b/unit/test_failover_promote.py
@@ -1,0 +1,249 @@
+import sys
+import unittest
+
+from parameterized import parameterized
+import module_utils.helpers as helpers
+
+from unit.instance import Instance
+
+sys.modules['ansible.module_utils.helpers'] = helpers
+from library.cartridge_failover_promote import failover_promote
+
+
+def call_failover_promote(console_sock, params):
+    return failover_promote({
+        'console_sock': console_sock,
+        'failover_promote_params': params,
+    })
+
+
+class TestEditTopology(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+        self.instance = Instance()
+        self.console_sock = self.instance.console_sock
+        self.cookie = self.instance.cluster_cookie
+
+        self.instance.start()
+
+    @parameterized.expand([
+        ['disabled'],  # force_inconsistency
+        ['eventual'],
+    ])
+    def test_failover_bad_mode(self, mode):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode=mode)
+
+        self.instance.set_fail_on('failover_promote')
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {'r1': 'r1-replica'}
+        }
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertTrue(res.failed, msg=res.msg)
+        self.assertEqual(res.msg, "Leaders promotion is possible only when stateful failover is enabled")
+
+    def test_failover_promote_fails(self):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode='stateful', state_provider='stateboard')
+        self.instance.set_variable('active_leaders', {
+            'r1-uuid': 'r1-leader-uuid',
+        })
+
+        self.instance.set_fail_on('failover_promote')
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {'r1': 'r1-replica'}
+        }
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertTrue(res.failed, msg=res.msg)
+        self.assertEqual(res.msg, "Failed to promote leaders: cartridge err")
+
+        calls = self.instance.get_calls('failover_promote')
+        self.assertEqual(len(calls), 1)
+
+        exp_replicaset_leaders_params = {'r1-uuid': 'r1-replica-uuid'}
+        self.assertEqual(calls[0], [exp_replicaset_leaders_params, None])
+
+    def test_replicaset_not_in_cluster(self):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode='stateful', state_provider='stateboard')
+        self.instance.set_variable('active_leaders', {
+            'r1-uuid': 'r1-leader-uuid',
+        })
+
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {'some-bad-rpl': 'r1-replica'}
+        }
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertTrue(res.failed, msg=res.msg)
+        self.assertEqual(res.msg, "Replicaset 'some-bad-rpl' isn't found in cluster")
+
+    def test_instance_not_in_cluster(self):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode='stateful', state_provider='stateboard')
+        self.instance.set_variable('active_leaders', {
+            'r1-uuid': 'r1-leader-uuid',
+        })
+
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {'r1': 'some-bad-instance'}
+        }
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertTrue(res.failed, msg=res.msg)
+        self.assertEqual(res.msg, "Instance 'some-bad-instance' isn't found in replicaset 'r1'")
+
+    @parameterized.expand([
+        [True],  # force_inconsistency
+        [False],
+    ])
+    def test_failover_promote(self, force_inconsistency):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.add_replicaset(
+            alias='r2',
+            instances=['r2-leader', 'r2-replica', 'r2-replica-2'],
+        )
+
+        self.instance.add_replicaset(
+            alias='r3',
+            instances=['r3-leader', 'r3-replica', 'r3-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode='stateful', state_provider='stateboard')
+        self.instance.set_variable('active_leaders', {
+            'r1-uuid': 'r1-leader-uuid',
+            'r2-uuid': 'r2-leader-uuid',
+            'r3-uuid': 'r3-leader-uuid',
+        })
+
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {
+                'r1': 'r1-replica',
+                'r3': 'r3-replica',
+            },
+        }
+        if force_inconsistency:
+            params.update({'force_inconsistency': True})
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertFalse(res.failed, msg=res.msg)
+        self.assertTrue(res.changed)
+
+        calls = self.instance.get_calls('failover_promote')
+        self.assertEqual(len(calls), 1)
+
+        exp_replicaset_leaders_params = {
+            'r1-uuid': 'r1-replica-uuid',
+            'r3-uuid': 'r3-replica-uuid',
+        }
+
+        exp_force_inconsistency = True if force_inconsistency is True else None
+        self.assertEqual(calls[0], [exp_replicaset_leaders_params, exp_force_inconsistency])
+
+    @parameterized.expand([
+        [True],  # force_inconsistency
+        [False],
+    ])
+    def test_failover_promote_not_changed(self, force_inconsistency):
+        self.instance.add_replicaset(
+            alias='r1',
+            instances=['r1-leader', 'r1-replica', 'r1-replica-2'],
+        )
+
+        self.instance.add_replicaset(
+            alias='r2',
+            instances=['r2-leader', 'r2-replica', 'r2-replica-2'],
+        )
+
+        self.instance.add_replicaset(
+            alias='r3',
+            instances=['r3-leader', 'r3-replica', 'r3-replica-2'],
+        )
+
+        self.instance.set_failover_params(mode='stateful', state_provider='stateboard')
+        self.instance.set_variable('active_leaders', {
+            'r1-uuid': 'r1-leader-uuid',
+            'r2-uuid': 'r2-leader-uuid',
+            'r3-uuid': 'r3-leader-uuid',
+        })
+
+        self.instance.clear_calls('failover_promote')
+
+        params = {
+            'replicaset_leaders': {
+                'r1': 'r1-leader',
+                'r3': 'r3-leader',
+            },
+        }
+        if force_inconsistency:
+            params.update({'force_inconsistency': True})
+
+        res = call_failover_promote(
+            self.console_sock,
+            params
+        )
+        self.assertFalse(res.failed, msg=res.msg)
+        self.assertFalse(res.changed)
+
+        calls = self.instance.get_calls('failover_promote')
+        self.assertEqual(len(calls), 1)
+
+        exp_replicaset_leaders_params = {
+            'r1-uuid': 'r1-leader-uuid',
+            'r3-uuid': 'r3-leader-uuid',
+        }
+
+        exp_force_inconsistency = True if force_inconsistency is True else None
+        self.assertEqual(calls[0], [exp_replicaset_leaders_params, exp_force_inconsistency])
+
+    def tearDown(self):
+        self.instance.stop()
+        del self.instance

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -1081,7 +1081,7 @@ class TestValidateConfig(unittest.TestCase):
         })
         self.assertTrue(res.failed)
         self.assertIn(
-            "'replicaset_leaders' should be a string -> string map",
+            "Variable 'replicaset_leaders' should be of type map(string -> string)",
             res.msg
         )
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -276,7 +276,11 @@ class TestValidateConfig(unittest.TestCase):
             'cartridge_custom_steps': [
                 [{'name': 'task_1', 'file': 'task_1.yml'}],
                 [{'name': 'task_2', 'file': 'task_2.yml'}],
-            ]
+            ],
+            'cartridge_failover_promote_params': [
+                {'replicaset_leaders': {'rpl-1': 'instance-2'}},
+                {'replicaset_leaders': {'rpl-1': 'instance-3'}},
+            ],
         }
 
         required_params = {
@@ -1013,6 +1017,71 @@ class TestValidateConfig(unittest.TestCase):
         self.assertTrue(res.failed)
         self.assertIn(
             "File 'qwerty' from custom task '{'name': 'task', 'file': 'qwerty'}' doesn't exists",
+            res.msg
+        )
+
+    def test_failover_promote_params(self):
+        res = call_validate_config({
+            'instance-1': {
+                'cartridge_app_name': 'app-name',
+                'cartridge_cluster_cookie': 'cookie',
+                'config': {'advertise_uri': 'localhost:3301'},
+
+                'cartridge_failover_promote_params': {
+                    'replicaset_leaders': {'rpl-1': 'instance-2'},
+                    'force_inconsistency': False,
+                },
+            },
+        })
+        self.assertFalse(res.failed)
+
+        res = call_validate_config({
+            'instance-1': {
+                'cartridge_app_name': 'app-name',
+                'cartridge_cluster_cookie': 'cookie',
+                'config': {'advertise_uri': 'localhost:3301'},
+
+                'cartridge_failover_promote_params': {
+                    'replicaset_leaders': {'rpl-1': 'instance-2'},
+                },
+            },
+        })
+        self.assertFalse(res.failed)
+
+        res = call_validate_config({
+            'instance-1': {
+                'cartridge_app_name': 'app-name',
+                'cartridge_cluster_cookie': 'cookie',
+                'config': {'advertise_uri': 'localhost:3301'},
+
+                'cartridge_failover_promote_params': {
+                    'replicaset_leaders': {'rpl-1': 'instance-2'},
+                    'force_inconsistency': False,
+                    'bad-field': 'I am very very bad',
+                },
+            },
+        })
+        self.assertTrue(res.failed)
+        self.assertIn(
+            "Passed unknown failover promote parameter: 'bad-field'",
+            res.msg
+        )
+
+        res = call_validate_config({
+            'instance-1': {
+                'cartridge_app_name': 'app-name',
+                'cartridge_cluster_cookie': 'cookie',
+                'config': {'advertise_uri': 'localhost:3301'},
+
+                'cartridge_failover_promote_params': {
+                    'replicaset_leaders': {'rpl-1': 43},
+                    'force_inconsistency': False,
+                },
+            },
+        })
+        self.assertTrue(res.failed)
+        self.assertIn(
+            "'replicaset_leaders' should be a string -> string map",
             res.msg
         )
 


### PR DESCRIPTION
Added `failover_promote` step that allows to promote leaders.
It can be useful for rolling update (examples added to doc).
This step isn't idempotent - it performs `cartridge.failover_promote`
rgardless of current configuration. It allows to avoid skipping 
leaders promotion when cluster configuration isn't consistent
or state provider is unavaliable.

Closes #219 