### PR TITLE
Fix configuring only stateboard instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ README.md to use the newest tag with new release
 ### Fixed
 
 - Removing stateboard instance distribution directory on `rotate_dists` step
+- Fixed fail on getting one non-expelled instance when only stateboard instance
+  is configured.
 
 ## [1.8.0] - 2021-03-23
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,5 +92,6 @@ delivered_package_path: null
 package_info: null
 systemd_units_info: null
 needs_restart: null
+non_expelled_instance: null
 control_instance: null
 dists_dirs_to_remove: null

--- a/library/cartridge_get_dist_dirs_to_remove.py
+++ b/library/cartridge_get_dist_dirs_to_remove.py
@@ -21,8 +21,8 @@ def is_dist(filename, app_install_dir, app_name):
     if not os.path.isdir(os.path.join(app_install_dir, filename)):
         return False
 
-    DIST_DIR_RGX = r'%s-\d+\.\d+\.\d+-\d+(-\S+)?' % app_name
-    return re.fullmatch(DIST_DIR_RGX, filename) is not None
+    DIST_DIR_RGX = r'^%s-\d+\.\d+\.\d+-\d+(-\S+)?$' % app_name
+    return re.match(DIST_DIR_RGX, filename) is not None
 
 
 def get_dist_dirs_to_remove(params):

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -68,19 +68,3 @@
   run_once: true
   delegate_to: localhost
   become: false
-
-- name: 'Select one not expelled instance'
-  cartridge_get_not_expelled_instance:
-    hostvars: '{{ hostvars }}'
-    play_hosts: '{{ play_hosts }}'
-  run_once: true
-  delegate_to: localhost
-  become: false
-  register: not_expelled_instance_res
-
-- name: 'Set "not_expelled_instance" fact'
-  set_fact:
-    not_expelled_instance: '{{ not_expelled_instance_res.fact }}'
-  run_once: true
-  delegate_to: localhost
-  become: false

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -1,5 +1,8 @@
 ---
 
+- import_tasks: 'set_non_expelled_instance.yml'
+  when: not non_expelled_instance
+
 - name: 'Select control instance to manage topology and configuration'
   cartridge_get_control_instance:
     hostvars: '{{ hostvars }}'

--- a/tasks/steps/blocks/set_non_expelled_instance.yml
+++ b/tasks/steps/blocks/set_non_expelled_instance.yml
@@ -1,0 +1,17 @@
+---
+
+- name: 'Select one not expelled instance'
+  cartridge_get_not_expelled_instance:
+    hostvars: '{{ hostvars }}'
+    play_hosts: '{{ play_hosts }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+  register: not_expelled_instance_res
+
+- name: 'Set "not_expelled_instance" fact'
+  set_fact:
+    not_expelled_instance: '{{ not_expelled_instance_res.fact }}'
+  run_once: true
+  delegate_to: localhost
+  become: false

--- a/tasks/steps/connect_to_membership.yml
+++ b/tasks/steps/connect_to_membership.yml
@@ -1,5 +1,8 @@
 ---
 
+- import_tasks: 'blocks/set_non_expelled_instance.yml'
+  when: not non_expelled_instance
+
 - name: 'Connect instance to membership'
   cartridge_connect_to_membership:
     console_sock: '{{ not_expelled_instance.console_sock }}'


### PR DESCRIPTION
Before this patch it was impossible to update distribution
or configure only stateboard instance. Now non-expelled
instance is selected only for tasks it's really needed.