### PR TITLE
Allow to disable persisting cluster cookie in app conf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ README.md to use the newest tag with new release
   and specified state
 - `wait_cluster_has_no_issues` step to wait until cluster has no issues
 - availability to upload ZIP configs to TDG
-- `set_cluster_cookie_in_config` variable that allows to disable persisting cluster
+- `cartridge_not_save_cookie_in_app_config` variable that allows to disable persisting cluster
   cookie in the application configuration file
 
 ## [1.9.0] - 2021-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ README.md to use the newest tag with new release
   and specified state
 - `wait_cluster_has_no_issues` step to wait until cluster has no issues
 - availability to upload ZIP configs to TDG
+- `set_cluster_cookie_in_config` variable that allows to disable persisting cluster
+  cookie in the application configuration file
 
 ## [1.9.0] - 2021-04-30
 

--- a/create-packages.sh
+++ b/create-packages.sh
@@ -133,13 +133,20 @@ if [ -z "${skip_cartridge}" ]; then
     rm -rf ${app_name}
     cartridge create --name ${app_name}
 
+    # configure vshard group "hot"
     awk '{gsub(/cartridge.cfg\({/, "&\n    vshard_groups = { hot = { bucket_count = 20000 } },")}1' \
         ${app_name}/init.lua >${app_name}/temp.lua
     mv ${app_name}/temp.lua ${app_name}/init.lua
 
+    # add dependencies to app.roles.custom role
     awk '{gsub(/-- dependencies/, "dependencies")}1' \
         ${app_name}/app/roles/custom.lua >${app_name}/temp.lua
     mv ${app_name}/temp.lua ${app_name}/app/roles/custom.lua
+
+    # remove setting cluster_cookie on cartridge.cfg
+    awk '{gsub(/cluster_cookie/, "-- cluster_cookie")}1' \
+        ${app_name}/init.lua >${app_name}/temp.lua
+    mv ${app_name}/temp.lua ${app_name}/init.lua
 
     lazy_pack tgz "${app_name}" "${version}"
     lazy_pack rpm "${app_name}" "${version}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 
 cartridge_app_name: null
 cartridge_cluster_cookie: null
-set_cluster_cookie_in_config: true
+cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
 
 # Role scenario configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 
 cartridge_app_name: null
 cartridge_cluster_cookie: null
