### PR TITLE
Use assert for checking OS

### DIFF
--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -3,8 +3,8 @@
 - name: 'Check that OS family is supported'
   assert:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
-    success_msg: 'Deploy to {{ ansible_os_family }} distributions is supported'
     that: ansible_os_family in ["RedHat", "Debian"]
+    quiet: true
   when: ansible_os_family is defined
 
 - name: 'Set "remote_user" for delegated tasks'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: 'Validate OS Family'
-  fail:
+- name: 'Check that OS family is supported'
+  assert:
     msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
-  when:
-    - ansible_os_family is defined
-    - ansible_os_family not in ["RedHat", "Debian"]
+    success_msg: 'Deploy to {{ ansible_os_family }} distributions is supported'
+    that: ansible_os_family in ["RedHat", "Debian"]
+  when: ansible_os_family is defined
 
 - name: 'Set "remote_user" for delegated tasks'
   set_fact:

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -2,8 +2,8 @@
 
 - name: 'Check that OS family is supported'
   assert:
-    msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
     that: ansible_os_family in ["RedHat", "Debian"]
+    fail_msg: 'Deploy to {{ ansible_os_family }} distributions is not supported yet'
     quiet: true
   when: ansible_os_family is defined
 


### PR DESCRIPTION
Now `assert` module is used for the `ansible_os_family` check to make logs prettier.