### PR TITLE
Handle bad membership members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ README.md to use the newest tag with new release
 - Fail on getting control instance when all unjoined instances haven't
   `replicaset_alias` set
 - Support of Ansible 4.0
+- Handling of bad membership members - empty or with empty payload
 
 ### Added
 

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -93,6 +93,9 @@ def candidate_is_ok(uri, names_by_uris, module_hostvars):
 def get_control_instance_name(module_hostvars, play_hosts, control_console):
     members = get_membership_members(control_console)
 
+    if not members:
+        return None, "Membership is empty"
+
     # try to find joined alive instance that isn't set to be expelled
     alive_instances_uris = set()
     joined_instances_uris = set()
@@ -102,9 +105,15 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
     names_by_uris = {}
 
     for uri, member in sorted(members.items()):
+        if not member:
+            return None, "Membership contains empty member with URI %s" % uri
+
         member_payload = member.get('payload')
         if member_payload is None:
             return None, "Instance with URI %s doesn't contain payload" % uri
+
+        if not member_payload:
+            return None, "Instance with URI %s has empty payload" % uri
 
         instance_name = member_payload.get('alias')
         if instance_name is None:

--- a/unit/instance.py
+++ b/unit/instance.py
@@ -278,6 +278,11 @@ class Instance:
 
         for m in specified_members:
             uri = m['uri']
+
+            if m.get('empty'):
+                members[uri] = {}
+                continue
+
             member = {
                 'uri': uri,
                 'status': m.get('status', 'alive'),
@@ -292,6 +297,9 @@ class Instance:
                         'state': m.get('state'),
                     }
                 })
+
+            if m.get('empty_payload'):
+                member.update({"payload": {}})
 
             members[uri] = member
 

--- a/unit/utils.py
+++ b/unit/utils.py
@@ -1,5 +1,14 @@
-def get_member(alias, with_alias=True, uuid=None, with_uuid=False, status=None, state=None):
+def get_member(alias, with_alias=True, empty=False, empty_payload=False,
+               uuid=None, with_uuid=False, status=None, state=None):
     member = {'uri': '%s-uri' % alias}
+
+    if empty:
+        member.update({'empty': True})
+        return member
+
+    if empty_payload:
+        member.update({'empty_payload': True})
+        return member
 
     if with_alias:
         member.update({'alias': alias})


### PR DESCRIPTION
Before this patch getting control instance failed on checking membership members
if some member payload is empty. It caused because an empty Lua table is serialized
as an empty array, but the Python module expects a dict. Since this patch, all empty
table cases are handled for membership.