### PR TITLE
Fix facts setting in `hostvars` fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Fixed
+
+- Fix facts setting in `hostvars` fact
+
 ## [1.8.1] - 2021-03-31
 
 ### Fixed

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -281,8 +281,7 @@ Some of useful facts are established during preparation, so you can use them at 
   for example, in `delegate_to`;
 - `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
   - `name` - name of step;
-  - `path` - path to YAML file of step;
-- `role_vars` - dictionary with all role variables.
+  - `path` - path to YAML file of step.
 
 ## Role Steps Description
 

--- a/library/cartridge_connect_to_membership.py
+++ b/library/cartridge_connect_to_membership.py
@@ -27,9 +27,6 @@ def connect_to_membership(params):
     changed = False
 
     for instance_name, instance_vars in hostvars.items():
-        if 'role_vars' in instance_vars:
-            instance_vars = instance_vars['role_vars']
-
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -116,7 +116,7 @@ def get_configured_replicasets(hostvars, play_hosts):
     replicasets = {}
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]['role_vars']
+        instance_vars = hostvars[instance_name]
 
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
@@ -144,7 +144,7 @@ def get_instances_to_configure(hostvars, play_hosts):
     instances = {}
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]['role_vars']
+        instance_vars = hostvars[instance_name]
 
         if helpers.is_stateboard(instance_vars):
             continue

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -105,7 +105,7 @@ def get_control_instance(params):
 
     if not control_instance_candidates:
         for instance_name in play_hosts:
-            instance_vars = hostvars[instance_name]['role_vars']
+            instance_vars = hostvars[instance_name]
 
             if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
                 continue
@@ -118,8 +118,6 @@ def get_control_instance(params):
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
     advertise_uris = [
-        hostvars[instance_name]['role_vars']['config']['advertise_uri']
-        if 'role_vars' in hostvars[instance_name] else
         hostvars[instance_name]['config']['advertise_uri']
         for instance_name in control_instance_candidates
     ]
@@ -135,8 +133,6 @@ def get_control_instance(params):
     # instance_vars['instance_info'], but if control instance is not
     # in play_hosts, instance_info isn't computed for it
     instance_vars = hostvars[control_instance_name]
-    if 'role_vars' in instance_vars:
-        instance_vars = instance_vars['role_vars']
     run_dir = instance_vars.get('cartridge_run_dir', helpers.DEFAULT_RUN_DIR)
     control_instance_console_sock = helpers.get_instance_console_sock(
         run_dir, app_name, control_instance_name,

--- a/library/cartridge_get_not_expelled_instance.py
+++ b/library/cartridge_get_not_expelled_instance.py
@@ -15,7 +15,7 @@ def get_one_not_expelled_instance(params):
     not_expelled_instance_name = None
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]['role_vars']
+        instance_vars = hostvars[instance_name]
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 

--- a/library/cartridge_get_single_instances_for_each_machine.py
+++ b/library/cartridge_get_single_instances_for_each_machine.py
@@ -25,7 +25,7 @@ def get_one_not_expelled_instance_for_machine(params):
     for instance_name in play_hosts:
         instance_vars = hostvars[instance_name]
 
-        if helpers.is_expelled(instance_vars['role_vars']):
+        if helpers.is_expelled(instance_vars):
             continue
 
         machine_hostname = get_machine_hostname(instance_vars, instance_name)

--- a/molecule/common/tests/test_cluster.py
+++ b/molecule/common/tests/test_cluster.py
@@ -147,6 +147,9 @@ def test_services_status_and_config(host):
         instance_vars = variable_manager.get_vars(host=instance)
 
         instance_conf = instance_vars['config']
+        if instance_conf.get('memtx_memory') == '{{ common_memtx_memory }}':
+            instance_conf['memtx_memory'] = 268436000
+
         instance_name = instance_vars['inventory_hostname']
 
         conf_dir = instance_vars.get('cartridge_conf_dir', '/etc/tarantool/conf.d')

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -12,6 +12,8 @@ all:
         # common cartridge opts
         cartridge_app_name: ['incorrect type to check playbook vars']
         cartridge_cluster_cookie: secret-cookie
+
+        common_memtx_memory: 268436000
         cartridge_defaults:
           some_option: 'default value'
 
@@ -82,7 +84,7 @@ all:
           config:
             advertise_uri: 'vm2:3201'
             http_port: 8201
-            memtx_memory: 268436000
+            memtx_memory: '{{ common_memtx_memory }}'
           instance_start_timeout: 120
           instance_discover_buckets_timeout: 120
 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,17 +1,6 @@
 ---
 
-- name: 'Get default vars'
-  include_vars:
-    file: 'defaults/main.yml'
-    name: default_vars
-  run_once: true
-  delegate_to: localhost
-  become: false
-  when: default_vars is not defined
-
-- name: 'Get final values of role vars for each instance'
-  set_fact:
-    role_vars: "{{ vars | dict2items | selectattr('key', 'in', default_vars) | list | items2dict }}"
+- import_tasks: 'set_instance_facts.yml'
 
 - name: 'Set facts that can be set by the user'
   set_fact:

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -1,0 +1,96 @@
+---
+
+- name: 'Set instance facts'
+  set_fact:
+
+    # Common variables
+
+    cartridge_app_name: '{{ cartridge_app_name }}'
+    cartridge_cluster_cookie: '{{ cartridge_cluster_cookie }}'
+    cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
+
+    # Role scenario configuration
+
+    cartridge_scenario: '{{ cartridge_scenario }}'
+    cartridge_custom_steps_dir: '{{ cartridge_custom_steps_dir }}'
+    cartridge_custom_steps: '{{ cartridge_custom_steps }}'
+
+    cartridge_scenario_name: '{{ cartridge_scenario_name }}'
+    cartridge_custom_scenarios: '{{ cartridge_custom_scenarios }}'
+    cartridge_role_scenarios: '{{ cartridge_role_scenarios }}'
+
+    # Application package configuration
+
+    cartridge_package_path: '{{ cartridge_package_path }}'
+    cartridge_enable_tarantool_repo: '{{ cartridge_enable_tarantool_repo }}'
+
+    # TGZ specific configuration
+
+    cartridge_multiversion: '{{ cartridge_multiversion }}'
+
+    cartridge_install_tarantool_for_tgz: '{{ cartridge_install_tarantool_for_tgz }}'
+
+    cartridge_app_user: '{{ cartridge_app_user }}'
+    cartridge_app_group: '{{ cartridge_app_group }}'
+
+    cartridge_data_dir: '{{ cartridge_data_dir }}'
+    cartridge_memtx_dir_parent: '{{ cartridge_memtx_dir_parent }}'
+    cartridge_vinyl_dir_parent: '{{ cartridge_vinyl_dir_parent }}'
+    cartridge_wal_dir_parent: '{{ cartridge_wal_dir_parent }}'
+    cartridge_run_dir: '{{ cartridge_run_dir }}'
+    cartridge_conf_dir: '{{ cartridge_conf_dir }}'
+    cartridge_app_install_dir: '{{ cartridge_app_install_dir }}'
+    cartridge_app_instances_dir: '{{ cartridge_app_instances_dir }}'
+
+    cartridge_configure_systemd_unit_files: '{{ cartridge_configure_systemd_unit_files }}'
+    cartridge_systemd_dir: '{{ cartridge_systemd_dir }}'
+
+    cartridge_configure_tmpfiles: '{{ cartridge_configure_tmpfiles }}'
+    cartridge_tmpfiles_dir: '{{ cartridge_tmpfiles_dir }}'
+
+    cartridge_keep_num_latest_dists: '{{ cartridge_keep_num_latest_dists }}'
+
+    # Instances configuration
+
+    cartridge_defaults: '{{ cartridge_defaults }}'
+    config: '{{ config }}'
+    zone: '{{ zone }}'
+
+    restarted: '{{ restarted }}'
+    expelled: '{{ expelled }}'
+    stateboard: '{{ stateboard }}'
+
+    cartridge_wait_buckets_discovery: '{{ cartridge_wait_buckets_discovery }}'
+    instance_start_timeout: '{{ instance_start_timeout }}'
+    instance_discover_buckets_timeout: '{{ instance_discover_buckets_timeout }}'
+
+    # Replicasets configuration
+
+    replicaset_alias: '{{ replicaset_alias }}'
+    failover_priority: '{{ failover_priority }}'
+    roles: '{{ roles }}'
+    all_rw: '{{ all_rw }}'
+    vshard_group: '{{ vshard_group }}'
+    weight: '{{ weight }}'
+    edit_topology_timeout: '{{ edit_topology_timeout }}'
+
+    ## Cluster configuration
+
+    cartridge_bootstrap_vshard: '{{ cartridge_bootstrap_vshard }}'
+    cartridge_app_config: '{{ cartridge_app_config }}'
+    cartridge_auth: '{{ cartridge_auth }}'
+    cartridge_failover: '{{ cartridge_failover }}'
+    cartridge_failover_params: '{{ cartridge_failover_params }}'
+
+    # Internal role facts that can be set by the user
+
+    cartridge_delivered_package_path: '{{ cartridge_delivered_package_path }}'
+    cartridge_control_instance: '{{ cartridge_control_instance }}'
+
+    # Cross-step facts (for correct 'tasks_from' option usage)
+
+    delivered_package_path: '{{ delivered_package_path }}'
+    control_instance: '{{ control_instance }}'
+    temporary_files: '{{ temporary_files }}'
+    needs_restart: '{{ needs_restart }}'
+    non_expelled_instance: '{{ non_expelled_instance }}'

--- a/unit/test_connect_to_membership.py
+++ b/unit/test_connect_to_membership.py
@@ -8,15 +8,9 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_connect_to_membership import connect_to_membership
 
 
-def call_probe_instance(console_sock, role_vars, play_hosts=None):
+def call_probe_instance(console_sock, hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = role_vars.keys()
-
-    hostvars = {}
-    for instance_name, instance_role_vars in role_vars.items():
-        hostvars[instance_name] = {
-            'role_vars': instance_role_vars
-        }
+        play_hosts = hostvars.keys()
 
     return connect_to_membership({
         'console_sock': console_sock,
@@ -50,7 +44,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 }
@@ -66,7 +60,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -89,7 +83,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-2': {
                     'config': {'advertise_uri': URI2},
                 }
@@ -105,7 +99,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -132,7 +126,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-2': {
                     'expelled': True,
                     'config': {'advertise_uri': URI2},
@@ -148,7 +142,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -171,7 +165,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-2': {
                     'restarted': True,
                     'config': {'advertise_uri': URI2},
@@ -193,7 +187,7 @@ class TestProbeInstance(unittest.TestCase):
 
         res = call_probe_instance(
             console_sock=self.console_sock,
-            role_vars={
+            hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -8,15 +8,9 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_edit_topology import edit_topology
 
 
-def call_edit_topology(console_sock, role_vars, play_hosts=None, timeout=60):
+def call_edit_topology(console_sock, hostvars, play_hosts=None, timeout=60):
     if play_hosts is None:
-        play_hosts = role_vars.keys()
-
-    hostvars = {}
-    for instance_name, instance_role_vars in role_vars.items():
-        hostvars[instance_name] = {
-            'role_vars': instance_role_vars
-        }
+        play_hosts = hostvars.keys()
 
     return edit_topology({
         'console_sock': console_sock,

--- a/unit/test_edit_topology_helpers.py
+++ b/unit/test_edit_topology_helpers.py
@@ -10,15 +10,9 @@ from library.cartridge_edit_topology import get_replicaset_params
 from library.cartridge_edit_topology import get_server_params
 
 
-def call_get_configured_replicasets(role_vars, play_hosts=None):
+def call_get_configured_replicasets(hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = role_vars.keys()
-
-    hostvars = {}
-    for instance_name, instance_role_vars in role_vars.items():
-        hostvars[instance_name] = {
-            'role_vars': instance_role_vars
-        }
+        play_hosts = hostvars.keys()
 
     return get_configured_replicasets(hostvars, play_hosts)
 
@@ -117,7 +111,7 @@ class TestGetConfiguredReplicasets(unittest.TestCase):
 
 class TestGetInstancesToConfigure(unittest.TestCase):
     def test_get_instances_to_configure(self):
-        role_vars = {
+        hostvars = {
             'instance-expelled': {  # expelled
                 'replicaset_alias': 'replicaset-1',
                 'expelled': True,
@@ -150,13 +144,7 @@ class TestGetInstancesToConfigure(unittest.TestCase):
         }
 
         # found instances to configure
-        play_hosts = role_vars.keys()
-
-        hostvars = {}
-        for instance_name, instance_role_vars in role_vars.items():
-            hostvars[instance_name] = {
-                'role_vars': instance_role_vars
-            }
+        play_hosts = hostvars.keys()
 
         instances = get_instances_to_configure(hostvars, play_hosts)
         self.assertEqual(instances, {

--- a/unit/test_get_control_instance.py
+++ b/unit/test_get_control_instance.py
@@ -22,18 +22,12 @@ def get_twophase_commit_versions_mock(_, advertise_uris):
 get_control_instance_lib.get_twophase_commit_versions = get_twophase_commit_versions_mock
 
 
-def call_get_control_instance(app_name, console_sock, role_vars=None, play_hosts=None):
-    if role_vars is None:
-        role_vars = {}
+def call_get_control_instance(app_name, console_sock, hostvars=None, play_hosts=None):
+    if hostvars is None:
+        hostvars = {}
 
     if play_hosts is None:
-        play_hosts = role_vars.keys()
-
-    hostvars = {}
-    for instance_name, instance_role_vars in role_vars.items():
-        hostvars[instance_name] = {
-            'role_vars': instance_role_vars
-        }
+        play_hosts = hostvars.keys()
 
     return get_control_instance({
         'hostvars': hostvars,

--- a/unit/test_get_non_expelled_instance.py
+++ b/unit/test_get_non_expelled_instance.py
@@ -21,25 +21,22 @@ class TestGetOneNotExpelledInstance(unittest.TestCase):
     def setUp(self):
         self.hostvars = {
             'expelled-1': {
-                'role_vars': {'expelled': True},
+                'expelled': True,
             },
             'my-stateboard': {
-                'role_vars': {'stateboard': True},
+                'stateboard': True,
             },
             'expelled-2': {
-                'role_vars': {'expelled': True},
+                'expelled': True,
             },
             'instance-1': {
                 'instance_info': {'console_sock': 'sock-1'},
-                'role_vars': {},
             },
             'instance-2': {
                 'instance_info': {'console_sock': 'sock-2'},
-                'role_vars': {},
             },
             'instance-3': {
                 'instance_info': {'console_sock': 'sock-3'},
-                'role_vars': {},
             },
         }
 

--- a/unit/test_get_single_instances_for_each_machine.py
+++ b/unit/test_get_single_instances_for_each_machine.py
@@ -22,35 +22,25 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
         self.hostvars = {
             'stateboard-1': {
                 'ansible_host': 'host-1',
-                'role_vars': {
-                    'stateboard': True,
-                },
+                'stateboard': True,
             },
             'expelled-1': {
                 'ansible_host': 'host-1',
-                'role_vars': {
-                    'expelled': True,
-                },
+                'expelled': True,
             },
             'instance-1': {
                 'ansible_host': 'host-1',
-                'role_vars': {},
             },
             'stateboard-2': {
                 'ansible_host': 'host-2',
-                'role_vars': {
-                    'stateboard': True,
-                },
+                'stateboard': True,
             },
             'expelled-2': {
                 'ansible_host': 'host-2',
-                'role_vars': {
-                    'expelled': True,
-                },
+                'expelled': True,
             },
             'instance-2': {
                 'ansible_host': 'host-2',
-                'role_vars': {},
             },
         }
 

--- a/unit/test_set_instance_facts_task.py
+++ b/unit/test_set_instance_facts_task.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+import yaml
+
+
+class TestSetInstanceFacts(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+        role_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+
+        self.defaults_file = os.path.join(role_dir, 'defaults', 'main.yml')
+        with open(self.defaults_file, 'r') as f:
+            try:
+                self.defaults = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                self.fail(f"Impossible to parse 'set_instance_facts.yml': {e}")
+
+        self.set_instance_facts_file = os.path.join(role_dir, 'tasks', 'set_instance_facts.yml')
+        with open(self.set_instance_facts_file, 'r') as f:
+            try:
+                self.set_instance_facts = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                self.fail(f"Impossible to parse 'set_instance_facts.yml': {e}")
+
+    # This test protects against inattentive people, who do not completely change the variables list
+    # (if someone added a variable to defaults, but forgot to set it in 'set_instance_facts' step)
+    def test_set_instance_facts(self):
+        default_names = list(self.defaults.keys())
+        set_instance_facts_name = list(self.set_instance_facts[0]['set_fact'].keys())
+
+        self.assertEqual(default_names, set_instance_facts_name)

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -8,15 +8,9 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_validate_config import validate_config
 
 
-def call_validate_config(role_vars, play_hosts=None):
+def call_validate_config(hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = role_vars.keys()
-
-    hostvars = {}
-    for instance_name, instance_role_vars in role_vars.items():
-        hostvars[instance_name] = {
-            'role_vars': instance_role_vars
-        }
+        play_hosts = hostvars.keys()
 
     return validate_config({
         'hosts': play_hosts,


### PR DESCRIPTION
Before this patch, complex variables (lists, dictionaries) were not fully expanded
on old Ansible versions (2.8 or earlier). As a result, it was impossible to use other
variables (e.g. `{{ common_memtx }}` value) in dictionaries and lists in `hosts.yml`.

We are now using the standard `set_fact` mechanism, which solves this problem.