### PR TITLE
Use cartridge-cli 2.9.0 in CI tests

### DIFF
--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  CARTRIDGE_CLI_VERSION: '2.7.2'
+  CARTRIDGE_CLI_VERSION: '2.9.0'
 
 jobs:
   setup-molecule-test-matrix:


### PR DESCRIPTION
It creates an application with the cartridge 2.6.0.