### PR TITLE
Speed up tasks that use `hostsvars`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Changed
+
+- Now only the necessary information will be transferred in tasks,
+  which used `hostvars`. Due to this duration of these tasks was reduced.
+
 ## [1.8.2] - 2021-04-01
 
 ### Fixed

--- a/library/cartridge_connect_to_membership.py
+++ b/library/cartridge_connect_to_membership.py
@@ -4,7 +4,7 @@ from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
     'console_sock': {'required': True, 'type': 'str'},
-    'facts': {'required': True, 'type': 'dict'},
+    'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
@@ -21,12 +21,12 @@ def probe_server(control_console, uri):
 
 def connect_to_membership(params):
     control_console = helpers.get_control_console(params['console_sock'])
-    facts = params['facts']
+    module_hostvars = params['module_hostvars']
     play_hosts = params['play_hosts']
 
     changed = False
 
-    for instance_name, instance_vars in facts.items():
+    for instance_name, instance_vars in module_hostvars.items():
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 

--- a/library/cartridge_connect_to_membership.py
+++ b/library/cartridge_connect_to_membership.py
@@ -4,7 +4,7 @@ from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
     'console_sock': {'required': True, 'type': 'str'},
-    'hostvars': {'required': True, 'type': 'dict'},
+    'facts': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
@@ -21,12 +21,12 @@ def probe_server(control_console, uri):
 
 def connect_to_membership(params):
     control_console = helpers.get_control_console(params['console_sock'])
-    hostvars = params['hostvars']
+    facts = params['facts']
     play_hosts = params['play_hosts']
 
     changed = False
 
-    for instance_name, instance_vars in hostvars.items():
+    for instance_name, instance_vars in facts.items():
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -5,7 +5,7 @@ import time
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'hostvars': {'required': True, 'type': 'dict'},
+    'facts': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
     'console_sock': {'required': True, 'type': 'str'},
     'timeout': {'required': True, 'type': 'int'},
@@ -112,11 +112,11 @@ def get_cluster_instances(control_console):
     return instances
 
 
-def get_configured_replicasets(hostvars, play_hosts):
+def get_configured_replicasets(facts, play_hosts):
     replicasets = {}
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]
+        instance_vars = facts[instance_name]
 
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
@@ -140,11 +140,11 @@ def get_configured_replicasets(hostvars, play_hosts):
     return replicasets
 
 
-def get_instances_to_configure(hostvars, play_hosts):
+def get_instances_to_configure(facts, play_hosts):
     instances = {}
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]
+        instance_vars = facts[instance_name]
 
         if helpers.is_stateboard(instance_vars):
             continue
