### PR TITLE
Steps to start, stop and force restart instances

### DIFF
--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -41,6 +41,7 @@ def main(event_name, repo_owner, review_state, ref):
         ce_matrix.append(get_ce_params(molecule_scenario='needs_restart'))
         ce_matrix.append(get_ce_params(molecule_scenario='package_name'))
         ce_matrix.append(get_ce_params(molecule_scenario='eval'))
+        ce_matrix.append(get_ce_params(molecule_scenario='start_stop'))
 
         ce_matrix.append(get_ce_params(tarantool_version='1.10'))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ README.md to use the newest tag with new release
   * `twophase_upload_config_timeout`
   * `twophase_apply_config_timeout`
 - `eval` step to eval code on instances
+- Step `stop_instance` to stop and disable instance systemd service
+- Step `start_instance` to start and enable instance systemd service
+- Step `restart_instance_force` to restart systemd service without any conditions
 
 ### Changed
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -46,6 +46,9 @@ There are additional steps that are not included in the default scenario, but ca
 - [rotate_dists](#rotate_dists)
 - [failover_promote](#failover_promote)
 - [eval](#eval)
+- [stop_instance](#stop_instance)
+- [start_instance](#start_instance)
+- [restart_instance_force](#restart_instance_force)
 
 To replace the steps of the role with your own or add new steps, you should use `cartridge_custom_steps_dir`
 or `cartridge_custom_steps` options (see [examples](#examples)).
@@ -672,11 +675,11 @@ Input facts (set by role):
 Input facts (set by config):
 
 - `cartridge_failover_promote_params` - promote leaders params. More details in
-  [rolling update doc](#/doc/rolling_update.md).
+  [rolling update doc](/doc/rolling_update.md).
 
 ### eval
 
-[Eval code](#/doc/eval.md) on instance.
+[Eval code](/doc/eval.md) on instance.
 
 Input facts (set by role):
 
@@ -688,3 +691,27 @@ Input facts (set by config):
   `cartridge_eval_body` is specified);
 - `cartridge_eval_body` - code to eval;
 - `cartridge_eval_args` - function arguments.
+
+### stop_instance
+
+Stop and disable instance systemd service.
+
+Input facts (set by role):
+
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
+
+### start_instance
+
+Start and enable instance systemd service.
+
+Input facts (set by role):
+
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
+
+### restart_instance_force
+
+Restart instance systemd service without any conditions.
+
+Input facts (set by role):
+
+- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -427,7 +427,7 @@ Output facts:
 
 ### restart_instance
 
-Restart instance if it should be restarted.
+Restart and enable instance systemd service if it should be restarted.
 
 Input facts (set by role):
 
@@ -710,7 +710,7 @@ Input facts (set by role):
 
 ### restart_instance_force
 
-Restart instance systemd service without any conditions.
+Restart and enable instance systemd service without any conditions.
 
 Input facts (set by role):
 

--- a/molecule/start_stop/Dockerfile.j2
+++ b/molecule/start_stop/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/start_stop/converge.yml
+++ b/molecule/start_stop/converge.yml
@@ -1,0 +1,117 @@
+---
+
+- name: 'Restart all instances except one'
+  hosts: cluster:!instance-started
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - restart_instance
+      - wait_instance_started
+
+- name: 'Start instance-started instance'
+  hosts: instance-started
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - start_instance
+      - wait_instance_started
+
+- name: 'Set up topology'
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - edit_topology
+
+- name: 'Stop instance'
+  hosts: instance-stopped
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - stop_instance
+
+- name: 'Set runtime variable for instances'
+  hosts: instance-restarted,instance-restarted-force
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - eval
+    cartridge_eval_body: |
+      rawset(_G, 'some_runtime_variable', true)
+
+- name: 'Restart instance forcely'
+  hosts: instance-restarted-force
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - restart_instance_force
+
+- name: 'Restart instance if needed'
+  hosts: instance-restarted
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - restart_instance
+
+- name: 'Get runtime variable for instances'
+  hosts: instance-restarted,instance-restarted-force
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - eval
+    cartridge_eval_body: |
+      return rawget(_G, 'some_runtime_variable') or box.NULL
+
+- name: 'Check runtime variable for instances'
+  hosts: instance-restarted,instance-restarted-force
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Check that runtime variable for forcely restarted instance was discarded'
+      assert:
+        msg: "Instance wasn't restarted"
+        success_msg: 'Runtime variable for forcely restarted instance was discarded'
+        that: >-
+          eval_res[0] == none
+      when: inventory_hostname == 'instance-restarted-force'
+
+    - name: "Check that runtime variable for restarted instance wasn't discarded"
+      assert:
+        msg: "Instance was restarted"
+        success_msg: "Runtime variable for restarted instance wasn't discarded"
+        that: >-
+          eval_res[0] != none
+      when: inventory_hostname == 'instance-restarted'

--- a/molecule/start_stop/hosts.yml
+++ b/molecule/start_stop/hosts.yml
@@ -1,0 +1,59 @@
+---
+
+cluster:
+  vars:
+    # common connection opts
+    ansible_user: root
+    ansible_connection: docker
+    become: true
+    become_user: root
+
+    # common cartridge opts
+    cartridge_app_name: myapp
+    cartridge_cluster_cookie: secret-cookie
+
+    cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
+
+  # instances
+  hosts:
+    instance-started:
+      config:
+        advertise_uri: 'vm1:3101'
+        http_port: 8101
+
+    instance-stopped:
+      config:
+        advertise_uri: 'vm1:3102'
+        http_port: 8102
+
+    instance-restarted:
+      config:
+        advertise_uri: 'vm1:3103'
+        http_port: 8103
+
+    instance-restarted-force:
+      config:
+        advertise_uri: 'vm1:3104'
+        http_port: 8104
+
+  children:
+    machine_1:
+      vars:
+        ansible_host: vm1
+
+      hosts:
+        instance-started:
+        instance-stopped:
+        instance-restarted:
+        instance-restarted-force:
+
+    replicaset_1:
+      vars:
+        replicaset_alias: r-1
+        roles: []
+
+      hosts:
+        instance-started:
+        instance-stopped:
+        instance-restarted:
+        instance-restarted-force:

--- a/molecule/start_stop/molecule.yml
+++ b/molecule/start_stop/molecule.yml
@@ -1,0 +1,63 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: vm1
+    image: centos:7
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    published_ports:
+      - 8100-8199:8100-8199/tcp
+    networks:
+      - name: cartridge-network
+
+lint: |
+  set -xe
+  yamllint .
+  flake8
+
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      hosts: hosts.yml
+
+verifier:
+  name: testinfra
+  options:
+    v: true
+
+scenario:
+  create_sequence:
+    - create
+    - prepare
+  converge_sequence:
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy
+  check_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy

--- a/molecule/start_stop/prepare.yml
+++ b/molecule/start_stop/prepare.yml
@@ -1,0 +1,15 @@
+---
+
+- name: 'Configure instances'
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - deliver_package
+      - update_package
+      - update_instance
+      - configure_instance

--- a/molecule/start_stop/tests/test_systemd_services.py
+++ b/molecule/start_stop/tests/test_systemd_services.py
@@ -1,0 +1,52 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+from ansible.inventory.manager import InventoryManager
+from ansible.vars.manager import VariableManager
+from ansible.parsing.dataloader import DataLoader
+
+ansible_runner = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+)
+testinfra_hosts = ansible_runner.get_hosts('all')
+
+
+scenario_name = os.environ['MOLECULE_SCENARIO_NAME']
+
+HOSTS_PATH = os.path.join('molecule', scenario_name, 'hosts.yml')
+
+inventory = InventoryManager(loader=DataLoader(), sources=HOSTS_PATH)
+variable_manager = VariableManager(loader=DataLoader(), inventory=inventory)
+
+app_name = 'myapp'
+if scenario_name == 'package_name':
+    app_name = inventory.groups['cluster'].get_vars()['cartridge_app_name']
+
+
+def test_services_status(host):
+    hostname = host.check_output('hostname -s')
+
+    machine_instances = [
+        instance for instance in inventory.get_hosts()
+        if variable_manager.get_vars(host=instance).get('ansible_host') == hostname
+    ]
+
+    assert machine_instances
+
+    for instance in machine_instances:
+        instance_vars = variable_manager.get_vars(host=instance)
+        instance_name = instance_vars['inventory_hostname']
+
+        service_name = '%s@%s' % (app_name, instance_name)
+        service = host.service(service_name)
+
+        running_instances = ['instance-started', 'instance-restarted', 'instance-restarted-force']
+        if instance_name == 'instance-stopped':
+            assert not service.is_running
+            assert not service.is_enabled
+        elif instance_name in running_instances:
+            assert service.is_running
+            assert service.is_enabled
+        else:
+            assert False

--- a/tasks/step_restart_instance_force.yml
+++ b/tasks/step_restart_instance_force.yml
@@ -1,0 +1,9 @@
+---
+
+- import_tasks: 'prepare.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
+- import_tasks: 'steps/restart_instance_force.yml'

--- a/tasks/step_start_instance.yml
+++ b/tasks/step_start_instance.yml
@@ -1,0 +1,9 @@
+---
+
+- import_tasks: 'prepare.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
+- import_tasks: 'steps/start_instance.yml'

--- a/tasks/step_stop_instance.yml
+++ b/tasks/step_stop_instance.yml
@@ -1,0 +1,9 @@
+---
+
+- import_tasks: 'prepare.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
+- import_tasks: 'steps/stop_instance.yml'

--- a/tasks/steps/restart_instance.yml
+++ b/tasks/steps/restart_instance.yml
@@ -1,6 +1,10 @@
 ---
 
 - tags: cartridge-instances
+  when:
+    - not expelled
+    - restarted is none
+    - needs_restart is none
   block:
     - name: 'Check if instance restart is required'
       cartridge_get_needs_restart:
@@ -18,12 +22,7 @@
       set_fact:
         needs_restart: '{{ needs_restart_res.fact }}'
 
-  when:
-    - not expelled
-    - restarted is none
-    - needs_restart is none
-
-- name: 'Restart instance systemd service if needed'
+- name: 'Restart and enable instance systemd service if needed'
   systemd:
     name: '{{ instance_info.systemd_service }}'
     state: restarted

--- a/tasks/steps/restart_instance.yml
+++ b/tasks/steps/restart_instance.yml
@@ -1,6 +1,29 @@
 ---
 
-- name: 'Restart instance systemd service'
+- tags: cartridge-instances
+  block:
+    - name: 'Check if instance restart is required'
+      cartridge_get_needs_restart:
+        app_name: '{{ cartridge_app_name }}'
+        config: '{{ config }}'
+        cartridge_defaults: '{{ cartridge_defaults }}'
+        cluster_cookie: '{{ cartridge_cluster_cookie }}'
+        stateboard: '{{ stateboard }}'
+        instance_info: '{{ instance_info }}'
+        check_package_updated: true
+        check_config_updated: true
+      register: needs_restart_res
+
+    - name: 'Set "needs_restart" fact'
+      set_fact:
+        needs_restart: '{{ needs_restart_res.fact }}'
+
+  when:
+    - not expelled
+    - restarted is none
+    - needs_restart is none
+
+- name: 'Restart instance systemd service if needed'
   systemd:
     name: '{{ instance_info.systemd_service }}'
     state: restarted

--- a/tasks/steps/restart_instance_force.yml
+++ b/tasks/steps/restart_instance_force.yml
@@ -1,0 +1,8 @@
+---
+
+- name: 'Restart instance systemd service'
+  systemd:
+    name: '{{ instance_info.systemd_service }}'
+    state: restarted
+    enabled: true
+  tags: cartridge-instances

--- a/tasks/steps/restart_instance_force.yml
+++ b/tasks/steps/restart_instance_force.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: 'Restart instance systemd service'
+- name: 'Restart and enable instance systemd service'
   systemd:
     name: '{{ instance_info.systemd_service }}'
     state: restarted

--- a/tasks/steps/start_instance.yml
+++ b/tasks/steps/start_instance.yml
@@ -1,0 +1,8 @@
+---
+
+- name: 'Start and enable instance systemd service'
+  systemd:
+    name: '{{ instance_info.systemd_service }}'
+    state: started
+    enabled: true
+  tags: cartridge-instances

--- a/tasks/steps/stop_instance.yml
+++ b/tasks/steps/stop_instance.yml
@@ -1,0 +1,8 @@
+---
+
+- name: 'Stop and disable instance systemd service'
+  systemd:
+    name: '{{ instance_info.systemd_service }}'
+    state: stopped
+    enabled: false
+  tags: cartridge-instances


### PR DESCRIPTION
- Step `stop_instance` to stop and disable instance systemd service
- Step `start_instance` to start and enable instance systemd service
- Step `restart_instance_force` to restart systemd service without any conditions

Step `restart_instance` is reworked to check if the instance should be
restarted (if `needs_restart` flag is none).

Closes #220 