### PR TITLE
Fix select control instance task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ README.md to use the newest tag with new release
 
 - Hosts uniqueness considers `ansible_port`, not only `ansible_host`
 
+### Fixed
+
+- Now select control instance task ignores bad instances from membership.
+
 ## [1.10.0] - 2021-06-04
 
 ### Added

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -114,10 +114,6 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
         member_incarnation = member.get('incarnation')
         member_status = member.get('status')
 
-        if member_status == 'left':
-            # ignore it, because it was expelled
-            continue
-
         if not member_incarnation or not member_status or not member_payload or not member_payload.get('alias'):
             # it's possible for old instances, but it can be an error
             alien_members_uris.append(uri)
@@ -153,7 +149,7 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
         uuid = member['payload'].get('uuid')
 
         instance_vars = module_hostvars.get(alias)
-        if instance_vars is None:
+        if instance_vars is None and status != 'left':
             return None, "Membership contains instance %s that isn't described in inventory" % alias
 
         names_by_uris[uri] = alias

--- a/library/cartridge_get_control_instance.py
+++ b/library/cartridge_get_control_instance.py
@@ -99,14 +99,14 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
     if err is not None:
         return None, err
 
-    strange_members_uris = []
+    alien_members_uris = []
     members_without_uuid = []
     members_by_uuid = {}
 
     for uri, member in sorted(members.items()):
         if not member:
             # it's impossible :)
-            strange_members_uris.append(uri)
+            alien_members_uris.append(uri)
             continue
 
         member['uri'] = uri
@@ -120,7 +120,7 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
 
         if not member_incarnation or not member_status or not member_payload or not member_payload.get('alias'):
             # it's possible for old instances, but it can be an error
-            strange_members_uris.append(uri)
+            alien_members_uris.append(uri)
             continue
 
         member_uuid = member_payload.get('uuid')
@@ -135,8 +135,8 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
 
         members_by_uuid[member_uuid] = member
 
-    if strange_members_uris:
-        helpers.warn('Incorrect members with the following URIs ignored: %s' % ', '.join(strange_members_uris))
+    if alien_members_uris:
+        helpers.warn('Incorrect members with the following URIs ignored: %s' % ', '.join(alien_members_uris))
 
     alive_instances_uris = set()
     joined_instances_uris = set()
@@ -145,11 +145,12 @@ def get_control_instance_name(module_hostvars, play_hosts, control_console):
 
     names_by_uris = {}
 
-    all_correct_members = list(members_by_uuid.items()) + list(map(lambda m: (None, m), members_without_uuid))
-    for uuid, member in all_correct_members:
+    all_correct_members = list(members_by_uuid.values()) + members_without_uuid
+    for member in all_correct_members:
         uri = member['uri']
         status = member['status']
         alias = member['payload']['alias']
+        uuid = member['payload'].get('uuid')
 
         instance_vars = module_hostvars.get(alias)
         if instance_vars is None:

--- a/molecule/dead_instances/converge.yml
+++ b/molecule/dead_instances/converge.yml
@@ -293,6 +293,10 @@
         cartridge_scenario:
           - set_control_instance
 
+    - name: 'Debug select control instance result'
+      debug: var=control_instance_res
+      run_once: true
+
     - name: 'Check setting control instance failed'
       assert:
         msg: 'Setting control instance should fail'


### PR DESCRIPTION
Closes #349
Closes #350 
Closes #354

Before the patch, expelled instances with status `left` were taken into account.
Old instances with small `incarnation` were taken into account too.

Now select control instance task ignores bad and old instances from membership.