### PR TITLE
Make cluster cookie param optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ README.md to use the newest tag with new release
 
 - Timeout to wait for cluster health after topology editing
   renamed from `edit_topology_timeout` to `edit_topology_healthy_timeout`
+- `cartridge_cluster_cookie` now is required only for `configure_instance`,
+  `restart_instance` and `upload_app_config` steps
 
 ## [1.8.3] - 2021-04-06
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -439,6 +439,7 @@ Input facts (set by role):
 
 Input facts (set by config):
 
+- `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
 - `restarted` - if instance should be restarted or not (user forced decision).
 
 ### wait_instance_started

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -6,7 +6,7 @@ vshard bootstrapping, and failover.
 ## Common variables
 
 * `cartridge_app_name` (`string`): application name, required;
-* `cartridge_cluster_cookie` (`string`, required): cluster cookie for all
+* `cartridge_cluster_cookie` (`string`): cluster cookie for all
   cluster instances;
 * `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
   indicates if temporary files should be removed

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -78,7 +78,6 @@ FACTS_BY_TARGETS = {
         'config',
     ],
     'alive_not_expelled_instance': [
-        'cartridge_cluster_cookie',
         'expelled',
         'stateboard',
         'config',

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -10,7 +10,7 @@ argument_spec = {
     'module_hostvars': {'required': True, 'type': 'dict'}
 }
 
-INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'cartridge_cluster_cookie', 'config']
+INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'config']
 PARAMS_THE_SAME_FOR_ALL_HOSTS = [
     'cartridge_app_name',
     'cartridge_cluster_cookie',
@@ -228,6 +228,9 @@ def validate_types(all_vars):
 
 
 def check_cluster_cookie_symbols(cluster_cookie):
+    if cluster_cookie is None:
+        return None
+
     if len(cluster_cookie) > CLUSTER_COOKIE_MAX_LEN:
         errmsg = 'Cluster cookie cannot be longer than {}'.format(CLUSTER_COOKIE_MAX_LEN)
         return errmsg
@@ -246,10 +249,6 @@ def check_required_params(instance_vars, host):
         if instance_vars.get(p) is None:
             errmsg = '"{}" must be specified (missed for "{}")'.format(p, host)
             return errmsg
-
-    errmsg = check_cluster_cookie_symbols(instance_vars['cartridge_cluster_cookie'])
-    if errmsg is not None:
-        return errmsg
 
     return None
 
@@ -547,6 +546,10 @@ def validate_config(params):
         errmsg = check_required_params(instance_vars, host)
         if errmsg is not None:
             return helpers.ModuleRes(failed=True, msg=errmsg)
+
+        errmsg = check_cluster_cookie_symbols(instance_vars.get('cartridge_cluster_cookie'))
+        if errmsg is not None:
+            return errmsg
 
         # Instance config
         errmsg = check_instance_config(instance_vars['config'], host)

--- a/molecule/common/tests/test_cluster_is_healthy.py
+++ b/molecule/common/tests/test_cluster_is_healthy.py
@@ -20,7 +20,8 @@ HOSTS_PATH = os.path.join('molecule', scenario_name, 'hosts.yml')
 inventory = InventoryManager(loader=DataLoader(), sources=HOSTS_PATH)
 variable_manager = VariableManager(loader=DataLoader(), inventory=inventory)
 
-cluster_cookie = inventory.groups['cluster'].get_vars()['cartridge_cluster_cookie']
+cluster_vars = inventory.groups['cluster'].get_vars()
+cluster_cookie = cluster_vars.get('cartridge_cluster_cookie', 'secret-cookie')
 
 __authorized_session = None
 __configured_instances = None

--- a/molecule/dead_instances/hosts.yml
+++ b/molecule/dead_instances/hosts.yml
@@ -9,7 +9,6 @@ cluster:
 
     # common cartridge opts
     cartridge_app_name: myapp
-    cartridge_cluster_cookie: secret-cookie
 
     cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
 

--- a/molecule/dead_instances/prepare.yml
+++ b/molecule/dead_instances/prepare.yml
@@ -8,6 +8,7 @@
   become_user: root
   gather_facts: false
   vars:
+    cartridge_cluster_cookie: secret-cookie
     cartridge_scenario_name: configure_instances
 
 - name: Join all instances except instance-5-not-joined

--- a/molecule/eval/hosts.yml
+++ b/molecule/eval/hosts.yml
@@ -9,7 +9,6 @@ cluster:
 
     # common cartridge opts
     cartridge_app_name: myapp
-    cartridge_cluster_cookie: secret-cookie
 
     cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
 

--- a/molecule/eval/prepare.yml
+++ b/molecule/eval/prepare.yml
@@ -7,3 +7,5 @@
   become: true
   become_user: root
   gather_facts: false
+  vars:
+    cartridge_cluster_cookie: secret-cookie

--- a/molecule/rolling_update/hosts.yml
+++ b/molecule/rolling_update/hosts.yml
@@ -9,7 +9,6 @@ cluster:
 
     # common cartridge opts
     cartridge_app_name: myapp
-    cartridge_cluster_cookie: secret-cookie
 
     cartridge_multiversion: true
 

--- a/molecule/rolling_update/prepare.yml
+++ b/molecule/rolling_update/prepare.yml
@@ -8,6 +8,7 @@
   become_user: root
   gather_facts: false
   vars:
+    cartridge_cluster_cookie: secret-cookie
     cartridge_enable_tarantool_repo: true
     cartridge_configure_systemd_unit_files: true
     cartridge_configure_tmpfiles: true

--- a/molecule/start_stop/converge.yml
+++ b/molecule/start_stop/converge.yml
@@ -8,6 +8,7 @@
   become_user: root
   gather_facts: false
   vars:
+    cartridge_cluster_cookie: secret-cookie
     cartridge_scenario:
       - restart_instance
       - wait_instance_started
@@ -78,6 +79,7 @@
   become_user: root
   gather_facts: false
   vars:
+    cartridge_cluster_cookie: secret-cookie
     cartridge_scenario:
       - restart_instance
 

--- a/molecule/start_stop/hosts.yml
+++ b/molecule/start_stop/hosts.yml
@@ -10,7 +10,6 @@ cluster:
 
     # common cartridge opts
     cartridge_app_name: myapp
-    cartridge_cluster_cookie: secret-cookie
 
     cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
 

--- a/molecule/start_stop/prepare.yml
+++ b/molecule/start_stop/prepare.yml
@@ -8,6 +8,7 @@
   become_user: root
   gather_facts: false
   vars:
+    cartridge_cluster_cookie: secret-cookie
     cartridge_scenario:
       - deliver_package
       - update_package

--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -29,6 +29,13 @@
         needs_restart: '{{ needs_restart_res.fact }}'
       when: "'fact' in needs_restart_res"
 
+    - name: 'Check that cluster cookie is specified'
+      assert:
+        that: cartridge_cluster_cookie is not none
+        msg: 'cartridge_cluster_cookie should be specified to configure instance'
+        quiet: true
+      when: inventory_hostname in single_instances_for_each_machine
+
     - name: 'Place default config'
       copy:
         content: >-
@@ -40,8 +47,7 @@
         owner: '{{ cartridge_app_user }}'
         group: '{{ cartridge_app_group }}'
         mode: '644'
-      when:
-        - inventory_hostname in single_instances_for_each_machine
+      when: inventory_hostname in single_instances_for_each_machine
 
     - name: 'Place instance config'
       copy:

--- a/unit/test_get_cached_facts.py
+++ b/unit/test_get_cached_facts.py
@@ -72,7 +72,6 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_1': {
                     'expelled': True,
                     'config': {'advertise_uri': '10.0.0.1:3001'},
-                    'cartridge_cluster_cookie': 'some-cookie',
                     'cartridge_run_dir': 'some-run-dir',
                 },
                 'instance_2': {

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -189,7 +189,6 @@ class TestValidateConfig(unittest.TestCase):
     def test_instance_required_params(self):
         required_params = {
             'cartridge_app_name': 'app-name',
-            'cartridge_cluster_cookie': 'cookie',
             'config': {'advertise_uri': 'localhost:3301'}
         }
 


### PR DESCRIPTION
Now `cartridge_cluster_cookie` is required only for `configure_instance`,
 `restart_instance` and `upload_app_config` steps.
 It allows to pass it only for steps that really need it and make it securely.