### PR TITLE
Consider enabled roles on editing topology

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=120
 ignore=E402
-exclude=venv
+exclude=venv,tarantool-enterprise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ README.md to use the newest tag with new release
   - If there are some joined instances, but no one of them isn't alive,
     getting control instance fails.
 - `set_control_instance` is improved to consider non-joined instance status
+- `edit_topology` step now considers roles dependencies, permanent and hidden roles
+  and don't perform unnecessary calls if enabled roles list isn't changed
 
 ### Added
 

--- a/create-packages.sh
+++ b/create-packages.sh
@@ -41,6 +41,11 @@ awk '{gsub(/cartridge.cfg\({/, "&\n    vshard_groups = { hot = { bucket_count = 
     ${appname}/init.lua >${appname}/temp.lua
 mv ${appname}/temp.lua ${appname}/init.lua
 
+awk '{gsub(/-- dependencies/, "dependencies")}1' \
+    ${appname}/app/roles/custom.lua >${appname}/temp.lua
+mv ${appname}/temp.lua ${appname}/app/roles/custom.lua
+
+
 cartridge pack tgz --version ${version} ${pack_flags} ${appname}
 cartridge pack rpm --version ${version} ${pack_flags} ${appname}
 cartridge pack deb --version ${version} ${pack_flags} ${appname}

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -509,7 +509,6 @@ def edit_topology(params):
 
     cluster_instances = helpers.get_cluster_instances(control_console)
     cluster_replicasets = helpers.get_cluster_replicasets(control_console)
-    # roles_deps = get_roles_deps(control_console)
 
     # Configure replicasets and instances:
     # * Create new replicasets.

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -100,19 +100,51 @@ def get_instances_to_configure(module_hostvars, play_hosts):
     return instances
 
 
+def set_enabled_roles(replicasets, control_console):
+    roles_by_aliases = {alias: r['roles'] for alias, r in replicasets.items()}
+
+    if not roles_by_aliases:
+        return
+
+    enabled_roles_by_aliases, _ = control_console.eval_res_err('''
+        local cartridge_roles = require('cartridge.roles')
+
+        local roles_by_aliases = ...
+        local enabled_roles_by_aliases = {}
+
+        for alias, roles in pairs(roles_by_aliases) do
+            enabled_roles_by_aliases[alias] = cartridge_roles.get_enabled_roles(roles or {})
+        end
+
+        return enabled_roles_by_aliases
+    ''', roles_by_aliases)
+
+    for alias, enabled_roles in enabled_roles_by_aliases.items():
+        replicasets[alias].update({
+            'enabled_roles': enabled_roles,
+        })
+
+
 def add_replicaset_param_if_required(replicaset_params, replicaset, cluster_replicaset, param_name):
     if replicaset.get(param_name) is None:
         return
 
     if cluster_replicaset is not None:
-        if param_name == 'roles':
-            if set(replicaset.get('roles', [])) == set(cluster_replicaset.get('roles', [])):
-                return
-
         if replicaset.get(param_name) == cluster_replicaset.get(param_name):
             return
 
     replicaset_params[param_name] = replicaset.get(param_name)
+
+
+def add_replicaset_roles_param_if_required(replicaset_params, replicaset, cluster_replicaset):
+    if replicaset.get('roles') is None:
+        return
+
+    if cluster_replicaset is not None:
+        if set(replicaset['enabled_roles']) == set(cluster_replicaset['enabled_roles']):
+            return
+
+    replicaset_params['roles'] = replicaset['roles']
 
 
 def check_filtered_instances(instances, filtered_instances, fmt, allow_missed_instances):
@@ -226,10 +258,14 @@ def get_replicaset_params(replicaset, cluster_replicaset, cluster_instances, all
     else:
         replicaset_params['alias'] = replicaset['alias']
 
-    for param_name in ['weight', 'vshard_group', 'all_rw', 'roles']:
+    for param_name in ['weight', 'vshard_group', 'all_rw']:
         add_replicaset_param_if_required(
             replicaset_params, replicaset, cluster_replicaset, param_name
         )
+
+    add_replicaset_roles_param_if_required(
+        replicaset_params, replicaset, cluster_replicaset
+    )
 
     join_servers, err = get_join_servers(
         replicaset, cluster_replicaset, cluster_instances, allow_missed_instances
@@ -469,9 +505,11 @@ def edit_topology(params):
     control_console = helpers.get_control_console(console_sock)
 
     helpers.set_twophase_options_from_params(control_console, params)
+    set_enabled_roles(replicasets, control_console)
 
     cluster_instances = helpers.get_cluster_instances(control_console)
     cluster_replicasets = helpers.get_cluster_replicasets(control_console)
+    # roles_deps = get_roles_deps(control_console)
 
     # Configure replicasets and instances:
     # * Create new replicasets.

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -51,6 +51,7 @@ MEMORY_SIZE_BOX_CFG_PARAMS = {
 }
 
 FORMAT_REPLICASET_FUNC = '''
+local cartridge_roles = require('cartridge.roles')
 local function format_replicaset(r)
     local instances = {}
     for _, s in ipairs(r.servers) do
@@ -62,7 +63,7 @@ local function format_replicaset(r)
     return {
         uuid = r.uuid,
         alias = r.alias,
-        roles = r.roles,
+        enabled_roles = cartridge_roles.get_enabled_roles(r.roles),
         all_rw = r.all_rw,
         weight = r.weight,
         vshard_group = r.vshard_group,

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -192,7 +192,6 @@ all:
             replicaset_alias: core-1
             roles:
               - app.roles.custom
-              - vshard-router
               - failover-coordinator
 
         core_2_replicaset:

--- a/unit/instance.py
+++ b/unit/instance.py
@@ -287,6 +287,11 @@ class Instance:
             require('cartridge').internal.add_replicaset(...)
         ''', kwargs)
 
+    def cfg_roles(self, *roles):
+        self.eval_res_err('''
+            require('cartridge').internal.cfg_roles(...)
+        ''', roles)
+
     def bootstrap_cluster(self):
         self.eval_res_err('''
             require('cartridge').internal.bootstrap_cluster()


### PR DESCRIPTION
Before this patch passed `roles` were compared with `replicaset.roles`.
But `replicaset.roles` contain roles and their dependencies, so it can
be different from passed `roles`. This leads to unnecessary
`edit_topology` calls for all replicasets, which leads to different
issues on big clusters. Since this patch enabled roles for passed
`roles` and `replicaset.roles` are compared to understand if changes
are needed.

Closes #311 