### PR TITLE
Fixes for Ansible 4.0

### DIFF
--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -49,6 +49,7 @@ def main(event_name, repo_owner, review_state, ref):
 
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
         ce_matrix.append(get_ce_params(molecule_scenario='check_facts'))
+        ce_matrix.append(get_ce_params(molecule_scenario='cluster_cookie'))
         ce_matrix.append(get_ce_params(molecule_scenario='config_upload'))
         ce_matrix.append(get_ce_params(molecule_scenario='dead_instances'))
         ce_matrix.append(get_ce_params(molecule_scenario='eval'))
@@ -64,6 +65,7 @@ def main(event_name, repo_owner, review_state, ref):
 
         ce_matrix.append(get_ce_params(ansible_version='2.9.0'))
         ce_matrix.append(get_ce_params(ansible_version='2.10.0'))
+        ce_matrix.append(get_ce_params(ansible_version='4.0.0'))
 
         # TODO: Uncomment after fixing the check mode
         # ce_matrix.append(get_ce_version(molecule_command='check'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ README.md to use the newest tag with new release
 
 - Fail on getting control instance when all unjoined instances haven't
   `replicaset_alias` set
+- Support of Ansible 4.0
 
 ### Added
 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -23,6 +23,9 @@
   run_once: true
   delegate_to: localhost
   become: false
+  when: >-
+    cartridge_delivered_package_path or
+    cartridge_control_instance
 
 - name: 'Collect instance info'
   cartridge_get_instance_info:


### PR DESCRIPTION
Task 'Set facts that can be set by the user' fell on Ansible 4.0.

Now it works.
Also added skipped molecule test.