### PR TITLE
Allow missed instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ README.md to use the newest tag with new release
   - `fencing_enabled`
   - `fencing_timeout`
   - `fencing_pause`
+- `edit_topology_allow_missed_instances` variable to allow replicasets containing
+  the instances that are not started yet
 
 ### Changed
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,6 +111,7 @@ twophase_apply_config_timeout: null
 
 edit_topology_timeout: null  # DEPRECATED
 edit_topology_healthy_timeout: 60
+edit_topology_allow_missed_instances: false
 
 ## Cluster configuration
 

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -111,6 +111,9 @@ For more details see [scenario documentation](/doc/scenario.md).
 * `edit_topology_healthy_timeout` (`number`, default: `60`): time in seconds to wait until a cluster become
   healthy after editing topology;
 - [DEPRECATED] `edit_topology_timeout` - the same timeout as `edit_topology_healthy_timeout`.
+- `edit_topology_allow_missed_instances` (`boolean`, default: `false`) - if set, then
+  instances that aren't started yet are ignored on editing topology. A warning
+  message is shown in case of error.
 
 ## Cluster configuration
 

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -181,12 +181,11 @@ def get_join_servers(replicaset, cluster_replicaset, cluster_instances, allow_mi
     if err is not None:
         return None, err
 
-    # generally, we always apply failover priority AFTER
-    # all other changes
-    # the only one optimization is to join new replicaset
-    # with failover priority
-    # and call second `edit_topology` only for replicasets that have
-    # failover priority different from the specified
+    # When the new replicaset is created, instances can be joined in failover
+    # priority order.
+    # When the existing replicaset is edited, failover priority is configured
+    # later when all replicaset instances UUIDs are set (when new instances
+    # are joined, UUID isn't specified).
 
     if instances_to_join:
         if cluster_replicaset is None:

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -52,6 +52,7 @@ FACTS_BY_TARGETS = {
         'twophase_apply_config_timeout',
         'edit_topology_timeout',
         'edit_topology_healthy_timeout',
+        'edit_topology_allow_missed_instances',
         'expelled',
         'failover_priority',
         'instance_discover_buckets_timeout',

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -23,6 +23,12 @@ PARAMS_THE_SAME_FOR_ALL_HOSTS = [
     'cartridge_custom_steps_dir',
     'cartridge_custom_steps',
     'cartridge_failover_promote_params',
+    'twophase_netbox_call_timeout',
+    'twophase_upload_config_timeout',
+    'twophase_apply_config_timeout',
+    'edit_topology_timeout',
+    'edit_topology_healthy_timeout',
+    'edit_topology_allow_missed_instances',
 ]
 
 CONFIG_REQUIRED_PARAMS = ['advertise_uri']
@@ -106,6 +112,7 @@ SCHEMA = {
     'twophase_apply_config_timeout': int,
     'edit_topology_timeout': int,
     'edit_topology_healthy_timeout': int,
+    'edit_topology_allow_missed_instances': bool,
     'replicaset_alias': str,
     'failover_priority': [str],
     'roles': [str],

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -376,7 +376,7 @@ def debug(value, key=None):
     DEBUG_MESSAGES += value
 
 
-def add_warning(msg):
+def warn(msg):
     global WARNINGS
     WARNINGS.append(msg)
 
@@ -500,7 +500,7 @@ class Helpers:
     Console = Console
 
     debug = staticmethod(debug)
-    add_warning = staticmethod(add_warning)
+    warn = staticmethod(warn)
     execute_module = staticmethod(execute_module)
     get_control_console = staticmethod(get_control_console)
     is_expelled = staticmethod(is_expelled)

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -202,8 +202,8 @@ class ModuleRes:
         self.warnings += DEBUG_MESSAGES
         res['warnings'] = self.warnings
 
-        WARNINGS.clear()
-        DEBUG_MESSAGES.clear()
+        del WARNINGS[:]
+        del DEBUG_MESSAGES[:]
 
         for key, value in self.kwargs.items():
             res[key] = value

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -165,6 +165,7 @@ end
 
 RANDOM_PREFIX = random.randint(1, 1000)
 DEBUG_MESSAGES = []
+WARNINGS = []
 
 
 class ModuleRes:
@@ -197,8 +198,12 @@ class ModuleRes:
 
         if self.warnings is None:
             self.warnings = []
+        self.warnings += WARNINGS
         self.warnings += DEBUG_MESSAGES
         res['warnings'] = self.warnings
+
+        WARNINGS.clear()
+        DEBUG_MESSAGES.clear()
 
         for key, value in self.kwargs.items():
             res[key] = value
@@ -371,6 +376,11 @@ def debug(value, key=None):
     DEBUG_MESSAGES += value
 
 
+def add_warning(msg):
+    global WARNINGS
+    WARNINGS.append(msg)
+
+
 def execute_module(argument_spec, function):
     module = AnsibleModule(argument_spec=argument_spec)
     try:
@@ -490,6 +500,7 @@ class Helpers:
     Console = Console
 
     debug = staticmethod(debug)
+    add_warning = staticmethod(add_warning)
     execute_module = staticmethod(execute_module)
     get_control_console = staticmethod(get_control_console)
     is_expelled = staticmethod(is_expelled)

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -80,6 +80,7 @@
 
       edit_topology_timeout: '{{ edit_topology_timeout }}'
       edit_topology_healthy_timeout: '{{ edit_topology_healthy_timeout }}'
+      edit_topology_allow_missed_instances: '{{ edit_topology_allow_missed_instances }}'
 
       ## Cluster configuration
 

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -16,5 +16,6 @@
         netbox_call_timeout: '{{ twophase_netbox_call_timeout }}'
         upload_config_timeout: '{{ twophase_upload_config_timeout }}'
         apply_config_timeout: '{{ twophase_apply_config_timeout }}'
+        allow_missed_instances: '{{ edit_topology_allow_missed_instances }}'
       run_once: true
       delegate_to: '{{ control_instance.name }}'

--- a/unit/test_failover_promote.py
+++ b/unit/test_failover_promote.py
@@ -32,7 +32,7 @@ class TestEditTopology(unittest.TestCase):
         self.instance.start()
 
     @parameterized.expand([
-        ['disabled'],  # force_inconsistency
+        ['disabled'],
         ['eventual'],
     ])
     def test_failover_bad_mode(self, mode):

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -82,6 +82,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_install_tarantool_for_tgz',
                 'cartridge_remove_temporary_files',
                 'cartridge_failover_params.fencing_enabled',
+                'edit_topology_allow_missed_instances',
             },
             dict: {
                 'cartridge_defaults',


### PR DESCRIPTION
Introduces `edit_topology_allow_missed_instances` that allows managing replicasets
with instances that aren't running. In this case, a warning message is shown and 
missed instances are ignored.
Closes #294 