@@ -455,12 +455,12 @@ def update_cluster_instances_and_replicasets(
 
 def edit_topology(params):
     console_sock = params['console_sock']
-    hostvars = params['hostvars']
+    facts = params['facts']
     play_hosts = params['play_hosts']
     timeout = params['timeout']
 
-    replicasets = get_configured_replicasets(hostvars, play_hosts)
-    instances = get_instances_to_configure(hostvars, play_hosts)
+    replicasets = get_configured_replicasets(facts, play_hosts)
+    instances = get_instances_to_configure(facts, play_hosts)
 
     if not replicasets and not instances:
         return helpers.ModuleRes(changed=False)

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -5,7 +5,7 @@ import time
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'facts': {'required': True, 'type': 'dict'},
+    'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
     'console_sock': {'required': True, 'type': 'str'},
     'timeout': {'required': True, 'type': 'int'},
@@ -112,11 +112,11 @@ def get_cluster_instances(control_console):
     return instances
 
 
-def get_configured_replicasets(facts, play_hosts):
+def get_configured_replicasets(module_hostvars, play_hosts):
     replicasets = {}
 
     for instance_name in play_hosts:
-        instance_vars = facts[instance_name]
+        instance_vars = module_hostvars[instance_name]
 
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
@@ -140,11 +140,11 @@ def get_configured_replicasets(facts, play_hosts):
     return replicasets
 
 
-def get_instances_to_configure(facts, play_hosts):
+def get_instances_to_configure(module_hostvars, play_hosts):
     instances = {}
 
     for instance_name in play_hosts:
-        instance_vars = facts[instance_name]
+        instance_vars = module_hostvars[instance_name]
 
         if helpers.is_stateboard(instance_vars):
             continue
@@ -455,12 +455,12 @@ def update_cluster_instances_and_replicasets(
 
 def edit_topology(params):
     console_sock = params['console_sock']
-    facts = params['facts']
+    module_hostvars = params['module_hostvars']
     play_hosts = params['play_hosts']
     timeout = params['timeout']
 
-    replicasets = get_configured_replicasets(facts, play_hosts)
-    instances = get_instances_to_configure(facts, play_hosts)
+    replicasets = get_configured_replicasets(module_hostvars, play_hosts)
+    instances = get_instances_to_configure(module_hostvars, play_hosts)
 
     if not replicasets and not instances:
         return helpers.ModuleRes(changed=False)

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -6,27 +6,32 @@ argument_spec = {
     'hostvars': {'required': True, 'type': 'dict'},
 }
 
-sets_list = {
+FACTS_BY_TARGETS = {
     'validate_config': [
         'all_rw',
         'cartridge_app_config',
+        'cartridge_app_install_dir',
+        'cartridge_app_instances_dir',
+        'cartridge_app_group',
         'cartridge_app_name',
+        'cartridge_app_user',
         'cartridge_auth',
         'cartridge_bootstrap_vshard',
         'cartridge_cluster_cookie',
         'cartridge_conf_dir',
         'cartridge_configure_systemd_unit_files',
         'cartridge_configure_tmpfiles',
+        'cartridge_control_instance',
+        'cartridge_custom_scenarios',
         'cartridge_custom_steps',
         'cartridge_custom_steps_dir',
         'cartridge_data_dir',
         'cartridge_defaults',
+        'cartridge_delivered_package_path',
         'cartridge_enable_tarantool_repo',
         'cartridge_failover',
         'cartridge_failover_params',
-        'cartridge_install_dir',
         'cartridge_install_tarantool_for_tgz',
-        'cartridge_instances_dir',
         'cartridge_keep_num_latest_dists',
         'cartridge_memtx_dir_parent',
         'cartridge_multiversion',
@@ -34,6 +39,7 @@ sets_list = {
         'cartridge_remove_temporary_files',
         'cartridge_run_dir',
         'cartridge_scenario',
+        'cartridge_scenario_name',
         'cartridge_systemd_dir',
         'cartridge_tmpfiles_dir',
         'cartridge_vinyl_dir_parent',
@@ -89,23 +95,21 @@ sets_list = {
 }
 
 
-def get_scenario_steps(params):
+def get_cached_facts(params):
     hostvars = params['hostvars']
 
     facts = {}
-    for host_name in hostvars:
-        instance_vars = hostvars[host_name]
-
-        for set_name, fact_names in sets_list.items():
-            facts[set_name] = facts.get(set_name, {})
-            facts[set_name][host_name] = facts[set_name].get(host_name, {})
+    for instance_name, instance_vars in hostvars.items():
+        for target, fact_names in FACTS_BY_TARGETS.items():
+            facts[target] = facts.get(target, {})
+            facts[target][instance_name] = facts[target].get(instance_name, {})
 
             for fact_name in fact_names:
                 if fact_name in instance_vars:
-                    facts[set_name][host_name][fact_name] = instance_vars[fact_name]
+                    facts[target][instance_name][fact_name] = instance_vars[fact_name]
 
     return helpers.ModuleRes(changed=False, facts=facts)
 
 
 if __name__ == '__main__':
-    helpers.execute_module(argument_spec, get_scenario_steps)
+    helpers.execute_module(argument_spec, get_cached_facts)

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -3,7 +3,7 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'hostvars': {'required': True, 'type': 'dict'},
+    'facts': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
     'console_sock': {'required': True, 'type': 'str'},
     'app_name': {'required': True, 'type': 'str'},
@@ -73,7 +73,7 @@ def get_twophase_commit_versions(control_console, advertise_uris):
 
 
 def get_control_instance(params):
-    hostvars = params['hostvars']
+    facts = params['facts']
     play_hosts = params['play_hosts']
     console_sock = params['console_sock']
     app_name = params['app_name']
@@ -98,14 +98,14 @@ def get_control_instance(params):
                 return helpers.ModuleRes(failed=True, msg='Instance %s payload does not contain alias' % uri)
 
             instance_name = member_payload['alias']
-            if instance_name not in hostvars:
+            if instance_name not in facts:
                 continue
 
             control_instance_candidates.append(instance_name)
 
     if not control_instance_candidates:
         for instance_name in play_hosts:
-            instance_vars = hostvars[instance_name]
+            instance_vars = facts[instance_name]
 
             if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
                 continue
@@ -118,7 +118,7 @@ def get_control_instance(params):
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
     advertise_uris = [
-        hostvars[instance_name]['config']['advertise_uri']
+        facts[instance_name]['config']['advertise_uri']
         for instance_name in control_instance_candidates
     ]
 
@@ -132,7 +132,7 @@ def get_control_instance(params):
     # in the ideal imagined world we could just use
     # instance_vars['instance_info'], but if control instance is not
     # in play_hosts, instance_info isn't computed for it
-    instance_vars = hostvars[control_instance_name]
+    instance_vars = facts[control_instance_name]
     run_dir = instance_vars.get('cartridge_run_dir', helpers.DEFAULT_RUN_DIR)
     control_instance_console_sock = helpers.get_instance_console_sock(
         run_dir, app_name, control_instance_name,

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -3,7 +3,7 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'facts': {'required': True, 'type': 'dict'},
+    'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
     'console_sock': {'required': True, 'type': 'str'},
     'app_name': {'required': True, 'type': 'str'},
@@ -73,7 +73,7 @@ def get_twophase_commit_versions(control_console, advertise_uris):
 
 
 def get_control_instance(params):
-    facts = params['facts']
+    module_hostvars = params['module_hostvars']
     play_hosts = params['play_hosts']
     console_sock = params['console_sock']
     app_name = params['app_name']
@@ -98,14 +98,14 @@ def get_control_instance(params):
                 return helpers.ModuleRes(failed=True, msg='Instance %s payload does not contain alias' % uri)
 
             instance_name = member_payload['alias']
-            if instance_name not in facts:
+            if instance_name not in module_hostvars:
                 continue
 
             control_instance_candidates.append(instance_name)
 
     if not control_instance_candidates:
         for instance_name in play_hosts:
-            instance_vars = facts[instance_name]
+            instance_vars = module_hostvars[instance_name]
 
             if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
                 continue
@@ -118,7 +118,7 @@ def get_control_instance(params):
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
     advertise_uris = [
-        facts[instance_name]['config']['advertise_uri']
+        module_hostvars[instance_name]['config']['advertise_uri']
         for instance_name in control_instance_candidates
     ]
 
@@ -132,7 +132,7 @@ def get_control_instance(params):
     # in the ideal imagined world we could just use
     # instance_vars['instance_info'], but if control instance is not
     # in play_hosts, instance_info isn't computed for it
-    instance_vars = facts[control_instance_name]
+    instance_vars = module_hostvars[control_instance_name]
     run_dir = instance_vars.get('cartridge_run_dir', helpers.DEFAULT_RUN_DIR)
     control_instance_console_sock = helpers.get_instance_console_sock(
         run_dir, app_name, control_instance_name,

--- a/library/cartridge_get_not_expelled_instance.py
+++ b/library/cartridge_get_not_expelled_instance.py
@@ -3,19 +3,19 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'facts': {'required': True, 'type': 'dict'},
+    'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
 
 def get_one_not_expelled_instance(params):
-    facts = params['facts']
+    module_hostvars = params['module_hostvars']
     play_hosts = params['play_hosts']
 
     not_expelled_instance_name = None
 
     for instance_name in play_hosts:
-        instance_vars = facts[instance_name]
+        instance_vars = module_hostvars[instance_name]
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 
@@ -26,7 +26,7 @@ def get_one_not_expelled_instance(params):
         errmsg = "Not found any instance that is not expelled and is not a stateboard"
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
-    instance_info = facts[not_expelled_instance_name]['instance_info']
+    instance_info = module_hostvars[not_expelled_instance_name]['instance_info']
 
     return helpers.ModuleRes(changed=False, fact={
         'name': not_expelled_instance_name,

--- a/library/cartridge_get_not_expelled_instance.py
+++ b/library/cartridge_get_not_expelled_instance.py
@@ -3,19 +3,19 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'hostvars': {'required': True, 'type': 'dict'},
+    'facts': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
 
 def get_one_not_expelled_instance(params):
-    hostvars = params['hostvars']
+    facts = params['facts']
     play_hosts = params['play_hosts']
 
     not_expelled_instance_name = None
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]
+        instance_vars = facts[instance_name]
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 
@@ -26,7 +26,7 @@ def get_one_not_expelled_instance(params):
         errmsg = "Not found any instance that is not expelled and is not a stateboard"
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
-    instance_info = hostvars[not_expelled_instance_name]['instance_info']
+    instance_info = facts[not_expelled_instance_name]['instance_info']
 
     return helpers.ModuleRes(changed=False, fact={
         'name': not_expelled_instance_name,

--- a/library/cartridge_get_shortened_fact_sets.py
+++ b/library/cartridge_get_shortened_fact_sets.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+from ansible.module_utils.helpers import Helpers as helpers
+
+argument_spec = {
+    'hostvars': {'required': True, 'type': 'dict'},
+}
+
+sets_list = {
+    'validate_config': [
+        'all_rw',
+        'cartridge_app_config',
+        'cartridge_app_name',
+        'cartridge_auth',
+        'cartridge_bootstrap_vshard',
+        'cartridge_cluster_cookie',
+        'cartridge_conf_dir',
+        'cartridge_configure_systemd_unit_files',
+        'cartridge_configure_tmpfiles',
+        'cartridge_custom_steps',
+        'cartridge_custom_steps_dir',
+        'cartridge_data_dir',
+        'cartridge_defaults',
+        'cartridge_enable_tarantool_repo',
+        'cartridge_failover',
+        'cartridge_failover_params',
+        'cartridge_install_dir',
+        'cartridge_install_tarantool_for_tgz',
+        'cartridge_instances_dir',
+        'cartridge_keep_num_latest_dists',
+        'cartridge_memtx_dir_parent',
+        'cartridge_multiversion',
+        'cartridge_package_path',
+        'cartridge_remove_temporary_files',
+        'cartridge_run_dir',
+        'cartridge_scenario',
+        'cartridge_systemd_dir',
+        'cartridge_tmpfiles_dir',
+        'cartridge_vinyl_dir_parent',
+        'cartridge_wait_buckets_discovery',
+        'cartridge_wal_dir_parent',
+        'config',
+        'edit_topology_timeout',
+        'expelled',
+        'failover_priority',
+        'instance_discover_buckets_timeout',
+        'instance_start_timeout',
+        'replicaset_alias',
+        'restarted',
+        'roles',
+        'stateboard',
+        'vshard_group',
+        'weight',
+        'zone',
+    ],
+    'single_instances_for_each_machine': [
+        'expelled',
+        'ansible_host',
+    ],
+    'connect_to_membership': [
+        'expelled',
+        'stateboard',
+        'config',
+    ],
+    'not_expelled_instance': [
+        'expelled',
+        'stateboard',
+        'instance_info',
+    ],
+    'control_instance': [
+        'expelled',
+        'stateboard',
+        'config',
+        'replicaset_alias',
+        'cartridge_run_dir',
+    ],
+    'edit_topology': [
+        'expelled',
+        'stateboard',
+        'replicaset_alias',
+        'roles',
+        'failover_priority',
+        'all_rw',
+        'weight',
+        'vshard_group',
+        'zone',
+        'config',
+    ],
+}
+
+
+def get_scenario_steps(params):
+    hostvars = params['hostvars']
+
+    facts = {}
+    for host_name in hostvars:
+        instance_vars = hostvars[host_name]
+
+        for set_name, fact_names in sets_list.items():
+            facts[set_name] = facts.get(set_name, {})
+            facts[set_name][host_name] = facts[set_name].get(host_name, {})
+
+            for fact_name in fact_names:
+                if fact_name in instance_vars:
+                    facts[set_name][host_name][fact_name] = instance_vars[fact_name]
+
+    return helpers.ModuleRes(changed=False, facts=facts)
+
+
+if __name__ == '__main__':
+    helpers.execute_module(argument_spec, get_scenario_steps)

--- a/library/cartridge_get_single_instances_for_each_machine.py
+++ b/library/cartridge_get_single_instances_for_each_machine.py
@@ -3,7 +3,7 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'hostvars': {'required': True, 'type': 'dict'},
+    'facts': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
@@ -16,14 +16,14 @@ def get_machine_hostname(instance_vars, instance_name):
 
 
 def get_one_not_expelled_instance_for_machine(params):
-    hostvars = params['hostvars']
+    facts = params['facts']
     play_hosts = params['play_hosts']
 
     machine_hostnames = set()
     instance_names = []
 
     for instance_name in play_hosts:
-        instance_vars = hostvars[instance_name]
+        instance_vars = facts[instance_name]
 
         if helpers.is_expelled(instance_vars):
             continue

--- a/library/cartridge_get_single_instances_for_each_machine.py
+++ b/library/cartridge_get_single_instances_for_each_machine.py
@@ -3,7 +3,7 @@
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'facts': {'required': True, 'type': 'dict'},
+    'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
@@ -16,14 +16,14 @@ def get_machine_hostname(instance_vars, instance_name):
 
 
 def get_one_not_expelled_instance_for_machine(params):
-    facts = params['facts']
+    module_hostvars = params['module_hostvars']
     play_hosts = params['play_hosts']
 
     machine_hostnames = set()
     instance_names = []
 
     for instance_name in play_hosts:
-        instance_vars = facts[instance_name]
+        instance_vars = module_hostvars[instance_name]
 
         if helpers.is_expelled(instance_vars):
             continue

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -7,7 +7,7 @@ from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
     'play_hosts': {'required': True, 'type': 'list'},
-    'facts': {'required': True, 'type': 'dict'}
+    'module_hostvars': {'required': True, 'type': 'dict'}
 }
 
 INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'cartridge_cluster_cookie', 'config']
@@ -479,7 +479,7 @@ def validate_config(params):
     warnings = []
 
     for host in params['play_hosts']:
-        instance_vars = params['facts'][host]
+        instance_vars = params['module_hostvars'][host]
 
         # Validate types
         errmsg = validate_types(instance_vars)

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -6,7 +6,7 @@ import re
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'hosts': {'required': True, 'type': 'list'},
+    'play_hosts': {'required': True, 'type': 'list'},
     'hostvars': {'required': True, 'type': 'dict'}
 }
 
@@ -478,7 +478,7 @@ def validate_config(params):
 
     warnings = []
 
-    for host in params['hosts']:
+    for host in params['play_hosts']:
         instance_vars = params['hostvars'][host]
 
         # Validate types

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -7,7 +7,7 @@ from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
     'play_hosts': {'required': True, 'type': 'list'},
-    'hostvars': {'required': True, 'type': 'dict'}
+    'facts': {'required': True, 'type': 'dict'}
 }
 
 INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'cartridge_cluster_cookie', 'config']
@@ -75,6 +75,90 @@ STATEBOARD_CONFIG_REQUIRED_PARAMS = [
     'password',
 ]
 
+SCHEMA = {
+    'cartridge_package_path': str,
+    'cartridge_app_name': str,
+    'cartridge_cluster_cookie': str,
+    'cartridge_defaults': dict,
+    'cartridge_bootstrap_vshard': bool,
+    'cartridge_wait_buckets_discovery': bool,
+    'cartridge_failover': bool,
+    'cartridge_app_config': dict,
+    'cartridge_scenario': list,
+    'cartridge_custom_steps_dir': str,
+    'cartridge_custom_steps': list,
+    'cartridge_scenario_name': str,
+    'cartridge_custom_scenarios': dict,
+    'restarted': bool,
+    'expelled': bool,
+    'stateboard': bool,
+    'cartridge_multiversion': bool,
+    'instance_start_timeout': int,
+    'instance_discover_buckets_timeout': int,
+    'edit_topology_timeout': int,
+    'replicaset_alias': str,
+    'failover_priority': [str],
+    'roles': [str],
+    'all_rw': bool,
+    'weight': int,
+    'vshard_group': str,
+    'cartridge_enable_tarantool_repo': bool,
+    'cartridge_conf_dir': str,
+    'cartridge_run_dir': str,
+    'cartridge_data_dir': str,
+    'cartridge_app_user': str,
+    'cartridge_app_group': str,
+    'cartridge_app_install_dir': str,
+    'cartridge_app_instances_dir': str,
+    'cartridge_delivered_package_path': str,
+    'cartridge_control_instance': dict,
+    'cartridge_memtx_dir_parent': str,
+    'cartridge_vinyl_dir_parent': str,
+    'cartridge_wal_dir_parent': str,
+    'cartridge_configure_systemd_unit_files': bool,
+    'cartridge_systemd_dir': str,
+    'cartridge_configure_tmpfiles': bool,
+    'cartridge_tmpfiles_dir': str,
+    'cartridge_install_tarantool_for_tgz': bool,
+    'cartridge_keep_num_latest_dists': int,
+    'cartridge_remove_temporary_files': bool,
+    'zone': str,
+    'config': {
+        'advertise_uri': str,
+        'memtx_memory': int,
+    },
+    'cartridge_auth': {
+        'enabled': bool,
+        'cookie_max_age': int,
+        'cookie_renew_age': int,
+        'users': [
+            {
+                'username': str,
+                'password': str,
+                'fullname': str,
+                'email': str,
+                'deleted': bool,
+            }
+        ]
+    },
+    'cartridge_failover_params': {
+        'enabled': bool,
+        'mode': str,
+        'state_provider': str,
+        'stateboard_params': {
+            'uri': str,
+            'password': str
+        },
+        'etcd2_params': {
+            'prefix': str,
+            'lock_delay': int,
+            'endpoints': [str],
+            'username': str,
+            'password': str,
+        },
+    }
+}
+
 
 def is_valid_advertise_uri(uri):
     rgx = re.compile(r'^\S+:\d+$')
@@ -111,92 +195,8 @@ def check_schema(schema, conf, path=''):
         return 'Wrong type'
 
 
-def validate_types(vars):
-    schema = {
-        'cartridge_package_path': str,
-        'cartridge_app_name': str,
-        'cartridge_cluster_cookie': str,
-        'cartridge_defaults': dict,
-        'cartridge_bootstrap_vshard': bool,
-        'cartridge_wait_buckets_discovery': bool,
-        'cartridge_failover': bool,
-        'cartridge_app_config': dict,
-        'cartridge_scenario': list,
-        'cartridge_custom_steps_dir': str,
-        'cartridge_custom_steps': list,
-        'cartridge_scenario_name': str,
-        'cartridge_custom_scenarios': dict,
-        'restarted': bool,
-        'expelled': bool,
-        'stateboard': bool,
-        'cartridge_multiversion': bool,
-        'instance_start_timeout': int,
-        'instance_discover_buckets_timeout': int,
-        'edit_topology_timeout': int,
-        'replicaset_alias': str,
-        'failover_priority': [str],
-        'roles': [str],
-        'all_rw': bool,
-        'weight': int,
-        'vshard_group': str,
-        'cartridge_enable_tarantool_repo': bool,
-        'cartridge_conf_dir': str,
-        'cartridge_run_dir': str,
-        'cartridge_data_dir': str,
-        'cartridge_app_user': str,
-        'cartridge_app_group': str,
-        'cartridge_app_install_dir': str,
-        'cartridge_app_instances_dir': str,
-        'cartridge_delivered_package_path': str,
-        'cartridge_control_instance': dict,
-        'cartridge_memtx_dir_parent': str,
-        'cartridge_vinyl_dir_parent': str,
-        'cartridge_wal_dir_parent': str,
-        'cartridge_configure_systemd_unit_files': bool,
-        'cartridge_systemd_dir': str,
-        'cartridge_configure_tmpfiles': bool,
-        'cartridge_tmpfiles_dir': str,
-        'cartridge_install_tarantool_for_tgz': bool,
-        'cartridge_keep_num_latest_dists': int,
-        'cartridge_remove_temporary_files': bool,
-        'zone': str,
-        'config': {
-            'advertise_uri': str,
-            'memtx_memory': int,
-        },
-        'cartridge_auth': {
-            'enabled': bool,
-            'cookie_max_age': int,
-            'cookie_renew_age': int,
-            'users': [
-                {
-                    'username': str,
-                    'password': str,
-                    'fullname': str,
-                    'email': str,
-                    'deleted': bool,
-                }
-            ]
-        },
-        'cartridge_failover_params': {
-            'enabled': bool,
-            'mode': str,
-            'state_provider': str,
-            'stateboard_params': {
-                'uri': str,
-                'password': str
-            },
-            'etcd2_params': {
-                'prefix': str,
-                'lock_delay': int,
-                'endpoints': [str],
-                'username': str,
-                'password': str,
-            },
-        }
-    }
-
-    return check_schema(schema, vars)
+def validate_types(all_vars):
+    return check_schema(SCHEMA, all_vars)
 
 
 def check_cluster_cookie_symbols(cluster_cookie):
@@ -479,7 +479,7 @@ def validate_config(params):
     warnings = []
 
     for host in params['play_hosts']:
-        instance_vars = params['hostvars'][host]
+        instance_vars = params['facts'][host]
 
         # Validate types
         errmsg = validate_types(instance_vars)

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -65,14 +65,14 @@
 - name: 'Validate config'
   cartridge_validate_config:
     play_hosts: '{{ play_hosts }}'
-    facts: '{{ cached_facts.validate_config }}'
+    module_hostvars: '{{ cached_facts.validate_config }}'
   run_once: true
   delegate_to: localhost
   become: false
 
 - name: 'Select one instance for each physical machine'
   cartridge_get_single_instances_for_each_machine:
-    facts: '{{ cached_facts.single_instances_for_each_machine }}'
+    module_hostvars: '{{ cached_facts.single_instances_for_each_machine }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,23 +1,5 @@
 ---
 
-- import_tasks: 'set_instance_facts.yml'
-
-- name: 'Set facts that can be set by the user'
-  set_fact:
-    delivered_package_path: '{{ cartridge_delivered_package_path | default(omit, true) }}'
-    control_instance: '{{ cartridge_control_instance | default(omit, true) }}'
-  run_once: true
-  delegate_to: localhost
-  become: false
-
-- name: 'Validate config'
-  cartridge_validate_config:
-    hosts: '{{ play_hosts }}'
-    hostvars: '{{ hostvars }}'
-  run_once: true
-  delegate_to: localhost
-  become: false
-
 - name: 'Validate OS Family'
   fail:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
@@ -31,6 +13,16 @@
   when:
     - remote_user is not defined
     - ansible_user is defined
+
+- import_tasks: 'set_instance_facts.yml'
+
+- name: 'Set facts that can be set by the user'
+  set_fact:
+    delivered_package_path: '{{ cartridge_delivered_package_path | default(omit, true) }}'
+    control_instance: '{{ cartridge_control_instance | default(omit, true) }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
 
 - name: 'Collect instance info'
   cartridge_get_instance_info:
@@ -55,9 +47,37 @@
   set_fact:
     instance_info: '{{ instance_info_res.fact }}'
 
+- name: 'Get shortened vars sets'
+  cartridge_get_shortened_fact_sets:
+    hostvars: '{{ hostvars }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+  register: shortened_fact_sets_res
+
+- name: 'Set fact sets facts'
+  set_fact:
+    validate_config_facts: '{{ shortened_fact_sets_res.facts.validate_config }}'
+    single_instances_for_each_machine_facts: '{{ shortened_fact_sets_res.facts.single_instances_for_each_machine }}'
+    not_expelled_instance_facts: '{{ shortened_fact_sets_res.facts.not_expelled_instance }}'
+    connect_to_membership_facts: '{{ shortened_fact_sets_res.facts.connect_to_membership }}'
+    control_instance_facts: '{{ shortened_fact_sets_res.facts.control_instance }}'
+    edit_topology_facts: '{{ shortened_fact_sets_res.facts.edit_topology }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+
+- name: 'Validate config'
+  cartridge_validate_config:
+    play_hosts: '{{ play_hosts }}'
+    hostvars: '{{ validate_config_facts }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+
 - name: 'Select one instance for each physical machine'
   cartridge_get_single_instances_for_each_machine:
-    hostvars: '{{ hostvars }}'
+    hostvars: '{{ single_instances_for_each_machine_facts }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -48,21 +48,16 @@
     instance_info: '{{ instance_info_res.fact }}'
 
 - name: 'Get shortened vars sets'
-  cartridge_get_shortened_fact_sets:
+  cartridge_get_cached_facts:
     hostvars: '{{ hostvars }}'
   run_once: true
   delegate_to: localhost
   become: false
-  register: shortened_fact_sets_res
+  register: cached_facts_res
 
-- name: 'Set fact sets facts'
+- name: 'Cache facts for different targets'
   set_fact:
-    validate_config_facts: '{{ shortened_fact_sets_res.facts.validate_config }}'
-    single_instances_for_each_machine_facts: '{{ shortened_fact_sets_res.facts.single_instances_for_each_machine }}'
-    not_expelled_instance_facts: '{{ shortened_fact_sets_res.facts.not_expelled_instance }}'
-    connect_to_membership_facts: '{{ shortened_fact_sets_res.facts.connect_to_membership }}'
-    control_instance_facts: '{{ shortened_fact_sets_res.facts.control_instance }}'
-    edit_topology_facts: '{{ shortened_fact_sets_res.facts.edit_topology }}'
+    cached_facts: '{{ cached_facts_res.facts }}'
   run_once: true
   delegate_to: localhost
   become: false
@@ -70,14 +65,14 @@
 - name: 'Validate config'
   cartridge_validate_config:
     play_hosts: '{{ play_hosts }}'
-    hostvars: '{{ validate_config_facts }}'
+    facts: '{{ cached_facts.validate_config }}'
   run_once: true
   delegate_to: localhost
   become: false
 
 - name: 'Select one instance for each physical machine'
   cartridge_get_single_instances_for_each_machine:
-    hostvars: '{{ single_instances_for_each_machine_facts }}'
+    facts: '{{ cached_facts.single_instances_for_each_machine }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -5,7 +5,7 @@
 
 - name: 'Select control instance to manage topology and configuration'
   cartridge_get_control_instance:
-    hostvars: '{{ control_instance_facts }}'
+    facts: '{{ cached_facts.control_instance }}'
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -5,7 +5,7 @@
 
 - name: 'Select control instance to manage topology and configuration'
   cartridge_get_control_instance:
-    facts: '{{ cached_facts.control_instance }}'
+    module_hostvars: '{{ cached_facts.control_instance }}'
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -5,7 +5,7 @@
 
 - name: 'Select control instance to manage topology and configuration'
   cartridge_get_control_instance:
-    hostvars: '{{ hostvars }}'
+    hostvars: '{{ control_instance_facts }}'
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'

--- a/tasks/steps/blocks/set_non_expelled_instance.yml
+++ b/tasks/steps/blocks/set_non_expelled_instance.yml
@@ -2,7 +2,7 @@
 
 - name: 'Select one not expelled instance'
   cartridge_get_not_expelled_instance:
-    facts: '{{ cached_facts.not_expelled_instance }}'
+    module_hostvars: '{{ cached_facts.not_expelled_instance }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/steps/blocks/set_non_expelled_instance.yml
+++ b/tasks/steps/blocks/set_non_expelled_instance.yml
@@ -2,7 +2,7 @@
 
 - name: 'Select one not expelled instance'
   cartridge_get_not_expelled_instance:
-    hostvars: '{{ not_expelled_instance_facts }}'
+    facts: '{{ cached_facts.not_expelled_instance }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/steps/blocks/set_non_expelled_instance.yml
+++ b/tasks/steps/blocks/set_non_expelled_instance.yml
@@ -2,7 +2,7 @@
 
 - name: 'Select one not expelled instance'
   cartridge_get_not_expelled_instance:
-    hostvars: '{{ hostvars }}'
+    hostvars: '{{ not_expelled_instance_facts }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/steps/connect_to_membership.yml
+++ b/tasks/steps/connect_to_membership.yml
@@ -6,7 +6,7 @@
 - name: 'Connect instance to membership'
   cartridge_connect_to_membership:
     console_sock: '{{ not_expelled_instance.console_sock }}'
-    hostvars: '{{ connect_to_membership_facts }}'
+    facts: '{{ cached_facts.connect_to_membership }}'
     play_hosts: '{{ play_hosts }}'
   register: probe
   until: not probe.failed

--- a/tasks/steps/connect_to_membership.yml
+++ b/tasks/steps/connect_to_membership.yml
@@ -6,7 +6,7 @@
 - name: 'Connect instance to membership'
   cartridge_connect_to_membership:
     console_sock: '{{ not_expelled_instance.console_sock }}'
-    hostvars: '{{ hostvars }}'
+    hostvars: '{{ connect_to_membership_facts }}'
     play_hosts: '{{ play_hosts }}'
   register: probe
   until: not probe.failed

--- a/tasks/steps/connect_to_membership.yml
+++ b/tasks/steps/connect_to_membership.yml
@@ -6,7 +6,7 @@
 - name: 'Connect instance to membership'
   cartridge_connect_to_membership:
     console_sock: '{{ not_expelled_instance.console_sock }}'
-    facts: '{{ cached_facts.connect_to_membership }}'
+    module_hostvars: '{{ cached_facts.connect_to_membership }}'
     play_hosts: '{{ play_hosts }}'
   register: probe
   until: not probe.failed

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -7,7 +7,7 @@
 
     - name: 'Edit topology'
       cartridge_edit_topology:
-        hostvars: '{{ hostvars }}'
+        hostvars: '{{ edit_topology_facts }}'
         play_hosts: '{{ play_hosts }}'
         console_sock: '{{ control_instance.console_sock }}'
         timeout: '{{ edit_topology_timeout }}'

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -7,7 +7,7 @@
 
     - name: 'Edit topology'
       cartridge_edit_topology:
-        facts: '{{ cached_facts.edit_topology }}'
+        module_hostvars: '{{ cached_facts.edit_topology }}'
         play_hosts: '{{ play_hosts }}'
         console_sock: '{{ control_instance.console_sock }}'
         timeout: '{{ edit_topology_timeout }}'

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -7,7 +7,7 @@
 
     - name: 'Edit topology'
       cartridge_edit_topology:
-        hostvars: '{{ edit_topology_facts }}'
+        facts: '{{ cached_facts.edit_topology }}'
         play_hosts: '{{ play_hosts }}'
         console_sock: '{{ control_instance.console_sock }}'
         timeout: '{{ edit_topology_timeout }}'

--- a/unit/test_connect_to_membership.py
+++ b/unit/test_connect_to_membership.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_connect_to_membership import connect_to_membership
 
 
-def call_probe_instance(console_sock, facts, play_hosts=None):
+def call_probe_instance(console_sock, module_hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return connect_to_membership({
         'console_sock': console_sock,
-        'facts': facts,
+        'module_hostvars': module_hostvars,
         'play_hosts': play_hosts,
     })
 
@@ -44,7 +44,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 }
@@ -60,7 +60,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -83,7 +83,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-2': {
                     'config': {'advertise_uri': URI2},
                 }
@@ -99,7 +99,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -126,7 +126,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-2': {
                     'expelled': True,
                     'config': {'advertise_uri': URI2},
@@ -142,7 +142,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -165,7 +165,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-2': {
                     'restarted': True,
                     'config': {'advertise_uri': URI2},
@@ -187,7 +187,7 @@ class TestProbeInstance(unittest.TestCase):
 
         res = call_probe_instance(
             console_sock=self.console_sock,
-            facts={
+            module_hostvars={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },

--- a/unit/test_connect_to_membership.py
+++ b/unit/test_connect_to_membership.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_connect_to_membership import connect_to_membership
 
 
-def call_probe_instance(console_sock, hostvars, play_hosts=None):
+def call_probe_instance(console_sock, facts, play_hosts=None):
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return connect_to_membership({
         'console_sock': console_sock,
-        'hostvars': hostvars,
+        'facts': facts,
         'play_hosts': play_hosts,
     })
 
@@ -44,7 +44,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 }
@@ -60,7 +60,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -83,7 +83,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-2': {
                     'config': {'advertise_uri': URI2},
                 }
@@ -99,7 +99,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -126,7 +126,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-2': {
                     'expelled': True,
                     'config': {'advertise_uri': URI2},
@@ -142,7 +142,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },
@@ -165,7 +165,7 @@ class TestProbeInstance(unittest.TestCase):
         self.instance.clear_calls('admin_probe_server')
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-2': {
                     'restarted': True,
                     'config': {'advertise_uri': URI2},
@@ -187,7 +187,7 @@ class TestProbeInstance(unittest.TestCase):
 
         res = call_probe_instance(
             console_sock=self.console_sock,
-            hostvars={
+            facts={
                 'instance-1': {
                     'config': {'advertise_uri': URI1},
                 },

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_edit_topology import edit_topology
 
 
-def call_edit_topology(console_sock, facts, play_hosts=None, timeout=60):
+def call_edit_topology(console_sock, module_hostvars, play_hosts=None, timeout=60):
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return edit_topology({
         'console_sock': console_sock,
-        'facts': facts,
+        'module_hostvars': module_hostvars,
         'play_hosts': play_hosts,
         'timeout': timeout,
     })

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_edit_topology import edit_topology
 
 
-def call_edit_topology(console_sock, hostvars, play_hosts=None, timeout=60):
+def call_edit_topology(console_sock, facts, play_hosts=None, timeout=60):
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return edit_topology({
         'console_sock': console_sock,
-        'hostvars': hostvars,
+        'facts': facts,
         'play_hosts': play_hosts,
         'timeout': timeout,
     })

--- a/unit/test_get_cached_facts.py
+++ b/unit/test_get_cached_facts.py
@@ -1,0 +1,99 @@
+import sys
+import unittest
+
+import module_utils.helpers as helpers
+
+sys.modules['ansible.module_utils.helpers'] = helpers
+from library.cartridge_get_cached_facts import get_cached_facts, FACTS_BY_TARGETS
+from library.cartridge_validate_config import SCHEMA
+
+
+def call_get_cached_facts(hostvars):
+    return get_cached_facts({
+        'hostvars': hostvars,
+    })
+
+
+class TestGetCachedFacts(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_get_cached_facts(self):
+        res = call_get_cached_facts({
+            'instance_1': {
+                'expelled': True,
+                'config': {'advertise_uri': '10.0.0.1:3001'},
+                'ansible_host': 'some_host',
+            },
+            'instance_2': {
+                'stateboard': False,
+                'random_arg': {'test': 'value'},
+            },
+            'instance_3': {
+                'random_arg': {'test': 'value'},
+            },
+        })
+        self.assertFalse(res.failed, res.msg)
+        self.assertTrue('facts' in res.kwargs, 'No facts in result!')
+        self.assertEqual(res.kwargs['facts'], {
+            'validate_config': {
+                'instance_1': {
+                    'expelled': True,
+                    'config': {'advertise_uri': '10.0.0.1:3001'},
+                },
+                'instance_2': {
+                    'stateboard': False,
+                },
+                'instance_3': {},
+            },
+            'single_instances_for_each_machine': {
+                'instance_1': {
+                    'expelled': True,
+                    'ansible_host': 'some_host',
+                },
+                'instance_2': {},
+                'instance_3': {},
+            },
+            'connect_to_membership': {
+                'instance_1': {
+                    'expelled': True,
+                    'config': {'advertise_uri': '10.0.0.1:3001'},
+                },
+                'instance_2': {
+                    'stateboard': False,
+                },
+                'instance_3': {},
+            },
+            'not_expelled_instance': {
+                'instance_1': {
+                    'expelled': True,
+                },
+                'instance_2': {
+                    'stateboard': False,
+                },
+                'instance_3': {},
+            },
+            'control_instance': {
+                'instance_1': {
+                    'expelled': True,
+                    'config': {'advertise_uri': '10.0.0.1:3001'},
+                },
+                'instance_2': {
+                    'stateboard': False,
+                },
+                'instance_3': {},
+            },
+            'edit_topology': {
+                'instance_1': {
+                    'expelled': True,
+                    'config': {'advertise_uri': '10.0.0.1:3001'},
+                },
+                'instance_2': {
+                    'stateboard': False,
+                },
+                'instance_3': {},
+            },
+        })
+
+    def test_validate_config_cached_facts(self):
+        self.assertEqual(sorted(SCHEMA.keys()), sorted(FACTS_BY_TARGETS['validate_config']))

--- a/unit/test_get_control_instance.py
+++ b/unit/test_get_control_instance.py
@@ -22,15 +22,15 @@ def get_twophase_commit_versions_mock(_, advertise_uris):
 get_control_instance_lib.get_twophase_commit_versions = get_twophase_commit_versions_mock
 
 
-def call_get_control_instance(app_name, console_sock, hostvars=None, play_hosts=None):
-    if hostvars is None:
-        hostvars = {}
+def call_get_control_instance(app_name, console_sock, facts=None, play_hosts=None):
+    if facts is None:
+        facts = {}
 
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return get_control_instance({
-        'hostvars': hostvars,
+        'facts': facts,
         'play_hosts': play_hosts,
         'console_sock': console_sock,
         'app_name': app_name,

--- a/unit/test_get_control_instance.py
+++ b/unit/test_get_control_instance.py
@@ -22,15 +22,15 @@ def get_twophase_commit_versions_mock(_, advertise_uris):
 get_control_instance_lib.get_twophase_commit_versions = get_twophase_commit_versions_mock
 
 
-def call_get_control_instance(app_name, console_sock, facts=None, play_hosts=None):
-    if facts is None:
-        facts = {}
+def call_get_control_instance(app_name, console_sock, module_hostvars=None, play_hosts=None):
+    if module_hostvars is None:
+        module_hostvars = {}
 
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return get_control_instance({
-        'facts': facts,
+        'module_hostvars': module_hostvars,
         'play_hosts': play_hosts,
         'console_sock': console_sock,
         'app_name': app_name,

--- a/unit/test_get_non_expelled_instance.py
+++ b/unit/test_get_non_expelled_instance.py
@@ -7,12 +7,12 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_get_not_expelled_instance import get_one_not_expelled_instance
 
 
-def call_get_one_not_expelled_instance(facts, play_hosts=None):
+def call_get_one_not_expelled_instance(module_hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return get_one_not_expelled_instance({
-        'facts': facts,
+        'module_hostvars': module_hostvars,
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_get_non_expelled_instance.py
+++ b/unit/test_get_non_expelled_instance.py
@@ -7,12 +7,12 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_get_not_expelled_instance import get_one_not_expelled_instance
 
 
-def call_get_one_not_expelled_instance(hostvars, play_hosts=None):
+def call_get_one_not_expelled_instance(facts, play_hosts=None):
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return get_one_not_expelled_instance({
-        'hostvars': hostvars,
+        'facts': facts,
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_get_single_instances_for_each_machine.py
+++ b/unit/test_get_single_instances_for_each_machine.py
@@ -7,12 +7,12 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_get_single_instances_for_each_machine import get_one_not_expelled_instance_for_machine
 
 
-def call_get_one_not_expelled_instance_for_machine(hostvars, play_hosts=None):
+def call_get_one_not_expelled_instance_for_machine(facts, play_hosts=None):
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return get_one_not_expelled_instance_for_machine({
-        'hostvars': hostvars,
+        'facts': facts,
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_get_single_instances_for_each_machine.py
+++ b/unit/test_get_single_instances_for_each_machine.py
@@ -7,12 +7,12 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_get_single_instances_for_each_machine import get_one_not_expelled_instance_for_machine
 
 
-def call_get_one_not_expelled_instance_for_machine(facts, play_hosts=None):
+def call_get_one_not_expelled_instance_for_machine(module_hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return get_one_not_expelled_instance_for_machine({
-        'facts': facts,
+        'module_hostvars': module_hostvars,
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_validate_config import validate_config
 
 
-def call_validate_config(facts, play_hosts=None):
+def call_validate_config(module_hostvars, play_hosts=None):
     if play_hosts is None:
-        play_hosts = facts.keys()
+        play_hosts = module_hostvars.keys()
 
     return validate_config({
         'play_hosts': play_hosts,
-        'facts': facts,
+        'module_hostvars': module_hostvars,
     })
 
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -13,7 +13,7 @@ def call_validate_config(hostvars, play_hosts=None):
         play_hosts = hostvars.keys()
 
     return validate_config({
-        'hosts': play_hosts,
+        'play_hosts': play_hosts,
         'hostvars': hostvars,
     })
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -8,13 +8,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_validate_config import validate_config
 
 
-def call_validate_config(hostvars, play_hosts=None):
+def call_validate_config(facts, play_hosts=None):
     if play_hosts is None:
-        play_hosts = hostvars.keys()
+        play_hosts = facts.keys()
 
     return validate_config({
         'play_hosts': play_hosts,
-        'hostvars': hostvars,
+        'facts': facts,
     })
 
 


### PR DESCRIPTION
Closes #260

Beforw this patch the `hostsvars` variable is too large when deploying huge clusters.
Therefore, tasks that use `hostsvars` are executed for at least 40 seconds when deploying 500 instances.

Now only the necessary information will be transtered.
Due to this we will reduce duration of the tasks which use `hostvars`.

Some duration reduction results:
- Select control instance to manage topology and configuration from `70.38s` to `22.85s`
- Connect instance to membership from `54.30s` to `1.28s`
- Select one not expelled instance from `37.46s` to `0.71s`
- Select one instance for each physical machine from `30.60s` to `0.43s`
- Validate config from `26.03s` to `2.02s`