### PR TITLE
Make test matrix automatically

### DIFF
--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -2,23 +2,77 @@
 
 import argparse
 import json
+import os
+
+#############
+# CONSTANTS #
+#############
+
+MOLECULE_SCENARIOS_PATH = './molecule'
+DEFAULT_SCENARIO = 'default'
+IGNORED_PATHS = [
+    'common',
+]
+
+DEFAULT_MOLECULE_COMMAND = 'test'
+NOT_DEFAULT_MOLECULE_COMMANDS = [
+    # TODO: Uncomment after fixing the check mode
+    # 'check'
+]
+
+DEFAULT_ANSIBLE_VERSION = '2.8.0'
+NOT_DEFAULT_ANSIBLE_VERSIONS = [
+    '2.9.0',
+    '2.10.0',
+    '4.1.0',
+]
+
+DEFAULT_TARANTOOL_VERSION = '2.6'
+NOT_DEFAULT_TNT_VERSIONS = [
+    '1.10'
+]
+
+DEFAULT_SDK_VERSION = '2.6.2-124-g2c3b91439-r391'
+NOT_DEFAULT_SDK_VERSIONS = []
+
+TDG_SCENARIOS = [
+    'config_upload_tdg'
+]
+DEFAULT_TDG_VERSION = '1.7.7-0-g76c31fca'
+TDG_VERSIONS = {
+    'config_upload_tdg': [
+        # auth-token header; no common.app_version; no admin.upload_config_api;
+        '1.6.10-4-g06ea889e',
+        # authorization header; no common.app_version; no admin.upload_config_api;
+        '1.7.1-0-g92920bea',
+        # auth-token header; common.app_version; admin.upload_config_api;
+        '1.6.16-0-g7e140c94',
+        # authorization header; common.app_version; admin.upload_config_api;
+        '1.7.7-0-g76c31fca',
+    ],
+}
+
+
+######################
+# MATRIX CALCULATION #
+######################
 
 
 def get_matrix_base(molecule_scenario=None, ansible_version=None):
     return {
-        'molecule_scenario': molecule_scenario or 'default',
-        'ansible_version': ansible_version or '2.8.0',
+        'molecule_scenario': molecule_scenario or DEFAULT_SCENARIO,
+        'ansible_version': ansible_version or DEFAULT_ANSIBLE_VERSION,
     }
 
 
 def get_molecule_command(molecule_command=None):
-    return molecule_command or 'test'
+    return molecule_command or DEFAULT_MOLECULE_COMMAND
 
 
 def get_ce_params(molecule_scenario=None, ansible_version=None, tarantool_version=None, molecule_command=None):
     return {
         **get_matrix_base(molecule_scenario, ansible_version),
-        'tarantool_version': tarantool_version or '2.6',
+        'tarantool_version': tarantool_version or DEFAULT_TARANTOOL_VERSION,
         'molecule_command': get_molecule_command(molecule_command),
     }
 
