### PR TITLE
Fix compatibility with ansible 2.9

### DIFF
--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -37,8 +37,8 @@ def main(event_name, repo_owner, review_state, ref):
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
         ce_matrix.append(get_ce_params(molecule_scenario='update_cartridge'))
         ce_matrix.append(get_ce_params(tarantool_version='1.10'))
-        # TODO: Uncomment after fix for Ansible version ~=2.9.0
-        # ce_matrix.append(get_ce_params(ansible_version='2.9.0'))
+
+        ce_matrix.append(get_ce_params(ansible_version='2.9.0'))
         # TODO: Uncomment after fixing the check mode
         # ce_matrix.append(get_ce_version(molecule_command='check'))
 

--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -37,7 +37,6 @@ def main(event_name, repo_owner, review_state, ref):
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
         ce_matrix.append(get_ce_params(molecule_scenario='update_cartridge'))
         ce_matrix.append(get_ce_params(tarantool_version='1.10'))
-
         ce_matrix.append(get_ce_params(ansible_version='2.9.0'))
         # TODO: Uncomment after fixing the check mode
         # ce_matrix.append(get_ce_version(molecule_command='check'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ README.md to use the newest tag with new release
 
 - Removing stateboard instance distribution directory on `rotate_dists` step
 - Fixed fail on getting one non-expelled instance when only stateboard instance
-  is configured.
+  is configured
+- Fixed compatibility with Ansible 2.9
 
 ## [1.8.0] - 2021-03-23
 

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,0 +1,10 @@
+import os
+
+def path_join(parts):
+    return os.path.join(*parts)
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'cartridge_path_join': path_join,
+        }

--- a/tasks/steps/blocks/create_systemd_unit_files.yml
+++ b/tasks/steps/blocks/create_systemd_unit_files.yml
@@ -22,7 +22,7 @@
 - name: 'Place systemd units files'
   template:
     src: '{{ systemd_unit.template }}'
-    dest: '{{ (cartridge_systemd_dir, systemd_unit.filename) | path_join }}'
+    dest: '{{ (cartridge_systemd_dir, systemd_unit.filename) | cartridge_path_join }}'
     force: true
   loop_control:
     loop_var: systemd_unit

--- a/tasks/steps/blocks/unpack_tgz.yml
+++ b/tasks/steps/blocks/unpack_tgz.yml
@@ -40,7 +40,7 @@
       cartridge_app_install_dir,
       cartridge_app_instances_dir,
       instance_info.dist_dir,
-    ] | reject('equalto', none) }}"
+    ] | reject('none') | list }}"
   any_errors_fatal: true
 
 - name: 'Configure tmpfiles'

--- a/tasks/steps/update_package.yml
+++ b/tasks/steps/update_package.yml
@@ -1,6 +1,6 @@
 ---
 
-- when: delivered_package_path
+- when: delivered_package_path is not none
   tags: cartridge-instances
   block:
     - name: 'BLOCK : Install package'


### PR DESCRIPTION
Before this patch it wasn't possible to run the role using Ansible 2.9.
Now all compatibility errors are fixed and role is  Ansible 2.9 is tested
on CI for each PR before merging into master.