### PR TITLE
Fix test matrix generator

### DIFF
--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setup matrix for Molecule tests
         id: setup-matrix
         run: |
+          echo "${{ toJson(github.event.pull_request) }}"
           python3 .github/helpers/count_molecule_matrix.py \
             --event_name "${{ github.event_name }}" \
             --repo_owner "${{ github.event.pull_request.head.repo.owner.login }}" \


### PR DESCRIPTION
Before this patch, on push in pull request with approve,
it was imposssible to run all tests.

Now if pull request is mergable, then all tests will be started.