@@ -26,7 +80,7 @@ def get_ce_params(molecule_scenario=None, ansible_version=None, tarantool_versio
 def get_ee_params(molecule_scenario=None, ansible_version=None, sdk_version=None, molecule_command=None):
     return {
         **get_matrix_base(molecule_scenario, ansible_version),
-        'sdk_version': sdk_version or '2.6.2-124-g2c3b91439-r391',
+        'sdk_version': sdk_version or DEFAULT_SDK_VERSION,
         'molecule_command': get_molecule_command(molecule_command),
     }
 
@@ -34,7 +88,7 @@ def get_ee_params(molecule_scenario=None, ansible_version=None, sdk_version=None
 def get_tdg_params(molecule_scenario=None, ansible_version=None, tdg_version=None, molecule_command=None):
     return {
         **get_matrix_base(molecule_scenario, ansible_version),
-        'tdg_version': tdg_version or '',
+        'tdg_version': tdg_version or DEFAULT_TDG_VERSION,
         'molecule_command': get_molecule_command(molecule_command),
     }
 
@@ -48,39 +102,30 @@ def main(event_name, repo_owner, review_state, ref):
         ce_matrix.append(get_ce_params())
 
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
-        ce_matrix.append(get_ce_params(molecule_scenario='check_facts'))
-        ce_matrix.append(get_ce_params(molecule_scenario='cluster_cookie'))
-        ce_matrix.append(get_ce_params(molecule_scenario='cleanup_instance'))
-        ce_matrix.append(get_ce_params(molecule_scenario='config_upload'))
-        ce_matrix.append(get_ce_params(molecule_scenario='dead_instances'))
-        ce_matrix.append(get_ce_params(molecule_scenario='eval'))
-        ce_matrix.append(get_ce_params(molecule_scenario='needs_restart'))
-        ce_matrix.append(get_ce_params(molecule_scenario='package_name'))
-        ce_matrix.append(get_ce_params(molecule_scenario='patch_instance'))
-        ce_matrix.append(get_ce_params(molecule_scenario='rolling_update'))
-        ce_matrix.append(get_ce_params(molecule_scenario='start_stop'))
-        ce_matrix.append(get_ce_params(molecule_scenario='tasks_from'))
-        ce_matrix.append(get_ce_params(molecule_scenario='update_cartridge'))
+        ee_matrix.append(get_ee_params())
 
-        ce_matrix.append(get_ce_params(tarantool_version='1.10'))
+        for name in filter(
+            lambda scenario:
+            scenario != DEFAULT_SCENARIO and scenario not in IGNORED_PATHS and scenario not in TDG_SCENARIOS,
+            sorted(os.listdir(MOLECULE_SCENARIOS_PATH)),
+        ):
+            ce_matrix.append(get_ce_params(molecule_scenario=name))
 
-        ce_matrix.append(get_ce_params(ansible_version='2.9.0'))
-        ce_matrix.append(get_ce_params(ansible_version='2.10.0'))
-        ce_matrix.append(get_ce_params(ansible_version='4.1.0'))
+        for command in NOT_DEFAULT_MOLECULE_COMMANDS:
+            ce_matrix.append(get_ce_params(molecule_command=command))
 
-        # TODO: Uncomment after fixing the check mode
-        # ce_matrix.append(get_ce_version(molecule_command='check'))
+        for version in NOT_DEFAULT_ANSIBLE_VERSIONS:
+            ce_matrix.append(get_ce_params(ansible_version=version))
 
-        # Tests with enterprise bundle
-        ee_matrix.append(get_ee_params(sdk_version='2.6.2-124-g2c3b91439-r391'))
+        for version in NOT_DEFAULT_TNT_VERSIONS:
+            ce_matrix.append(get_ce_params(tarantool_version=version))
 
-        # TDG functionality: common.app_version [-]; admin.upload_config_api [-];
-        tdg_matrix.append(get_tdg_params(molecule_scenario='config_upload_tdg', tdg_version='1.6.10-4-g06ea889e'))
-        tdg_matrix.append(get_tdg_params(molecule_scenario='config_upload_tdg', tdg_version='1.7.1-0-g92920bea'))
+        for version in NOT_DEFAULT_SDK_VERSIONS:
+            ee_matrix.append(get_ee_params(sdk_version=version))
 
-        # TDG functionality: common.app_version [+]; admin.upload_config_api [+];
-        tdg_matrix.append(get_tdg_params(molecule_scenario='config_upload_tdg', tdg_version='1.6.16-0-g7e140c94'))
-        tdg_matrix.append(get_tdg_params(molecule_scenario='config_upload_tdg', tdg_version='1.7.7-0-g76c31fca'))
+        for name in TDG_SCENARIOS:
+            for version in TDG_VERSIONS.get(name, [None]):
+                tdg_matrix.append(get_tdg_params(molecule_scenario=name, tdg_version=version))
 
     print(f'::set-output name=ce-tests-found::{"true" if len(ce_matrix) > 0 else "false"}')
     print(f'::set-output name=ee-tests-found::{"true" if len(ee_matrix) > 0 else "false"}')

--- a/.github/helpers/count_molecule_matrix.py
+++ b/.github/helpers/count_molecule_matrix.py
@@ -104,11 +104,9 @@ def main(event_name, repo_owner, review_state, ref):
     if event_name == 'workflow_dispatch' or review_state == 'approved' or ref == 'refs/heads/master':
         ee_matrix.append(get_ee_params())
 
-        for name in filter(
-            lambda scenario:
-            scenario != DEFAULT_SCENARIO and scenario not in IGNORED_PATHS and scenario not in TDG_SCENARIOS,
-            sorted(os.listdir(MOLECULE_SCENARIOS_PATH)),
-        ):
+        all_scenarios = sorted(os.listdir(MOLECULE_SCENARIOS_PATH))
+        scenarios_to_skip = [DEFAULT_SCENARIO] + IGNORED_PATHS + TDG_SCENARIOS
+        for name in filter(lambda scenario: scenario not in scenarios_to_skip, all_scenarios):
             ce_matrix.append(get_ce_params(molecule_scenario=name))
 
         for command in NOT_DEFAULT_MOLECULE_COMMANDS:


### PR DESCRIPTION
Before the patch, it was possible forget to add molecule test to matrix.

Now matrix for molecule tests with defaults params is calculated automatically.