+set_cluster_cookie_in_config: true
 cartridge_remove_temporary_files: false
 
 # Role scenario configuration

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -427,7 +427,7 @@ Input facts (set by config):
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_app_name` - application name;
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
-- `cartridge_not_save_cookie_in_app_config` - flag indicates if cluster cookie shouldn't be persisted in application configuration file;
+- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
 - `cartridge_defaults` - default configuration parameters values for instances;
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
@@ -448,7 +448,7 @@ Input facts (set by role):
 Input facts (set by config):
 
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
-- `cartridge_not_save_cookie_in_app_config` - flag indicates if cluster cookie should be persisted in application configuration file;
+- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
 - `restarted` - if instance should be restarted or not (user forced decision).
 
 ### wait_instance_started

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -427,6 +427,7 @@ Input facts (set by config):
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_app_name` - application name;
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
+- `set_cluster_cookie_in_config` - flag indicates if cluster cookie should be persisted in application configuration file;
 - `cartridge_defaults` - default configuration parameters values for instances;
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
@@ -447,6 +448,7 @@ Input facts (set by role):
 Input facts (set by config):
 
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
+- `set_cluster_cookie_in_config` - flag indicates if cluster cookie should be persisted in application configuration file;
 - `restarted` - if instance should be restarted or not (user forced decision).
 
 ### wait_instance_started

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -427,7 +427,7 @@ Input facts (set by config):
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_app_name` - application name;
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
-- `set_cluster_cookie_in_config` - flag indicates if cluster cookie should be persisted in application configuration file;
+- `cartridge_not_save_cookie_in_app_config` - flag indicates if cluster cookie shouldn't be persisted in application configuration file;
 - `cartridge_defaults` - default configuration parameters values for instances;
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
@@ -448,7 +448,7 @@ Input facts (set by role):
 Input facts (set by config):
 
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
-- `set_cluster_cookie_in_config` - flag indicates if cluster cookie should be persisted in application configuration file;
+- `cartridge_not_save_cookie_in_app_config` - flag indicates if cluster cookie should be persisted in application configuration file;
 - `restarted` - if instance should be restarted or not (user forced decision).
 
 ### wait_instance_started

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -8,8 +8,7 @@ vshard bootstrapping, and failover.
 * `cartridge_app_name` (`string`): application name, required;
 * `cartridge_cluster_cookie` (`string`): cluster cookie for all
   cluster instances;
-* `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`) - indicates if
-  cluster cookie shouldn't be persisted in application configuration file;
+* `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`) - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
 * `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
   indicates if temporary files should be removed
   (more details in description of [`cleanup` step API](/doc/scenario.md#cleanup));

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -8,8 +8,8 @@ vshard bootstrapping, and failover.
 * `cartridge_app_name` (`string`): application name, required;
 * `cartridge_cluster_cookie` (`string`): cluster cookie for all
   cluster instances;
-* `set_cluster_cookie_in_config` (`boolean`, default: `true`) - indicates if
-  cluster cookie should be persisted in application configuration file;
+* `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`) - indicates if
+  cluster cookie shouldn't be persisted in application configuration file;
 * `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
   indicates if temporary files should be removed
   (more details in description of [`cleanup` step API](/doc/scenario.md#cleanup));

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -8,6 +8,8 @@ vshard bootstrapping, and failover.
 * `cartridge_app_name` (`string`): application name, required;
 * `cartridge_cluster_cookie` (`string`): cluster cookie for all
   cluster instances;
+* `set_cluster_cookie_in_config` (`boolean`, default: `true`) - indicates if
+  cluster cookie should be persisted in application configuration file;
 * `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
   indicates if temporary files should be removed
   (more details in description of [`cleanup` step API](/doc/scenario.md#cleanup));

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -18,7 +18,7 @@ FACTS_BY_TARGETS = {
         'cartridge_auth',
         'cartridge_bootstrap_vshard',
         'cartridge_cluster_cookie',
-        'set_cluster_cookie_in_config',
+        'cartridge_not_save_cookie_in_app_config',
         'cartridge_conf_dir',
         'cartridge_configure_systemd_unit_files',
         'cartridge_configure_tmpfiles',

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -18,6 +18,7 @@ FACTS_BY_TARGETS = {
         'cartridge_auth',
         'cartridge_bootstrap_vshard',
         'cartridge_cluster_cookie',
+        'set_cluster_cookie_in_config',
         'cartridge_conf_dir',
         'cartridge_configure_systemd_unit_files',
         'cartridge_configure_tmpfiles',

--- a/library/cartridge_get_needs_restart.py
+++ b/library/cartridge_get_needs_restart.py
@@ -13,7 +13,7 @@ argument_spec = {
     'config': {'required': False, 'type': 'dict'},
     'cartridge_defaults': {'required': False, 'type': 'dict'},
     'cluster_cookie': {'required': False, 'type': 'str'},
-    'set_cluster_cookie_in_config': {'required': False, 'type': 'bool'},
+    'cartridge_not_save_cookie_in_app_config': {'required': False, 'type': 'bool'},
     'stateboard': {'required': False, 'type': 'bool'},
 }
 
@@ -65,7 +65,7 @@ def check_needs_restart_to_update_config(params, control_console):
         'app_name',
         'config',
         'cartridge_defaults',
-        'set_cluster_cookie_in_config',
+        'cartridge_not_save_cookie_in_app_config',
         'stateboard',
     }
     for arg in required_args:
@@ -77,12 +77,12 @@ def check_needs_restart_to_update_config(params, control_console):
     new_instance_conf = params['config']
     new_default_conf = params['cartridge_defaults']
     cluster_cookie = params.get('cluster_cookie')
-    set_cluster_cookie_in_config = params['set_cluster_cookie_in_config']
+    cartridge_not_save_cookie_in_app_config = params['cartridge_not_save_cookie_in_app_config']
     stateboard = params['stateboard']
 
-    if set_cluster_cookie_in_config and cluster_cookie is None:
+    if not cartridge_not_save_cookie_in_app_config and cluster_cookie is None:
         return None, "'cartridge_cluster_cookie' should be set to check for configuration updates " + \
-            "when 'set_cluster_cookie_in_config' is true"
+            "when 'cartridge_not_save_cookie_in_app_config' is false"
 
     if not os.path.exists(instance_info['conf_file']):
         return True, None
@@ -112,7 +112,7 @@ def check_needs_restart_to_update_config(params, control_console):
         if err is not None:
             return None, "Failed to read current default config: %s" % err
 
-        if set_cluster_cookie_in_config:
+        if not cartridge_not_save_cookie_in_app_config:
             new_default_conf.update({'cluster_cookie': cluster_cookie})
         if check_conf_updated(new_default_conf, current_default_conf, helpers.DYNAMIC_BOX_CFG_PARAMS):
             return True, None

--- a/library/cartridge_get_needs_restart.py
+++ b/library/cartridge_get_needs_restart.py
@@ -113,7 +113,7 @@ def check_needs_restart_to_update_config(params, control_console):
             return None, "Failed to read current default config: %s" % err
 
         if not cartridge_not_save_cookie_in_app_config:
-            new_default_conf.update({'cluster_cookie': cluster_cookie})
+            new_default_conf['cluster_cookie'] = cluster_cookie
         if check_conf_updated(new_default_conf, current_default_conf, helpers.DYNAMIC_BOX_CFG_PARAMS):
             return True, None
 

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -14,7 +14,7 @@ INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'config']
 PARAMS_THE_SAME_FOR_ALL_HOSTS = [
     'cartridge_app_name',
     'cartridge_cluster_cookie',
-    'set_cluster_cookie_in_config',
+    'cartridge_not_save_cookie_in_app_config',
     'cartridge_auth',
     'cartridge_bootstrap_vshard',
     'cartridge_failover',
@@ -92,7 +92,7 @@ SCHEMA = {
     'cartridge_package_path': str,
     'cartridge_app_name': str,
     'cartridge_cluster_cookie': str,
-    'set_cluster_cookie_in_config': bool,
+    'cartridge_not_save_cookie_in_app_config': bool,
     'cartridge_defaults': dict,
     'cartridge_bootstrap_vshard': bool,
     'cartridge_wait_buckets_discovery': bool,

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -14,6 +14,7 @@ INSTANCE_REQUIRED_PARAMS = ['cartridge_app_name', 'config']
 PARAMS_THE_SAME_FOR_ALL_HOSTS = [
     'cartridge_app_name',
     'cartridge_cluster_cookie',
+    'set_cluster_cookie_in_config',
     'cartridge_auth',
     'cartridge_bootstrap_vshard',
     'cartridge_failover',
@@ -91,6 +92,7 @@ SCHEMA = {
     'cartridge_package_path': str,
     'cartridge_app_name': str,
     'cartridge_cluster_cookie': str,
+    'set_cluster_cookie_in_config': bool,
     'cartridge_defaults': dict,
     'cartridge_bootstrap_vshard': bool,
     'cartridge_wait_buckets_discovery': bool,

--- a/molecule/cluster_cookie/Dockerfile.j2
+++ b/molecule/cluster_cookie/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/cluster_cookie/converge.yml
+++ b/molecule/cluster_cookie/converge.yml
@@ -25,7 +25,7 @@
 
     - name: 'Check instance cluster cookie'
       assert:
-        msg: 'Received bad cluster cookie'
-        success_msg: 'Received cluster cookie is OK'
+        msg: 'Default Cartridge cluster cookie should be set'
+        success_msg: 'Default Cartridge cluster cookie is set'
         that: >-
           eval_res[0] == "secret-cluster-cookie"

--- a/molecule/cluster_cookie/converge.yml
+++ b/molecule/cluster_cookie/converge.yml
@@ -1,0 +1,31 @@
+---
+
+- name: 'Configure instances'
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - eval
+    cartridge_eval_body:
+      return require('cartridge.cluster-cookie').cookie()
+
+- name: 'Print and check instances cluster cookie'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Debug instance cluster cookie'
+      debug:
+        msg: '{{ eval_res[0] }}'
+
+    - name: 'Check instance cluster cookie'
+      assert:
+        msg: 'Received bad cluster cookie'
+        success_msg: 'Received cluster cookie is OK'
+        that: >-
+          eval_res[0] == "secret-cluster-cookie"

--- a/molecule/cluster_cookie/hosts.yml
+++ b/molecule/cluster_cookie/hosts.yml
@@ -1,0 +1,49 @@
+---
+cluster:
+  vars:
+    # common connection opts
+    ansible_user: root
+    ansible_connection: docker
+    become: true
+    become_user: root
+
+    # common cartridge opts
+    cartridge_app_name: myapp
+
+    cartridge_cluster_cookie: 'some-cookie-from-inventory'
+    set_cluster_cookie_in_config: false
+
+    cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
+
+    cartridge_auth:
+      enabled: true
+
+  # instances
+  hosts:
+    instance-1:
+      config:
+        advertise_uri: 'vm1:3101'
+        http_port: 8101
+
+    instance-2:
+      config:
+        advertise_uri: 'vm1:3102'
+        http_port: 8102
+
+  children:
+    # group by hosts
+    machine_1:
+      vars:
+        ansible_host: vm1
+
+      hosts:
+        instance-1:
+        instance-2:
+
+    replicaset_1:
+      vars:
+        replicaset_alias: rpl-1
+
+      hosts:
+        instance-1:
+        instance-2:

--- a/molecule/cluster_cookie/hosts.yml
+++ b/molecule/cluster_cookie/hosts.yml
@@ -11,7 +11,7 @@ cluster:
     cartridge_app_name: myapp
 
     cartridge_cluster_cookie: 'some-cookie-from-inventory'
-    set_cluster_cookie_in_config: false
+    cartridge_not_save_cookie_in_app_config: true
 
     cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
 

--- a/molecule/cluster_cookie/molecule.yml
+++ b/molecule/cluster_cookie/molecule.yml
@@ -1,0 +1,1 @@
+../common/molecule/1_vm_not_idempotent.yml

--- a/molecule/cluster_cookie/prepare.yml
+++ b/molecule/cluster_cookie/prepare.yml
@@ -1,0 +1,22 @@
+---
+
+- name: 'Configure instances'
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_scenario:
+      - deliver_package
+      - update_package
+      - update_instance
+      - configure_instance
+      - restart_instance
+      - wait_instance_started
+      - connect_to_membership
+      - edit_topology
+      - configure_auth
+      - wait_members_alive
+      - wait_cluster_has_no_issues

--- a/molecule/cluster_cookie/tests/test_instances.py
+++ b/molecule/cluster_cookie/tests/test_instances.py
@@ -1,0 +1,1 @@
+../../common/tests/test_instances.py

--- a/molecule/common/tests/test_instances.py
+++ b/molecule/common/tests/test_instances.py
@@ -111,7 +111,7 @@ def test_configs(host):
 
     default_conf = utils.get_cluster_var('cartridge_defaults', default={})
 
-    not_save_cookie_in_app_config = utils.get_cluster_var('cartridge_not_save_cookie_in_app_config', True)
+    not_save_cookie_in_app_config = utils.get_cluster_var('cartridge_not_save_cookie_in_app_config', False)
     if not not_save_cookie_in_app_config:
         default_conf.update(cluster_cookie=utils.get_cluster_cookie())
 

--- a/molecule/common/tests/test_instances.py
+++ b/molecule/common/tests/test_instances.py
@@ -110,7 +110,10 @@ def test_configs(host):
     assert machine_instances
 
     default_conf = utils.get_cluster_var('cartridge_defaults', default={})
-    default_conf.update(cluster_cookie=utils.get_cluster_cookie())
+
+    cookie_set_in_config = utils.get_cluster_var('set_cluster_cookie_in_config', True)
+    if cookie_set_in_config:
+        default_conf.update(cluster_cookie=utils.get_cluster_cookie())
 
     for instance in machine_instances:
         instance_vars = utils.get_instance_vars(instance)

--- a/molecule/common/tests/test_instances.py
+++ b/molecule/common/tests/test_instances.py
@@ -111,8 +111,8 @@ def test_configs(host):
 
     default_conf = utils.get_cluster_var('cartridge_defaults', default={})
 
-    cookie_set_in_config = utils.get_cluster_var('set_cluster_cookie_in_config', True)
-    if cookie_set_in_config:
+    not_save_cookie_in_app_config = utils.get_cluster_var('cartridge_not_save_cookie_in_app_config', True)
+    if not not_save_cookie_in_app_config:
         default_conf.update(cluster_cookie=utils.get_cluster_cookie())
 
     for instance in machine_instances:

--- a/molecule/common/tests/utils.py
+++ b/molecule/common/tests/utils.py
@@ -97,8 +97,8 @@ def get_app_name():
 def get_cluster_cookie():
     global __cluster_cookie
     if __cluster_cookie is None:
-        cookie_set_in_config = get_cluster_var('set_cluster_cookie_in_config', True)
-        if cookie_set_in_config:
+        not_save_cookie_in_app_config = get_cluster_var('cartridge_not_save_cookie_in_app_config', False)
+        if not not_save_cookie_in_app_config:
             __cluster_cookie = get_cluster_var('cartridge_cluster_cookie')
         else:
             __cluster_cookie = DEFAULT_CLUSTER_COOKIE

--- a/molecule/common/tests/utils.py
+++ b/molecule/common/tests/utils.py
@@ -9,6 +9,7 @@ from ansible.parsing.dataloader import DataLoader
 scenario_name = os.environ['MOLECULE_SCENARIO_NAME']
 
 DEFAULT_APP_NAME = 'myapp'
+DEFAULT_CLUSTER_COOKIE = 'secret-cluster-cookie'
 
 __inventory = None
 __variable_manager = None
@@ -96,7 +97,11 @@ def get_app_name():
 def get_cluster_cookie():
     global __cluster_cookie
     if __cluster_cookie is None:
-        __cluster_cookie = get_cluster_var('cartridge_cluster_cookie')
+        cookie_set_in_config = get_cluster_var('set_cluster_cookie_in_config', True)
+        if cookie_set_in_config:
+            __cluster_cookie = get_cluster_var('cartridge_cluster_cookie')
+        else:
+            __cluster_cookie = DEFAULT_CLUSTER_COOKIE
 
     return __cluster_cookie
 
@@ -105,6 +110,7 @@ def get_authorized_session():
     global __authorized_session
     if __authorized_session is None:
         cluster_cookie = get_cluster_cookie()
+
         __authorized_session = requests.Session()
         __authorized_session.auth = ('admin', cluster_cookie)
 

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -8,7 +8,7 @@
 
       cartridge_app_name: '{{ cartridge_app_name }}'
       cartridge_cluster_cookie: '{{ cartridge_cluster_cookie }}'
-      set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
+      cartridge_not_save_cookie_in_app_config: '{{ cartridge_not_save_cookie_in_app_config }}'
       cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
 
       # Role scenario configuration

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -8,6 +8,7 @@
 
       cartridge_app_name: '{{ cartridge_app_name }}'
       cartridge_cluster_cookie: '{{ cartridge_cluster_cookie }}'
+      set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
       cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
 
       # Role scenario configuration

--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -16,7 +16,7 @@
         config: '{{ config }}'
         cartridge_defaults: '{{ cartridge_defaults }}'
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
-        set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
+        cartridge_not_save_cookie_in_app_config: '{{ cartridge_not_save_cookie_in_app_config }}'
         stateboard: '{{ stateboard }}'
         instance_info: '{{ instance_info }}'
         check_config_updated: true
@@ -30,9 +30,9 @@
         needs_restart: '{{ needs_restart_res.fact }}'
       when: "'fact' in needs_restart_res"
 
-    - name: 'Check that cluster cookie is specified or set_cluster_cookie_in_config is false'
+    - name: 'Check that cluster cookie is specified or cartridge_not_save_cookie_in_app_config is true'
       assert:
-        that: cartridge_cluster_cookie is not none or not set_cluster_cookie_in_config
+        that: cartridge_not_save_cookie_in_app_config or cartridge_cluster_cookie is not none
         msg: 'cartridge_cluster_cookie should be specified to configure instance'
         quiet: true
       when: inventory_hostname in single_instances_for_each_machine
@@ -44,7 +44,7 @@
             {
               cartridge_app_name: cartridge_defaults | combine(
                 {"cluster_cookie": cartridge_cluster_cookie}
-                if set_cluster_cookie_in_config
+                if not cartridge_not_save_cookie_in_app_config
                 else {}
               )
             } | to_nice_yaml

--- a/tasks/steps/configure_instance.yml
+++ b/tasks/steps/configure_instance.yml
@@ -16,6 +16,7 @@
         config: '{{ config }}'
         cartridge_defaults: '{{ cartridge_defaults }}'
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
+        set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
         stateboard: '{{ stateboard }}'
         instance_info: '{{ instance_info }}'
         check_config_updated: true
@@ -29,9 +30,9 @@
         needs_restart: '{{ needs_restart_res.fact }}'
       when: "'fact' in needs_restart_res"
 
-    - name: 'Check that cluster cookie is specified'
+    - name: 'Check that cluster cookie is specified or set_cluster_cookie_in_config is false'
       assert:
-        that: cartridge_cluster_cookie is not none
+        that: cartridge_cluster_cookie is not none or not set_cluster_cookie_in_config
         msg: 'cartridge_cluster_cookie should be specified to configure instance'
         quiet: true
       when: inventory_hostname in single_instances_for_each_machine
@@ -40,8 +41,13 @@
       copy:
         content: >-
           {{
-            { cartridge_app_name: cartridge_defaults | combine({"cluster_cookie": cartridge_cluster_cookie}) }
-            | to_nice_yaml
+            {
+              cartridge_app_name: cartridge_defaults | combine(
+                {"cluster_cookie": cartridge_cluster_cookie}
+                if set_cluster_cookie_in_config
+                else {}
+              )
+            } | to_nice_yaml
           }}
         dest: '{{ instance_info.app_conf_file }}'
         owner: '{{ cartridge_app_user }}'

--- a/tasks/steps/restart_instance.yml
+++ b/tasks/steps/restart_instance.yml
@@ -12,6 +12,7 @@
         config: '{{ config }}'
         cartridge_defaults: '{{ cartridge_defaults }}'
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
+        set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
         stateboard: '{{ stateboard }}'
         instance_info: '{{ instance_info }}'
         check_package_updated: true

--- a/tasks/steps/restart_instance.yml
+++ b/tasks/steps/restart_instance.yml
@@ -12,7 +12,7 @@
         config: '{{ config }}'
         cartridge_defaults: '{{ cartridge_defaults }}'
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
-        set_cluster_cookie_in_config: '{{ set_cluster_cookie_in_config }}'
+        cartridge_not_save_cookie_in_app_config: '{{ cartridge_not_save_cookie_in_app_config }}'
         stateboard: '{{ stateboard }}'
         instance_info: '{{ instance_info }}'
         check_package_updated: true

--- a/unit/instance.py
+++ b/unit/instance.py
@@ -208,9 +208,10 @@ class Instance:
         )
         self.write_file(instance_conf_file, conf)
 
-    def set_app_config(self, config):
+    def set_app_config(self, config, set_cookie=True):
         config = config.copy()
-        config.update({'cluster_cookie': self.COOKIE})
+        if set_cookie:
+            config.update({'cluster_cookie': self.COOKIE})
 
         params = ', '.join([
             '{}: {}'.format(k, v)

--- a/unit/test_get_needs_restart.py
+++ b/unit/test_get_needs_restart.py
@@ -94,6 +94,50 @@ class TestGetNeedsRestart(unittest.TestCase):
             "updates when 'set_cluster_cookie_in_config' is true"
         )
 
+        # cookie isn't in config
+        self.instance.set_app_config({}, set_cookie=False)
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=False,
+            cluster_cookie="some-new-cookie",
+        )
+        self.assertFalse(res.failed, res.msg)
+        self.assertFalse(res.fact)
+
+        # cookie was in config, but now it isn't
+        self.instance.set_app_config({})
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=False,
+            cluster_cookie="some-new-cookie",
+        )
+        self.assertFalse(res.failed, res.msg)
+        self.assertTrue(res.fact)
+
+        # cookie is in config and it changed
+        self.instance.set_app_config({})
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=True,
+            cluster_cookie="some-new-cookie",
+        )
+        self.assertFalse(res.failed, res.msg)
+        self.assertTrue(res.fact)
+
+        # cookie wasn't in config, but now it is
+        self.instance.set_app_config({}, set_cookie=False)
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=True,
+            cluster_cookie=self.instance.COOKIE,
+        )
+        self.assertFalse(res.failed, res.msg)
+        self.assertTrue(res.fact)
+
     def test_instance_not_started(self):
         # console sock doesn't exists
         self.instance.remove_file(self.console_sock)

--- a/unit/test_get_needs_restart.py
+++ b/unit/test_get_needs_restart.py
@@ -20,6 +20,7 @@ def call_needs_restart(
     instance_id=Instance.instance_id,
     config=None,
     cluster_cookie=Instance.COOKIE,
+    set_cluster_cookie_in_config=True,
     cartridge_defaults=None,
     stateboard=False,
     check_package_updated=False,
@@ -39,6 +40,7 @@ def call_needs_restart(
         'config': config or {},
         'cartridge_defaults': cartridge_defaults or {},
         'cluster_cookie': cluster_cookie,
+        'set_cluster_cookie_in_config': set_cluster_cookie_in_config,
         'stateboard': stateboard,
         'instance_info': instance_info,
         'check_package_updated': check_package_updated,
@@ -61,7 +63,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         self.instance.start()
 
     def test_optional_fields(self):
-        for key in ['app_name', 'config', 'cartridge_defaults', 'cluster_cookie', 'stateboard']:
+        for key in ['app_name', 'config', 'cartridge_defaults', 'stateboard']:
             res = call_needs_restart(
                 console_sock=self.console_sock,
                 check_config_updated=True,
@@ -69,6 +71,28 @@ class TestGetNeedsRestart(unittest.TestCase):
             )
             self.assertTrue(res.failed)
             self.assertEqual(res.msg, "Argument '%s' is required to check for configuration updates" % key)
+
+    def test_cluster_cookie(self):
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=False,
+            cluster_cookie=None,
+        )
+        self.assertFalse(res.failed)
+
+        res = call_needs_restart(
+            console_sock=self.console_sock,
+            check_config_updated=True,
+            set_cluster_cookie_in_config=True,
+            cluster_cookie=None,
+        )
+        self.assertTrue(res.failed)
+        self.assertEqual(
+            res.msg,
+            "'cartridge_cluster_cookie' should be set to check for configuration "
+            "updates when 'set_cluster_cookie_in_config' is true"
+        )
 
     def test_instance_not_started(self):
         # console sock doesn't exists

--- a/unit/test_get_needs_restart.py
+++ b/unit/test_get_needs_restart.py
@@ -20,7 +20,7 @@ def call_needs_restart(
     instance_id=Instance.instance_id,
     config=None,
     cluster_cookie=Instance.COOKIE,
-    set_cluster_cookie_in_config=True,
+    cartridge_not_save_cookie_in_app_config=False,
     cartridge_defaults=None,
     stateboard=False,
     check_package_updated=False,
@@ -40,7 +40,7 @@ def call_needs_restart(
         'config': config or {},
         'cartridge_defaults': cartridge_defaults or {},
         'cluster_cookie': cluster_cookie,
-        'set_cluster_cookie_in_config': set_cluster_cookie_in_config,
+        'cartridge_not_save_cookie_in_app_config': cartridge_not_save_cookie_in_app_config,
         'stateboard': stateboard,
         'instance_info': instance_info,
         'check_package_updated': check_package_updated,
@@ -76,7 +76,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=False,
+            cartridge_not_save_cookie_in_app_config=True,
             cluster_cookie=None,
         )
         self.assertFalse(res.failed)
@@ -84,14 +84,14 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=True,
+            cartridge_not_save_cookie_in_app_config=False,
             cluster_cookie=None,
         )
         self.assertTrue(res.failed)
         self.assertEqual(
             res.msg,
             "'cartridge_cluster_cookie' should be set to check for configuration "
-            "updates when 'set_cluster_cookie_in_config' is true"
+            "updates when 'cartridge_not_save_cookie_in_app_config' is false"
         )
 
         # cookie isn't in config
@@ -99,7 +99,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=False,
+            cartridge_not_save_cookie_in_app_config=True,
             cluster_cookie="some-new-cookie",
         )
         self.assertFalse(res.failed, res.msg)
@@ -110,7 +110,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=False,
+            cartridge_not_save_cookie_in_app_config=True,
             cluster_cookie="some-new-cookie",
         )
         self.assertFalse(res.failed, res.msg)
@@ -121,7 +121,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=True,
+            cartridge_not_save_cookie_in_app_config=False,
             cluster_cookie="some-new-cookie",
         )
         self.assertFalse(res.failed, res.msg)
@@ -132,7 +132,7 @@ class TestGetNeedsRestart(unittest.TestCase):
         res = call_needs_restart(
             console_sock=self.console_sock,
             check_config_updated=True,
-            set_cluster_cookie_in_config=True,
+            cartridge_not_save_cookie_in_app_config=False,
             cluster_cookie=self.instance.COOKIE,
         )
         self.assertFalse(res.failed, res.msg)

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -87,7 +87,7 @@ class TestValidateConfig(unittest.TestCase):
                 'allow_warning_issues',
                 'show_issues',
                 'cartridge_eval_with_retries',
-                'set_cluster_cookie_in_config',
+                'cartridge_not_save_cookie_in_app_config',
             },
             dict: {
                 'cartridge_defaults',
@@ -284,7 +284,7 @@ class TestValidateConfig(unittest.TestCase):
         params = {
             'cartridge_app_name': ['app-name', 'other-app-name'],
             'cartridge_cluster_cookie': ['cookie', 'other-cookie'],
-            'set_cluster_cookie_in_config': [True, False],
+            'cartridge_not_save_cookie_in_app_config': [True, False],
             'cartridge_auth': [{'enabled': True}, {'enabled': False}],
             'cartridge_bootstrap_vshard': [True, False],
             'cartridge_failover': [True, False],

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -87,6 +87,7 @@ class TestValidateConfig(unittest.TestCase):
                 'allow_warning_issues',
                 'show_issues',
                 'cartridge_eval_with_retries',
+                'set_cluster_cookie_in_config',
             },
             dict: {
                 'cartridge_defaults',
@@ -283,6 +284,7 @@ class TestValidateConfig(unittest.TestCase):
         params = {
             'cartridge_app_name': ['app-name', 'other-app-name'],
             'cartridge_cluster_cookie': ['cookie', 'other-cookie'],
+            'set_cluster_cookie_in_config': [True, False],
             'cartridge_auth': [{'enabled': True}, {'enabled': False}],
             'cartridge_bootstrap_vshard': [True, False],
             'cartridge_failover': [True, False],


### PR DESCRIPTION
Added `cartridge_not_save_cookie_in_app_config` variable that allows disabling persisting cluster
cookie in the application configuration file. In this case, it's the user's responsibility to configure 
the cluster cookie for all instances. 

Closes #330 