### PR TITLE
Fix long facts caching on second role import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Fixed
+
+- Long facts caching when playbook has two or more role imports.
+
 ### Added
 
 - Step `cleanup_instance_files` to clean up data of stopped instance.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -173,6 +173,13 @@ temporary_files: []
 needs_restart: null
 alive_not_expelled_instance: null
 
+# Temp facts
+
+cached_facts_res: null
+cached_facts: null
+single_instances_for_each_machine_res: null
+single_instances_for_each_machine: null
+
 # Eval params
 
 cartridge_eval_file: null

--- a/molecule/common/molecule/1_vm.yml
+++ b/molecule/common/molecule/1_vm.yml
@@ -29,6 +29,9 @@ provisioner:
   inventory:
     links:
       hosts: hosts.yml
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
 
 verifier:
   name: testinfra

--- a/molecule/common/molecule/1_vm_not_idempotent.yml
+++ b/molecule/common/molecule/1_vm_not_idempotent.yml
@@ -29,6 +29,9 @@ provisioner:
   inventory:
     links:
       hosts: hosts.yml
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
 
 verifier:
   name: testinfra

--- a/molecule/common/molecule/2_vm.yml
+++ b/molecule/common/molecule/2_vm.yml
@@ -42,6 +42,9 @@ provisioner:
   inventory:
     links:
       hosts: hosts.yml
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
 
 verifier:
   name: testinfra

--- a/molecule/common/molecule/2_vm_not_idempotent.yml
+++ b/molecule/common/molecule/2_vm_not_idempotent.yml
@@ -42,6 +42,9 @@ provisioner:
   inventory:
     links:
       hosts: hosts.yml
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
 
 verifier:
   name: testinfra

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -66,6 +66,9 @@ provisioner:
   inventory:
     links:
       hosts: hosts.yml
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
 
 verifier:
   name: testinfra

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,3 +55,13 @@
     - cartridge-instances
     - cartridge-replicasets
     - cartridge-config
+
+- name: 'Cleanup temp facts'
+  set_fact:
+    cached_facts_res: null
+    cached_facts: null
+    single_instances_for_each_machine_res: null
+    single_instances_for_each_machine: null
+  run_once: true
+  delegate_to: localhost
+  become: false

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -51,7 +51,7 @@
   set_fact:
     instance_info: '{{ instance_info_res.fact }}'
 
-- name: 'Get shortened vars sets'
+- name: 'Cache facts for different targets'
   cartridge_get_cached_facts:
     hostvars: '{{ hostvars }}'
   run_once: true
@@ -59,7 +59,7 @@
   become: false
   register: cached_facts_res
 
-- name: 'Cache facts for different targets'
+- name: 'Set "cached_facts" fact'
   set_fact:
     cached_facts: '{{ cached_facts_res.facts }}'
   run_once: true

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -133,6 +133,13 @@
       needs_restart: '{{ needs_restart }}'
       alive_not_expelled_instance: '{{ alive_not_expelled_instance }}'
 
+      # Temp facts
+
+      cached_facts_res: '{{ cached_facts_res }}'
+      cached_facts: '{{ cached_facts }}'
+      single_instances_for_each_machine_res: '{{ single_instances_for_each_machine_res }}'
+      single_instances_for_each_machine: '{{ single_instances_for_each_machine }}'
+
       # Eval params
 
       cartridge_eval_file: '{{ cartridge_eval_file }}'


### PR DESCRIPTION
Before this patch `cached_facts` and `cached_facts_res` facts weren't clean
on role prepare. As a result, `hostvars` become huge after the first role
import and caching facts on next imports become much more longer