### PR TITLE
Eval with retries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,3 +163,6 @@ alive_not_expelled_instance: null
 cartridge_eval_file: null
 cartridge_eval_body: null
 cartridge_eval_args: []
+cartridge_eval_with_retries: false
+cartridge_eval_retries: 3
+cartridge_eval_delay: 5

--- a/doc/eval.md
+++ b/doc/eval.md
@@ -9,7 +9,8 @@ There are two steps that allow running code snippets:
   specified snipped only on the control instance.
 
 By default, result is simply saved to `eval_res` variable, but if
-`cartridge_eval_with_retries` is set to `true`, than [eval with retries](#eval-with-retries) is performed.
+`cartridge_eval_with_retries` is set to `true`, result will be checked for errors,
+more info [here](#eval-with-retries).
 
 ## How to pass a code snippet?
 
@@ -123,7 +124,7 @@ It retries until `err` is received.
 It can be useful to perform some checks in Lua code and wait until some condition is met.
 
 Retries and delay can be configured:
-- `cartridge_eval_retries` (`number`, default: `3`) number of eval retries;
+- `cartridge_eval_retries` (`number`, default: `3`) - number of eval retries;
 - `cartridge_eval_delay` (`number`, default: `5`)  - eval retries delay;
 
 ```yaml

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -775,7 +775,10 @@ Input facts (set by config):
 - `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
   `cartridge_eval_body` is specified);
 - `cartridge_eval_body` - code to eval;
-- `cartridge_eval_args` - function arguments.
+- `cartridge_eval_args` - function arguments;
+- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
+- `cartridge_eval_retries` number of eval retries;
+- `cartridge_eval_delay` - eval retries delay;
 
 ### eval_on_control_instance
 
@@ -791,7 +794,10 @@ Input facts (set by config):
 - `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
   `cartridge_eval_body` is specified);
 - `cartridge_eval_body` - code to eval;
-- `cartridge_eval_args` - function arguments.
+- `cartridge_eval_args` - function arguments;
+- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
+- `cartridge_eval_retries` number of eval retries;
+- `cartridge_eval_delay` - eval retries delay;
 
 ### stop_instance
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -778,7 +778,7 @@ Input facts (set by config):
 - `cartridge_eval_args` - function arguments;
 - `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
 - `cartridge_eval_retries` number of eval retries;
-- `cartridge_eval_delay` - eval retries delay;
+- `cartridge_eval_delay` - eval retries delay.
 
 ### eval_on_control_instance
 
@@ -797,7 +797,7 @@ Input facts (set by config):
 - `cartridge_eval_args` - function arguments;
 - `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
 - `cartridge_eval_retries` number of eval retries;
-- `cartridge_eval_delay` - eval retries delay;
+- `cartridge_eval_delay` - eval retries delay.
 
 ### stop_instance
 

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -74,6 +74,9 @@ FACTS_BY_TARGETS = {
         'show_issues',
         'wait_cluster_has_no_issues_retries',
         'wait_cluster_has_no_issues_delay',
+        'cartridge_eval_with_retries',
+        'cartridge_eval_retries',
+        'cartridge_eval_delay',
     ],
     'single_instances_for_each_machine': [
         'expelled',

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -143,6 +143,9 @@ SCHEMA = {
     'cartridge_eval_body': str,
     'cartridge_eval_file': str,
     'cartridge_eval_args': list,
+    'cartridge_eval_with_retries': bool,
+    'cartridge_eval_retries': int,
+    'cartridge_eval_delay': int,
     'config': {
         'advertise_uri': str,
         'memtx_memory': int,

--- a/molecule/eval/converge.yml
+++ b/molecule/eval/converge.yml
@@ -259,9 +259,6 @@
         cartridge_scenario:
           - eval
         cartridge_eval_body: return "I am some res"
-        cartridge_eval_with_retries: true
-        cartridge_eval_retries: 2
-        cartridge_eval_delay: 1
 
     - name: 'Check result'
       assert:

--- a/molecule/eval/converge.yml
+++ b/molecule/eval/converge.yml
@@ -224,6 +224,10 @@
   become: true
   become_user: root
   gather_facts: false
+  vars:
+    cartridge_eval_with_retries: true
+    cartridge_eval_retries: 2
+    cartridge_eval_delay: 1
   tasks:
     - name: Eval returns nil, err
       import_role:
@@ -233,15 +237,19 @@
         cartridge_scenario:
           - eval
         cartridge_eval_body: return nil, "I am horrible error"
-        cartridge_eval_with_retries: true
-        cartridge_eval_retries: 2
-        cartridge_eval_delay: 1
 
     - name: 'Check eval failed'
       assert:
         msg: 'Eval should fail'
         success_msg: 'Eval failed'
         that: eval_res_register.failed
+      run_once: true
+
+    - name: 'Check eval attempts count'
+      assert:
+        msg: 'Eval attempts should be {{ cartridge_eval_retries }}'
+        success_msg: 'Eval retries count is OK'
+        that: eval_res_register.attempts == cartridge_eval_retries
       run_once: true
 
     - name: Eval returns res

--- a/molecule/eval/converge.yml
+++ b/molecule/eval/converge.yml
@@ -217,6 +217,50 @@
               "--- {'other': 'cute-table'}\n...\n",
           ]
 
+# EVAL FROM STRING (with retries)
+
+- name: 'Eval with retries'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: Eval returns nil, err
+      import_role:
+        name: ansible-cartridge
+      ignore_errors: true
+      vars:
+        cartridge_scenario:
+          - eval
+        cartridge_eval_body: return nil, "I am horrible error"
+        cartridge_eval_with_retries: true
+        cartridge_eval_retries: 2
+        cartridge_eval_delay: 1
+
+    - name: 'Check eval failed'
+      assert:
+        msg: 'Eval should fail'
+        success_msg: 'Eval failed'
+        that: eval_res_register.failed
+      run_once: true
+
+    - name: Eval returns res
+      import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_scenario:
+          - eval
+        cartridge_eval_body: return "I am some res"
+        cartridge_eval_with_retries: true
+        cartridge_eval_retries: 2
+        cartridge_eval_delay: 1
+
+    - name: 'Check result'
+      assert:
+        msg: 'Received bad result'
+        success_msg: 'Received result is OK'
+        that: eval_res == ["I am some res"]
+
 # EVAL FROM STRING (control)
 
 - name: 'Eval function from string on control instance'

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -123,3 +123,6 @@
       cartridge_eval_file: '{{ cartridge_eval_file }}'
       cartridge_eval_body: '{{ cartridge_eval_body }}'
       cartridge_eval_args: '{{ cartridge_eval_args }}'
+      cartridge_eval_with_retries: '{{ cartridge_eval_with_retries }}'
+      cartridge_eval_retries: '{{ cartridge_eval_retries }}'
+      cartridge_eval_delay: '{{ cartridge_eval_delay }}'

--- a/tasks/steps/blocks/eval.yml
+++ b/tasks/steps/blocks/eval.yml
@@ -17,6 +17,11 @@
         body: '{{ eval_body }}'
         args: '{{ cartridge_eval_args }}'
       register: eval_res_register
+      until: >-
+        not cartridge_eval_with_retries
+        or eval_res_register.fact[1] | default(none) is none
+      retries: '{{ cartridge_eval_retries }}'
+      delay: '{{ cartridge_eval_delay }}'
 
     - name: 'Set "eval_res" fact'
       set_fact:

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -86,6 +86,7 @@ class TestValidateConfig(unittest.TestCase):
                 'edit_topology_allow_missed_instances',
                 'allow_warning_issues',
                 'show_issues',
+                'cartridge_eval_with_retries',
             },
             dict: {
                 'cartridge_defaults',
@@ -117,6 +118,8 @@ class TestValidateConfig(unittest.TestCase):
                 'wait_members_alive_delay',
                 'wait_cluster_has_no_issues_retries',
                 'wait_cluster_has_no_issues_delay',
+                'cartridge_eval_retries',
+                'cartridge_eval_delay',
             },
             list: {
                 'roles',


### PR DESCRIPTION
We often need to evaluate some code until the condition is reached.
This patch introduces `cartridge_eval_retries` variables that enables
checking `eval_res` for errors.