### PR TITLE
Fix role vars fact

### DIFF
--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import jinja2
+import yaml
+
+from ansible.module_utils.helpers import Helpers as helpers
+
+argument_spec = {
+    'vars': {'required': True, 'type': 'dict'},
+    'default_vars': {'required': True, 'type': 'dict'},
+}
+
+jinja_env = jinja2.Environment(loader=jinja2.BaseLoader())
+
+
+def resolve_var_values(all_vars, var_value):
+    if isinstance(var_value, list):
+        for value in var_value:
+            resolve_var_values(all_vars, value)
+
+    elif isinstance(var_value, dict):
+        for key, value in var_value.items():
+            var_value[key] = resolve_var_values(all_vars, value)
+
+    elif isinstance(var_value, str):
+        # For Ansible 2.8
+        old_value = None
+        new_value = var_value
+        while new_value != old_value:
+            old_value = new_value
+            new_value = jinja_env.from_string(old_value).render(**all_vars)
+
+        var_value = yaml.safe_load(new_value)
+
+    return var_value
+
+
+def get_cached_facts(params):
+    all_vars = params['vars']
+    default_vars = params['default_vars']
+
+    role_vars = {}
+    for var_name in default_vars:
+        role_vars[var_name] = resolve_var_values(all_vars, all_vars[var_name])
+
+    return helpers.ModuleRes(changed=False, facts={
+        'role_vars': role_vars,
+    })
+
+
+if __name__ == '__main__':
+    helpers.execute_module(argument_spec, get_cached_facts)

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -15,6 +15,9 @@ all:
         cartridge_defaults:
           some_option: 'default value'
 
+        common_memtx_memory_1: 134218000
+        common_memtx_memory_2: '{{ common_memtx_memory_1 * 2 }}'
+
         cartridge_bootstrap_vshard: true
         cartridge_failover_params:
           mode: stateful
@@ -82,7 +85,7 @@ all:
           config:
             advertise_uri: 'vm2:3201'
             http_port: 8201
-            memtx_memory: 268436000
+            memtx_memory: '{{ common_memtx_memory_2 }}'
           instance_start_timeout: 120
           instance_discover_buckets_timeout: 120
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tenacity~=6.3.1
 parameterized~=0.8.1
+jinja2~=2.11.3
 ansible~=2.10.6
 pytest-testinfra~=6.1.0
 flake8~=3.8.4

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: 'Set facts that can be set by the user'
+  set_fact:
+    delivered_package_path: '{{ cartridge_delivered_package_path | default(omit, true) }}'
+    control_instance: '{{ cartridge_control_instance | default(omit, true) }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+
 - name: 'Get default vars'
   include_vars:
     file: 'defaults/main.yml'
@@ -9,17 +17,15 @@
   become: false
   when: default_vars is not defined
 
-- name: 'Get final values of role vars for each instance'
-  set_fact:
-    role_vars: "{{ vars | dict2items | selectattr('key', 'in', default_vars) | list | items2dict }}"
+- name: 'Get cached facts for each instance'
+  cartridge_get_cached_facts:
+    vars: '{{ vars }}'
+    default_vars: '{{ default_vars }}'
+  register: cached_facts_res
 
-- name: 'Set facts that can be set by the user'
+- name: 'Set cached facts for each instance'
   set_fact:
-    delivered_package_path: '{{ cartridge_delivered_package_path | default(omit, true) }}'
-    control_instance: '{{ cartridge_control_instance | default(omit, true) }}'
-  run_once: true
-  delegate_to: localhost
-  become: false
+    role_vars: '{{ cached_facts_res.facts.role_vars }}'
 
 - name: 'Validate config'
   cartridge_validate_config:


### PR DESCRIPTION
Before this patch, complex variables (lists, dictionaries) were not fully expanded
on old Ansible versions. As a result, it was impossible to use other variables in
dictionaries and lists in `hosts.yml`.

Now such variables are expanded, so you can use variable value as `{{ other_var }}`.