### PR TITLE
Fix unexpected creating of unnamed replicasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ README.md to use the newest tag with new release
 - Skipping instances restart when package was updated, but configuration wasn't
 - Missing default config for machine with stateboard
 - Specifying `cartridge_app_name` other than the TGZ package name
+- Creating unnamed replicasets with instances without `replicaset_alias` set
 
 ### Added
 

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -52,21 +52,23 @@ def get_configured_replicasets(module_hostvars, play_hosts):
         if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
             continue
 
-        if 'replicaset_alias' in instance_vars:
-            replicaset_alias = instance_vars['replicaset_alias']
-            if replicaset_alias not in replicasets:
-                replicasets.update({
-                    replicaset_alias: {
-                        'instances': [],
-                        'roles': instance_vars.get('roles', None),
-                        'failover_priority': instance_vars.get('failover_priority', None),
-                        'all_rw': instance_vars.get('all_rw', None),
-                        'weight': instance_vars.get('weight', None),
-                        'vshard_group': instance_vars.get('vshard_group', None),
-                        'alias': replicaset_alias,
-                    }
-                })
-            replicasets[replicaset_alias]['instances'].append(instance_name)
+        if instance_vars.get('replicaset_alias') is None:
+            continue
+
+        replicaset_alias = instance_vars['replicaset_alias']
+        if replicaset_alias not in replicasets:
+            replicasets.update({
+                replicaset_alias: {
+                    'instances': [],
+                    'roles': instance_vars.get('roles', None),
+                    'failover_priority': instance_vars.get('failover_priority', None),
+                    'all_rw': instance_vars.get('all_rw', None),
+                    'weight': instance_vars.get('weight', None),
+                    'vshard_group': instance_vars.get('vshard_group', None),
+                    'alias': replicaset_alias,
+                }
+            })
+        replicasets[replicaset_alias]['instances'].append(instance_name)
 
     return replicasets
 

--- a/unit/test_edit_topology_helpers.py
+++ b/unit/test_edit_topology_helpers.py
@@ -37,6 +37,9 @@ class TestGetConfiguredReplicasets(unittest.TestCase):
             'instance-2': {
                 'replicaset_alias': 'replicaset-1',
             },
+            'instance-none-alias': {  # alias is none
+                'replicaset_alias': None,
+            },
             'not-play-host': {  # not in play hosts
                 'replicaset_alias': 'replicaset-1',
             },
@@ -48,7 +51,9 @@ class TestGetConfiguredReplicasets(unittest.TestCase):
                 'stateboard': True,
             },
         }
-        play_hosts = ['instance-expelled', 'instance-2', 'instance-4', 'instance-stateboard']
+        play_hosts = [
+            'instance-expelled', 'instance-2', 'instance-4', 'instance-stateboard', 'instance-none-alias'
+        ]
 
         replicasets = call_get_configured_replicasets(hostvars, play_hosts)
         self.assertEqual(len(replicasets), 1)


### PR DESCRIPTION
Because `replicaset_alias` has default value null, `unnamed` replicasets
were created for instances without `replicaset_alias`