### PR TITLE
Reduce the number of logs of the `set_control_instance` step

### DIFF
--- a/tasks/steps/bootstrap_vshard.yml
+++ b/tasks/steps/bootstrap_vshard.yml
@@ -5,7 +5,9 @@
     - not expelled
   tags: cartridge-config
   block:
-    - import_tasks: 'blocks/set_control_instance.yml'
+    - name: 'BLOCK: Select control instance'
+      include_tasks: 'blocks/set_control_instance.yml'
+      run_once: true
       when: not control_instance
 
     - name: 'Bootstrap VShard'

--- a/tasks/steps/configure_app_config.yml
+++ b/tasks/steps/configure_app_config.yml
@@ -3,7 +3,9 @@
 - when: cartridge_app_config is not none
   tags: cartridge-config
   block:
-    - import_tasks: 'blocks/set_control_instance.yml'
+    - name: 'BLOCK: Select control instance'
+      include_tasks: 'blocks/set_control_instance.yml'
+      run_once: true
       when: not control_instance
 
     - name: 'Configure application config'

--- a/tasks/steps/configure_auth.yml
+++ b/tasks/steps/configure_auth.yml
@@ -3,7 +3,9 @@
 - when: cartridge_auth is not none
   tags: cartridge-config
   block:
-    - import_tasks: 'blocks/set_control_instance.yml'
+    - name: 'BLOCK: Select control instance'
+      include_tasks: 'blocks/set_control_instance.yml'
+      run_once: true
       when: not control_instance
 
     - name: 'Configure cartridge auth'

--- a/tasks/steps/configure_failover.yml
+++ b/tasks/steps/configure_failover.yml
@@ -3,7 +3,9 @@
 - when: cartridge_failover is not none or cartridge_failover_params is not none
   tags: cartridge-config
   block:
-    - import_tasks: 'blocks/set_control_instance.yml'
+    - name: 'BLOCK: Select control instance'
+      include_tasks: 'blocks/set_control_instance.yml'
+      run_once: true
       when: not control_instance
 
     - name: 'Configure failover'

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -2,7 +2,9 @@
 
 - tags: cartridge-replicasets
   block:
-    - import_tasks: 'blocks/set_control_instance.yml'
+    - name: 'BLOCK: Select control instance'
+      include_tasks: 'blocks/set_control_instance.yml'
+      run_once: true
       when: not control_instance
 
     - name: 'Edit topology'


### PR DESCRIPTION
Before this patch, when the `set_control_instance` step was reused,
four skipped tasks were displayed in the logs. This clutters up the logs.

Currently, if `control_instance` already defined, only one skipped task is displayed.