### PR TITLE
Fix skipping group creation

### DIFF
--- a/tasks/steps/blocks/unpack_tgz.yml
+++ b/tasks/steps/blocks/unpack_tgz.yml
@@ -13,6 +13,7 @@
     name: '{{ cartridge_app_group }}'
     state: present
   any_errors_fatal: true
+  when: cartridge_create_user_group_for_tgz
 
 - name: 'Create user {{ cartridge_app_user }} and add to group {{ cartridge_app_group }}'
   user:


### PR DESCRIPTION
Before this patch creating group wasn't skipped even if
`cartridge_create_user_group_for_tgz` flag is set.