### PR TITLE
Add step to disable/enable instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ README.md to use the newest tag with new release
 - Add availability to set environment variables for instance service
 - Add `instances_from_same_machine` variable in preparation
 - Add `check_new_topology` step to compare inventory and real cluster topology
+- Availability to disable instances via `disabled` flag
 
 ### Changed
 

--- a/consistency/test_facts.py
+++ b/consistency/test_facts.py
@@ -53,6 +53,7 @@ class TestFacts(unittest.TestCase):
             'control_instance',
             'temporary_files',
             'needs_restart',
+            'cluster_disabled_instances',
             'alive_not_expelled_instance',
             'instance_backup_files',
             'backup_archive_path',

--- a/consistency/test_facts.py
+++ b/consistency/test_facts.py
@@ -54,6 +54,7 @@ class TestFacts(unittest.TestCase):
             'temporary_files',
             'needs_restart',
             'cluster_disabled_instances',
+            'inventory_disabled_instances',
             'alive_not_expelled_instance',
             'instance_backup_files',
             'backup_archive_path',

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ cartridge_app_name: null
 cartridge_cluster_cookie: null
 cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
+cartridge_ignore_split_brain: false
 cartridge_paths_to_keep_on_cleanup: []
 
 # Role scenario configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,6 +174,7 @@ control_instance: null
 temporary_files: []
 needs_restart: null
 cluster_disabled_instances: {}
+inventory_disabled_instances: {}
 alive_not_expelled_instance: null
 instance_backup_files: null
 backup_archive_path: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,7 +102,8 @@ zone: null
 cartridge_extra_env: null
 
 restarted: null
-expelled: false
+expelled: null
+disabled: null
 stateboard: false
 
 instance_start_timeout: null  # DEPRECATED
@@ -172,6 +173,7 @@ delivered_package_path: null
 control_instance: null
 temporary_files: []
 needs_restart: null
+cluster_disabled_instances: {}
 alive_not_expelled_instance: null
 instance_backup_files: null
 backup_archive_path: null

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -68,6 +68,9 @@ Some of useful variables always establishes during role preparation, so them can
   - `paths_to_remove_on_expel` - paths that will be removed on instance expel;
   - `files_to_remove_on_cleanup` - files that will be removed on instance cleanup;
   - `dirs_to_remove_on_cleanup` - dirs that will be removed on instance cleanup;
+  - `cluster_disabled_instances` - list of disabled instances from instance config;
+  - `cluster_topology_checksum` - checksum of topology section in instance config;
+- `cluster_disabled_instances` - disabled instances in cluster config;
 - `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine,
   for example, can be used in `delegate_to`;
 - `instances_from_same_machine` - dictionary, where key is the hostname of the instance,
@@ -139,8 +142,10 @@ Input variables from config:
 
 - `cartridge_package_path` - should be specified to compute app distribution directory
   (otherwise, `update_instance` is skipped);
-- `expelled` - indicates if instance must be expelled from topology;
-- `restarted` - if instance should be restarted or not (user forced decision);
+- `expelled` - indicates if instance must be expelled from topology
+  (to determine if it's should be checked if instance should be restarted);
+- `restarted` - if instance should be restarted or not (user forced decision)
+  (to determine if it's should be checked if instance should be restarted);
 - `cartridge_multiversion` - indicates that
   [multiversion approach](/doc/multiversion.md) is enabled;
 - `cartridge_app_user` - user which will own the links;
@@ -259,6 +264,7 @@ Edit topology of replicasets.
 Input variables from config (basic):
 
 - `expelled` - indicates if instance must be expelled from topology;
+- `disabled` - indicates if instance should be disabled;
 - `stateboard` - indicates that the instance is a stateboard;
 - `replicaset_alias` - replicaset alias, will be displayed in Web UI;
 - `roles` - roles to be enabled on the replicaset;
@@ -341,6 +347,7 @@ Bootstrap VShard in cluster.
 Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
+- `disabled` - indicates if instance should be disabled;
 - `stateboard` - indicates that the instance is a stateboard;
 - `cartridge_bootstrap_vshard` - indicates if vshard should be bootstrapped;
 - `bootstrap_vshard_retries` - retries to bootstrap vshard;

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -68,9 +68,10 @@ Some of useful variables always establishes during role preparation, so them can
   - `paths_to_remove_on_expel` - paths that will be removed on instance expel;
   - `files_to_remove_on_cleanup` - files that will be removed on instance cleanup;
   - `dirs_to_remove_on_cleanup` - dirs that will be removed on instance cleanup;
-  - `cluster_disabled_instances` - list of disabled instances from instance config;
-  - `cluster_topology_checksum` - checksum of topology section in instance config;
-- `cluster_disabled_instances` - disabled instances in cluster config;
+  - `disabled_instances` - list of disabled instances from instance config;
+  - `topology_checksum` - checksum of topology section from instance config;
+- `cluster_disabled_instances` - list of disabled instances from cluster config;
+- `inventory_disabled_instances` - list of disabled instances from inventory;
 - `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine,
   for example, can be used in `delegate_to`;
 - `instances_from_same_machine` - dictionary, where key is the hostname of the instance,

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -95,6 +95,7 @@ For more details see [scenario documentation](/doc/scenario.md).
   restarted or not (if this flag isn't specified, instance will be restarted if
   it's needed to apply configuration changes);
 * `expelled` (`boolean`, default: `false`): a boolean flag that indicates if instance must be expelled from topology;
+* `disabled` (`boolean`, default: `false`): a boolean flag that indicates if instance should be disabled;
 * `stateboard` (`boolean`, default: `false`): a boolean flag that indicates
    that the instance is a [stateboard](/doc/stateboard.md);
 * `instance_start_retries` (`number`, default: 10) retries to check that all instances become started;

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -8,11 +8,14 @@ vshard bootstrapping, and failover.
 * `cartridge_app_name` (`string`): application name, required;
 * `cartridge_cluster_cookie` (`string`): cluster cookie for all
   cluster instances;
-* `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`) - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
-* `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
+* `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`): flag
+  indicates that cluster cookie shouldn't be persisted in application configuration file;
+* `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`): flag
   indicates if temporary files should be removed
   (more details in description of [`cleanup` step API](/doc/steps.md#step-cleanup));
-* `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, optional, default: `[]`) -
+* `cartridge_ignore_split_brain` (`boolean`, optional, default: `false`): flag
+  indicates that detected split brain should be ignored on preparation stage;
+* `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, optional, default: `[]`):
   list of full paths or relative paths to work/memtx/vinyl/wal
   directory that should be kept on instance cleanup
   (it's possible to use bash patterns, e.g. `*.control`).

--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -68,6 +68,8 @@ def get_all_new_instances(module_hostvars):
         if helpers.is_expelled(instance_vars):
             instance['expelled'] = True
         else:
+            if instance_vars.get('disabled') is not None:
+                instance['disabled'] = instance_vars['disabled']
             if instance_vars.get('zone') is not None:
                 instance['zone'] = instance_vars['zone']
             if instance_vars.get('config') is not None:
@@ -454,6 +456,14 @@ def get_replicasets_params_for_changing_failover_priority(
 ####################################################
 
 
+def add_server_flag_if_required(server_params, new_instance, old_instance, flag_name):
+    if old_instance is not None:
+        if new_instance.get(flag_name, False) == old_instance.get(flag_name, False):
+            return
+
+    server_params[flag_name] = new_instance.get(flag_name, False)
+
+
 def add_server_param_if_required(server_params, new_instance, old_instance, param_name):
     if new_instance.get(param_name) is None:
         return
@@ -489,6 +499,9 @@ def get_server_params(instance_name, new_instance, old_instances, allow_missed_i
     if new_instance.get('expelled') is True:
         server_params['expelled'] = True
     else:
+        for flag_name in ['disabled']:
+            add_server_flag_if_required(server_params, new_instance, old_instance, flag_name)
+
         for param_name in ['zone', 'uri']:
             add_server_param_if_required(server_params, new_instance, old_instance, param_name)
 

--- a/library/cartridge_get_alive_not_expelled_instance.py
+++ b/library/cartridge_get_alive_not_expelled_instance.py
@@ -4,19 +4,19 @@ import socket
 
 from ansible.module_utils.helpers import Helpers as helpers
 
-
 argument_spec = {
     'module_hostvars': {'required': True, 'type': 'dict'},
     'play_hosts': {'required': True, 'type': 'list'},
+    'cluster_disabled_instances': {'required': True, 'type': 'list'},
     'app_name': {'required': True, 'type': 'str'},
 }
-
 
 CONNECTION_TIMEOUT = 3
 
 
 def get_alive_not_expelled_instance(params):
     module_hostvars = params['module_hostvars']
+    cluster_disabled_instances = params['cluster_disabled_instances']
     play_hosts = params['play_hosts']
     app_name = params['app_name']
 
@@ -24,11 +24,14 @@ def get_alive_not_expelled_instance(params):
 
     for instance_name in play_hosts:
         instance_vars = module_hostvars[instance_name]
-        if helpers.is_expelled(instance_vars) or helpers.is_stateboard(instance_vars):
-            continue
-
         instance_config = instance_vars.get('config')
-        if instance_config is None:
+
+        if any([
+            helpers.is_stateboard(instance_vars),
+            not helpers.is_enabled(instance_vars),
+            instance_name in cluster_disabled_instances,
+            instance_config is None
+        ]):
             continue
 
         advertise_uri = instance_config['advertise_uri']
@@ -49,7 +52,7 @@ def get_alive_not_expelled_instance(params):
         break
 
     if alive_not_expelled_instance_name is None:
-        errmsg = "Not found any alive instance that is not expelled and is not a stateboard"
+        errmsg = "Not found any alive instance that is not expelled, not disabled and not a stateboard"
         return helpers.ModuleRes(failed=True, msg=errmsg)
 
     instance_vars = module_hostvars[alive_not_expelled_instance_name]

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -96,6 +96,7 @@ FACTS_BY_TARGETS = {
     ],
     'count_disabled_instances': [
         'instance_info',
+        'disabled',
     ],
     'facts_for_machines': [
         'expelled',

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -62,6 +62,7 @@ FACTS_BY_TARGETS = {
         'edit_topology_healthy_timeout',
         'edit_topology_allow_missed_instances',
         'expelled',
+        'disabled',
         'failover_priority',
         'instance_discover_buckets_timeout',
         'instance_discover_buckets_retries',
@@ -93,24 +94,31 @@ FACTS_BY_TARGETS = {
         'cartridge_fetch_backups',
         'cartridge_fetch_backups_dir',
     ],
+    'count_disabled_instances': [
+        'instance_info',
+    ],
     'facts_for_machines': [
         'expelled',
+        'disabled',
         'ansible_host',
         'ansible_port',
     ],
     'connect_to_membership': [
         'expelled',
+        'disabled',
         'stateboard',
         'config',
     ],
     'alive_not_expelled_instance': [
         'expelled',
+        'disabled',
         'stateboard',
         'config',
         'cartridge_run_dir',
     ],
     'control_instance': [
         'expelled',
+        'disabled',
         'stateboard',
         'config',
         'replicaset_alias',
@@ -118,6 +126,7 @@ FACTS_BY_TARGETS = {
     ],
     'edit_topology': [
         'expelled',
+        'disabled',
         'stateboard',
         'replicaset_alias',
         'roles',
@@ -130,6 +139,7 @@ FACTS_BY_TARGETS = {
     ],
     'failover_promote': [
         'expelled',
+        'disabled',
         'stateboard',
     ],
 }

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -45,6 +45,7 @@ FACTS_BY_TARGETS = {
         'cartridge_multiversion',
         'cartridge_package_path',
         'cartridge_remove_temporary_files',
+        'cartridge_ignore_split_brain',
         'cartridge_paths_to_keep_on_cleanup',
         'cartridge_run_dir',
         'cartridge_scenario',

--- a/library/cartridge_get_disabled_instances.py
+++ b/library/cartridge_get_disabled_instances.py
@@ -8,70 +8,87 @@ argument_spec = {
 }
 
 
-def get_disabled_instances(instance_vars):
-    return instance_vars['instance_info']['cluster_disabled_instances']
+def get_disabled_instances_from_instance_config(instance_vars):
+    return instance_vars['instance_info']['disabled_instances']
 
 
-def get_topology_checksum(instance_vars):
-    return instance_vars['instance_info']['cluster_topology_checksum']
+def get_topology_checksum_from_instance_config(instance_vars):
+    return instance_vars['instance_info']['topology_checksum']
 
 
-def check_config_mismatch(module_hostvars, instance_name, other_hosts):
-    current_checksum = get_topology_checksum(module_hostvars[instance_name])
+def config_mismatched(module_hostvars, instance_name, other_hosts):
+    current_checksum = get_topology_checksum_from_instance_config(module_hostvars[instance_name])
 
     for other_name in other_hosts:
-        other_checksum = get_topology_checksum(module_hostvars[other_name])
+        other_checksum = get_topology_checksum_from_instance_config(module_hostvars[other_name])
         if current_checksum != other_checksum:
             return True
 
     return False
 
 
-def count_disabled_instances(params):
-    module_hostvars = params['module_hostvars']
-    play_hosts = params['play_hosts']
-
+def count_cluster_disabled_instances(module_hostvars, play_hosts):
     config_mismatch_count = 0
-    started_count = 0
-    rating = {}
+    healthy_count = 0
+    votes_to_disable = {}
 
     play_hosts = list(filter(
         # Disabled instances is None on stateboard and not started instances
         lambda name: all([
-            get_disabled_instances(module_hostvars[name]) is not None,
-            get_topology_checksum(module_hostvars[name]) is not None,
+            get_disabled_instances_from_instance_config(module_hostvars[name]) is not None,
+            get_topology_checksum_from_instance_config(module_hostvars[name]) is not None,
         ]),
         play_hosts,
     ))
 
     for instance_name in play_hosts:
-        disabled_instances = get_disabled_instances(module_hostvars[instance_name])
+        disabled_instances = get_disabled_instances_from_instance_config(module_hostvars[instance_name])
 
         not_disabled_names = list(filter(lambda other_name: other_name not in disabled_instances, play_hosts))
-        if check_config_mismatch(module_hostvars, instance_name, not_disabled_names):
+        if config_mismatched(module_hostvars, instance_name, not_disabled_names):
             config_mismatch_count += 1
             continue
 
-        started_count += 1
+        healthy_count += 1
         for disabled_instance in disabled_instances:
-            rating[disabled_instance] = rating.get(disabled_instance, 0) + 1
+            votes_to_disable[disabled_instance] = votes_to_disable.get(disabled_instance, 0) + 1
 
-    if started_count == 0 and config_mismatch_count > 0:
-        return helpers.ModuleRes(failed=True, msg='All instances in cluster has different topology configs')
+    if healthy_count == 0 and config_mismatch_count > 0:
+        return None, 'All instances in cluster has different topology configs'
 
     final_disabled_instances = []
-    split_brain_exists = False
+    split_brain_suspected = False
 
-    for name, score in rating.items():
-        if score >= started_count / 2:
+    for name, score in votes_to_disable.items():
+        if score >= healthy_count / 2:
             final_disabled_instances.append(name)
-        if score != started_count:
-            split_brain_exists = True
+        if score != healthy_count:
+            split_brain_suspected = True
 
-    if split_brain_exists:
+    if split_brain_suspected:
         helpers.warn("It seems that you have split brain in your cluster")
 
-    return helpers.ModuleRes(changed=False, fact=sorted(final_disabled_instances))
+    return sorted(final_disabled_instances), None
+
+
+def count_inventory_disabled_instances(module_hostvars, play_hosts):
+    return sorted(filter(
+        lambda name: helpers.is_disabled(module_hostvars[name]),
+        play_hosts,
+    ))
+
+
+def count_disabled_instances(params):
+    module_hostvars = params['module_hostvars']
+    play_hosts = params['play_hosts']
+
+    inventory_disabled_instances = count_inventory_disabled_instances(module_hostvars, play_hosts)
+
+    cluster_disabled_instances, err = count_cluster_disabled_instances(module_hostvars, play_hosts)
+    if err:
+        return helpers.ModuleRes(failed=True, msg=err)
+
+    return helpers.ModuleRes(changed=False, inventory=inventory_disabled_instances, cluster=cluster_disabled_instances)
 
 
 if __name__ == '__main__':

--- a/library/cartridge_get_disabled_instances.py
+++ b/library/cartridge_get_disabled_instances.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+from ansible.module_utils.helpers import Helpers as helpers
+
+argument_spec = {
+    'module_hostvars': {'required': True, 'type': 'dict'},
+    'play_hosts': {'required': True, 'type': 'list'},
+}
+
+
+def get_disabled_instances(instance_vars):
+    return instance_vars['instance_info']['cluster_disabled_instances']
+
+
+def get_topology_checksum(instance_vars):
+    return instance_vars['instance_info']['cluster_topology_checksum']
+
+
+def check_config_mismatch(module_hostvars, instance_name, other_hosts):
+    current_checksum = get_topology_checksum(module_hostvars[instance_name])
+
+    for other_name in other_hosts:
+        other_checksum = get_topology_checksum(module_hostvars[other_name])
+        if current_checksum != other_checksum:
+            return True
+
+    return False
+
+
+def count_disabled_instances(params):
+    module_hostvars = params['module_hostvars']
+    play_hosts = params['play_hosts']
+
+    config_mismatch_count = 0
+    started_count = 0
+    rating = {}
+
+    play_hosts = list(filter(
+        # Disabled instances is None on stateboard and not started instances
+        lambda name: all([
+            get_disabled_instances(module_hostvars[name]) is not None,
+            get_topology_checksum(module_hostvars[name]) is not None,
+        ]),
+        play_hosts,
+    ))
+
+    for instance_name in play_hosts:
+        disabled_instances = get_disabled_instances(module_hostvars[instance_name])
+
+        not_disabled_names = list(filter(lambda other_name: other_name not in disabled_instances, play_hosts))
+        if check_config_mismatch(module_hostvars, instance_name, not_disabled_names):
+            config_mismatch_count += 1
+            continue
+
+        started_count += 1
+        for disabled_instance in disabled_instances:
+            rating[disabled_instance] = rating.get(disabled_instance, 0) + 1
+
+    if started_count == 0 and config_mismatch_count > 0:
+        return helpers.ModuleRes(failed=True, msg='All instances in cluster has different topology configs')
+
+    final_disabled_instances = []
+    split_brain_exists = False
+
+    for name, score in rating.items():
+        if score >= started_count / 2:
+            final_disabled_instances.append(name)
+        if score != started_count:
+            split_brain_exists = True
+
+    if split_brain_exists:
+        helpers.warn("It seems that you have split brain in your cluster")
+
+    return helpers.ModuleRes(changed=False, fact=sorted(final_disabled_instances))
+
+
+if __name__ == '__main__':
+    helpers.execute_module(argument_spec, count_disabled_instances)

--- a/library/cartridge_get_disabled_instances.py
+++ b/library/cartridge_get_disabled_instances.py
@@ -58,15 +58,15 @@ def count_cluster_disabled_instances(module_hostvars, play_hosts, ignore_split_b
         return None, 'All instances in cluster has different topology configs'
 
     final_disabled_instances = []
-    split_brain_suspected = False
+    split_brain_detected = False
 
     for name, score in votes_to_disable.items():
         if score >= healthy_count / 2:
             final_disabled_instances.append(name)
         if score != healthy_count:
-            split_brain_suspected = True
+            split_brain_detected = True
 
-    if split_brain_suspected:
+    if split_brain_detected:
         msg = "It seems that you have split brain in your cluster."
         if ignore_split_brain:
             helpers.warn(msg)

--- a/library/cartridge_get_facts_for_machines.py
+++ b/library/cartridge_get_facts_for_machines.py
@@ -4,6 +4,7 @@ from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
     'module_hostvars': {'required': True, 'type': 'dict'},
+    'cluster_disabled_instances': {'required': True, 'type': 'list'},
     'play_hosts': {'required': True, 'type': 'list'},
 }
 
@@ -22,6 +23,7 @@ def get_machine_id(instance_vars, instance_name):
 
 def get_facts_for_machines(params):
     module_hostvars = params['module_hostvars']
+    cluster_disabled_instances = params['cluster_disabled_instances']
     play_hosts = params['play_hosts']
 
     single_instances_for_each_machine = {}
@@ -41,7 +43,8 @@ def get_facts_for_machines(params):
 
         # Calculate single not expelled instance for each machine
         if all([
-            not helpers.is_expelled(instance_vars),
+            helpers.is_enabled(instance_vars),
+            instance_name not in cluster_disabled_instances,
             machine_id not in single_instances_for_each_machine,
         ]):
             single_instances_for_each_machine[machine_id] = instance_name

--- a/library/cartridge_get_instance_info.py
+++ b/library/cartridge_get_instance_info.py
@@ -192,14 +192,14 @@ def get_instance_info(params):
         paths_to_keep_on_cleanup,
     )))
 
-    instance_info['cluster_topology_checksum'], err = helpers.get_topology_checksum(
+    instance_info['disabled_instances'], err = helpers.get_disabled_instances(
         instance_info['console_sock'],
         instance_vars['stateboard'],
     )
     if err is not None:
         return helpers.ModuleRes(failed=True, msg=err)
 
-    instance_info['cluster_disabled_instances'], err = helpers.get_disabled_instances(
+    instance_info['topology_checksum'], err = helpers.get_topology_checksum(
         instance_info['console_sock'],
         instance_vars['stateboard'],
     )

--- a/library/cartridge_get_instance_info.py
+++ b/library/cartridge_get_instance_info.py
@@ -192,6 +192,20 @@ def get_instance_info(params):
         paths_to_keep_on_cleanup,
     )))
 
+    instance_info['cluster_topology_checksum'], err = helpers.get_topology_checksum(
+        instance_info['console_sock'],
+        instance_vars['stateboard'],
+    )
+    if err is not None:
+        return helpers.ModuleRes(failed=True, msg=err)
+
+    instance_info['cluster_disabled_instances'], err = helpers.get_disabled_instances(
+        instance_info['console_sock'],
+        instance_vars['stateboard'],
+    )
+    if err is not None:
+        return helpers.ModuleRes(failed=True, msg=err)
+
     return helpers.ModuleRes(changed=False, fact=instance_info)
 
 

--- a/library/cartridge_get_scenario_steps.py
+++ b/library/cartridge_get_scenario_steps.py
@@ -57,7 +57,7 @@ def get_steps_paths(role_path, custom_steps_dir, custom_steps):
 
 
 def get_scenario(scenario, role_scenarios, custom_scenarios, scenario_name):
-    if not scenario:
+    if scenario is None:
         scenarios = role_scenarios.copy()
         scenarios.update(custom_scenarios)
         if scenario_name not in scenarios:

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -155,6 +155,7 @@ SCHEMA = {
     'cartridge_install_tarantool_for_tgz': bool,
     'cartridge_keep_num_latest_dists': int,
     'cartridge_remove_temporary_files': bool,
+    'cartridge_ignore_split_brain': bool,
     'cartridge_paths_to_keep_on_cleanup': list,
     'zone': str,
     'cartridge_extra_env': dict,

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -114,6 +114,7 @@ SCHEMA = {
     'cartridge_custom_scenarios': dict,
     'restarted': bool,
     'expelled': bool,
+    'disabled': bool,
     'stateboard': bool,
     'cartridge_multiversion': bool,
     'instance_start_timeout': int,
@@ -397,8 +398,9 @@ def check_auth(found_common_params):
 
 
 def check_stateboard(stateboard_vars):
-    if stateboard_vars.get('expelled') is True:
-        return "'expelled' flag can't be used for stateboard instance"
+    for flag_name in ['expelled', 'disabled']:
+        if stateboard_vars.get(flag_name) is True:
+            return "'%s' flag can't be used for stateboard instance" % flag_name
 
     for p in REPLICASET_PARAMS:
         if stateboard_vars.get(p) is not None:

--- a/molecule/disable_instance/Dockerfile.j2
+++ b/molecule/disable_instance/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/disable_instance/converge.yml
+++ b/molecule/disable_instance/converge.yml
@@ -1,0 +1,216 @@
+---
+
+- name: 'Check full cluster'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1']
+        expected_control_instance: 'core-2'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+- name: 'Set "disabled" flag for core-2'
+  hosts: core-2
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: true
+
+- name: 'Disable core-2 instance'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1']
+        expected_control_instance: 'core-3'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - vars:
+        cartridge_scenario:
+          - edit_topology
+      import_role:
+        name: ansible-cartridge
+
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2']
+        expected_control_instance: 'core-3'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+- name: 'Set "disabled" flag for core-3 and core-4'
+  hosts: core-3,core-4
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: true
+
+- name: 'Disable core-3 and core-4 instances'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2']
+        expected_control_instance: 'core-5'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - vars:
+        cartridge_scenario:
+          - edit_topology
+      import_role:
+        name: ansible-cartridge
+
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_control_instance: 'core-5'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+- name: 'Set "disabled" flag for core-5'
+  hosts: core-5
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: true
+
+- name: 'Try to disable last instance'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_control_instance: null
+        ignore_role_errors: true
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - name: 'Debug error message'
+      debug:
+        var: alive_not_expelled_instance_res
+      run_once: true
+
+    - name: 'Check error message'
+      assert:
+        fail_msg: "Fact 'alive_not_expelled_instance_res' has incorrect value"
+        success_msg: "Fact 'alive_not_expelled_instance_res' has correct value"
+        that:
+          - alive_not_expelled_instance_res is failed
+          - >-
+            alive_not_expelled_instance_res.msg ==
+            'Not found any alive instance that is not expelled, not disabled and not a stateboard'
+      run_once: true
+
+- name: 'Remove "disabled" flag for core-1'
+  hosts: core-1
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: false
+
+- name: 'Try to enable core-1 and disable core-5 instances'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_control_instance: null
+        ignore_role_errors: true
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - name: 'Debug error message'
+      debug:
+        var: alive_not_expelled_instance_res
+      run_once: true
+
+    - name: 'Check error message'
+      assert:
+        fail_msg: "Fact 'alive_not_expelled_instance_res' has incorrect value"
+        success_msg: "Fact 'alive_not_expelled_instance_res' has correct value"
+        that:
+          - alive_not_expelled_instance_res is failed
+          - >-
+            alive_not_expelled_instance_res.msg ==
+            'Not found any alive instance that is not expelled, not disabled and not a stateboard'
+      run_once: true
+
+- name: 'Remove "disabled" flag for core-5'
+  hosts: core-5
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: false
+
+- name: 'Enable core-1 instance'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_control_instance: 'core-5'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - vars:
+        cartridge_scenario:
+          - edit_topology
+      import_role:
+        name: ansible-cartridge
+
+    - vars:
+        expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4']
+        expected_control_instance: 'core-1'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+- name: 'Set "disabled" flag for core-5'
+  hosts: core-5
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Set "disabled" flag'
+      set_fact:
+        disabled: true
+
+- name: 'Disabled core-5 instance'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - vars:
+        expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4']
+        expected_control_instance: 'core-1'
+      import_tasks: 'tasks/check_disabled_and_control.yml'
+
+    - vars:
+        cartridge_scenario:
+          - edit_topology
+      import_role:
+        name: ansible-cartridge
+
+    - vars:
+        expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4', 'core-5']
+        expected_control_instance: 'core-1'
+      import_tasks: 'tasks/check_disabled_and_control.yml'

--- a/molecule/disable_instance/converge.yml
+++ b/molecule/disable_instance/converge.yml
@@ -8,6 +8,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1']
+        expected_inventory_disabled_instances: ['core-1']
         expected_control_instance: 'core-2'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -29,6 +30,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1']
+        expected_inventory_disabled_instances: ['core-1', 'core-2']
         expected_control_instance: 'core-3'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -40,6 +42,7 @@
 
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2']
+        expected_inventory_disabled_instances: ['core-1', 'core-2']
         expected_control_instance: 'core-3'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -61,6 +64,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2']
+        expected_inventory_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
         expected_control_instance: 'core-5'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -72,6 +76,7 @@
 
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
         expected_control_instance: 'core-5'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -93,6 +98,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4', 'core-5']
         expected_control_instance: null
         ignore_role_errors: true
       import_tasks: 'tasks/check_disabled_and_control.yml'
@@ -131,6 +137,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-2', 'core-3', 'core-4', 'core-5']
         expected_control_instance: null
         ignore_role_errors: true
       import_tasks: 'tasks/check_disabled_and_control.yml'
@@ -169,6 +176,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-1', 'core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-2', 'core-3', 'core-4']
         expected_control_instance: 'core-5'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -180,6 +188,7 @@
 
     - vars:
         expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-2', 'core-3', 'core-4']
         expected_control_instance: 'core-1'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -201,6 +210,7 @@
   tasks:
     - vars:
         expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4']
+        expected_inventory_disabled_instances: ['core-2', 'core-3', 'core-4', 'core-5']
         expected_control_instance: 'core-1'
       import_tasks: 'tasks/check_disabled_and_control.yml'
 
@@ -212,5 +222,6 @@
 
     - vars:
         expected_cluster_disabled_instances: ['core-2', 'core-3', 'core-4', 'core-5']
+        expected_inventory_disabled_instances: ['core-2', 'core-3', 'core-4', 'core-5']
         expected_control_instance: 'core-1'
       import_tasks: 'tasks/check_disabled_and_control.yml'

--- a/molecule/disable_instance/hosts.yml
+++ b/molecule/disable_instance/hosts.yml
@@ -1,0 +1,108 @@
+---
+
+all:
+  children:
+    cluster:
+      vars:
+        # common connection opts
+        ansible_user: root
+        ansible_connection: docker
+        become: true
+        become_user: root
+        ignore_role_errors: false
+
+        # common cartridge opts
+        cartridge_app_name: myapp
+        cartridge_cluster_cookie: secret-cookie
+        cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
+
+        cartridge_defaults:
+          some_option: 'default value'
+
+        cartridge_auth:
+          enabled: true
+
+          cookie_max_age: 1000
+          cookie_renew_age: 100
+
+          users:
+            - username: tarantool
+              password: tarantool-the-best
+              fullname: Tarantool The Best
+              email: tarantool@tarantool.org
+
+        cartridge_app_config:
+          section-1:
+            body:
+              key-1: value-1
+              key-2: value-2
+
+          section-2:
+            body: section-2-value
+
+          section-3:
+            deleted: true
+
+        cartridge_bootstrap_vshard: true
+
+      # instances
+      hosts:
+        core-1:
+          config:
+            advertise_uri: 'vm1:3101'
+            http_port: 8101
+          disabled: true
+
+        core-2:
+          config:
+            advertise_uri: 'vm1:3102'
+            http_port: 8102
+
+        core-3:
+          config:
+            advertise_uri: 'vm1:3103'
+            http_port: 8103
+
+        core-4:
+          config:
+            advertise_uri: 'vm1:3104'
+            http_port: 8104
+
+        core-5:
+          config:
+            advertise_uri: 'vm1:3105'
+            http_port: 8105
+
+      children:
+        # group by hosts
+        machine_1:
+          vars:
+            ansible_host: vm1
+
+          hosts:
+            core-1:
+            core-2:
+            core-3:
+            core-4:
+            core-5:
+
+        # group by replica sets
+        core_replicaset:
+          hosts:
+            core-1:
+            core-2:
+            core-3:
+            core-4:
+            core-5:
+          vars:
+            replicaset_alias: core
+            failover_priority:
+              - core-1
+              - core-2
+              - core-3
+              - core-4
+              - core-5
+            roles:
+              - app.roles.custom
+              - vshard-router
+              - failover-coordinator

--- a/molecule/disable_instance/molecule.yml
+++ b/molecule/disable_instance/molecule.yml
@@ -1,0 +1,1 @@
+../common/molecule/1_vm_not_idempotent.yml

--- a/molecule/disable_instance/prepare.yml
+++ b/molecule/disable_instance/prepare.yml
@@ -1,0 +1,9 @@
+---
+
+- name: 'Deploy cluster'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  roles:
+    - ansible-cartridge

--- a/molecule/disable_instance/tasks/check_disabled_and_control.yml
+++ b/molecule/disable_instance/tasks/check_disabled_and_control.yml
@@ -1,0 +1,34 @@
+---
+
+- name: 'Get control instance'
+  ignore_errors: '{{ ignore_role_errors }}'
+  import_role:
+    name: ansible-cartridge
+  vars:
+    cartridge_scenario:
+      - set_control_instance
+
+- name: 'Debug disabled instances'
+  debug:
+    msg: '{{ cluster_disabled_instances }}'
+  run_once: true
+
+- name: 'Check disabled instances'
+  assert:
+    fail_msg: "Fact 'cluster_disabled_instances' has incorrect value"
+    success_msg: "Fact 'cluster_disabled_instances' has correct value"
+    that: cluster_disabled_instances == expected_cluster_disabled_instances
+  run_once: true
+
+- name: 'Debug control instance'
+  debug:
+    msg: "{{ control_instance }}"
+  run_once: true
+
+- name: 'Check control instance name'
+  assert:
+    fail_msg: "Fact 'control_instance' has incorrect value"
+    success_msg: "Fact 'control_instance' has correct value"
+    that: >-
+      (control_instance or {'name': None}).name == expected_control_instance
+  run_once: true

--- a/molecule/disable_instance/tasks/check_disabled_and_control.yml
+++ b/molecule/disable_instance/tasks/check_disabled_and_control.yml
@@ -8,16 +8,28 @@
     cartridge_scenario:
       - set_control_instance
 
-- name: 'Debug disabled instances'
+- name: 'Debug cluster disabled instances'
   debug:
     msg: '{{ cluster_disabled_instances }}'
   run_once: true
 
-- name: 'Check disabled instances'
+- name: 'Debug inventory disabled instances'
+  debug:
+    msg: '{{ inventory_disabled_instances }}'
+  run_once: true
+
+- name: 'Check cluster disabled instances'
   assert:
     fail_msg: "Fact 'cluster_disabled_instances' has incorrect value"
     success_msg: "Fact 'cluster_disabled_instances' has correct value"
     that: cluster_disabled_instances == expected_cluster_disabled_instances
+  run_once: true
+
+- name: 'Check inventory disabled instances'
+  assert:
+    fail_msg: "Fact 'inventory_disabled_instances' has incorrect value"
+    success_msg: "Fact 'inventory_disabled_instances' has correct value"
+    that: inventory_disabled_instances == expected_inventory_disabled_instances
   run_once: true
 
 - name: 'Debug control instance'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -75,9 +75,26 @@
   delegate_to: localhost
   become: false
 
+- name: 'Count information about disabled instances in cluster'
+  cartridge_get_disabled_instances:
+    module_hostvars: '{{ cached_facts.count_disabled_instances }}'
+    play_hosts: '{{ play_hosts }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+  register: cluster_disabled_instances_res
+
+- name: 'Set "cluster_disabled_instances" fact'
+  set_fact:
+    cluster_disabled_instances: '{{ cluster_disabled_instances_res.fact }}'
+  run_once: true
+  delegate_to: localhost
+  become: false
+
 - name: 'Select one instance for each physical machine'
   cartridge_get_facts_for_machines:
     module_hostvars: '{{ cached_facts.facts_for_machines }}'
+    cluster_disabled_instances: '{{ cluster_disabled_instances }}'
     play_hosts: '{{ play_hosts }}'
   run_once: true
   delegate_to: localhost

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -82,11 +82,12 @@
   run_once: true
   delegate_to: localhost
   become: false
-  register: cluster_disabled_instances_res
+  register: disabled_instances_res
 
-- name: 'Set "cluster_disabled_instances" fact'
+- name: 'Set "cluster_disabled_instances" and "inventory_disabled_instances" fact'
   set_fact:
-    cluster_disabled_instances: '{{ cluster_disabled_instances_res.fact }}'
+    cluster_disabled_instances: '{{ disabled_instances_res.cluster }}'
+    inventory_disabled_instances: '{{ disabled_instances_res.inventory }}'
   run_once: true
   delegate_to: localhost
   become: false

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -79,6 +79,7 @@
   cartridge_get_disabled_instances:
     module_hostvars: '{{ cached_facts.count_disabled_instances }}'
     play_hosts: '{{ play_hosts }}'
+    ignore_split_brain: '{{ cartridge_ignore_split_brain }}'
   run_once: true
   delegate_to: localhost
   become: false

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -134,6 +134,7 @@
       temporary_files: '{{ temporary_files }}'
       needs_restart: '{{ needs_restart }}'
       cluster_disabled_instances: '{{ cluster_disabled_instances }}'
+      inventory_disabled_instances: '{{ inventory_disabled_instances }}'
       alive_not_expelled_instance: '{{ alive_not_expelled_instance }}'
       instance_backup_files: '{{ instance_backup_files }}'
       backup_archive_path: '{{ backup_archive_path }}'

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -64,6 +64,7 @@
 
       restarted: '{{ restarted }}'
       expelled: '{{ expelled }}'
+      disabled: '{{ disabled }}'
       stateboard: '{{ stateboard }}'
 
       instance_start_timeout: '{{ instance_start_timeout }}'
@@ -132,6 +133,7 @@
       control_instance: '{{ control_instance }}'
       temporary_files: '{{ temporary_files }}'
       needs_restart: '{{ needs_restart }}'
+      cluster_disabled_instances: '{{ cluster_disabled_instances }}'
       alive_not_expelled_instance: '{{ alive_not_expelled_instance }}'
       instance_backup_files: '{{ instance_backup_files }}'
       backup_archive_path: '{{ backup_archive_path }}'

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -10,6 +10,7 @@
       cartridge_cluster_cookie: '{{ cartridge_cluster_cookie }}'
       cartridge_not_save_cookie_in_app_config: '{{ cartridge_not_save_cookie_in_app_config }}'
       cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
+      cartridge_ignore_split_brain: '{{ cartridge_ignore_split_brain }}'
       cartridge_paths_to_keep_on_cleanup: '{{ cartridge_paths_to_keep_on_cleanup }}'
 
       # Role scenario configuration

--- a/tasks/steps/blocks/set_alive_not_expelled_instance.yml
+++ b/tasks/steps/blocks/set_alive_not_expelled_instance.yml
@@ -3,6 +3,7 @@
 - name: 'Select one not expelled instance'
   cartridge_get_alive_not_expelled_instance:
     module_hostvars: '{{ cached_facts.alive_not_expelled_instance }}'
+    cluster_disabled_instances: '{{ cluster_disabled_instances }}'
     play_hosts: '{{ play_hosts }}'
     app_name: '{{ cartridge_app_name }}'
   run_once: true

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -6,6 +6,7 @@
 - name: 'Select control instance to manage topology and configuration via {{ alive_not_expelled_instance.name }}'
   cartridge_get_control_instance:
     module_hostvars: '{{ cached_facts.control_instance }}'
+    cluster_disabled_instances: '{{ cluster_disabled_instances }}'
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ alive_not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'

--- a/tasks/steps/bootstrap_vshard.yml
+++ b/tasks/steps/bootstrap_vshard.yml
@@ -3,6 +3,7 @@
 - when:
     - cartridge_bootstrap_vshard
     - not expelled
+    - not disabled
   tags: cartridge-config
   block:
     - name: 'BLOCK: Select control instance'

--- a/tasks/steps/connect_to_membership.yml
+++ b/tasks/steps/connect_to_membership.yml
@@ -7,6 +7,7 @@
   cartridge_connect_to_membership:
     console_sock: '{{ alive_not_expelled_instance.console_sock }}'
     module_hostvars: '{{ cached_facts.connect_to_membership }}'
+    cluster_disabled_instances: '{{ cluster_disabled_instances }}'
     play_hosts: '{{ play_hosts }}'
   register: probe
   until: not probe.failed

--- a/tasks/steps/edit_topology.yml
+++ b/tasks/steps/edit_topology.yml
@@ -21,3 +21,9 @@
         allow_missed_instances: '{{ edit_topology_allow_missed_instances }}'
       run_once: true
       delegate_to: '{{ control_instance.name }}'
+
+    - name: 'Update information about disabled instances in cluster'
+      set_fact:
+        cluster_disabled_instances: '{{ inventory_disabled_instances }}'
+      run_once: true
+      delegate_to: '{{ control_instance.name }}'

--- a/tasks/steps/force_leaders.yml
+++ b/tasks/steps/force_leaders.yml
@@ -12,6 +12,7 @@
       cartridge_failover_promote:
         promote_play_hosts: true
         module_hostvars: '{{ cached_facts.failover_promote }}'
+        cluster_disabled_instances: '{{ cluster_disabled_instances }}'
         play_hosts: '{{ play_hosts }}'
         failover_promote_params: '{{ cartridge_failover_promote_params }}'
         console_sock: '{{ control_instance.console_sock }}'

--- a/tasks/steps/wait_cluster_has_no_issues.yml
+++ b/tasks/steps/wait_cluster_has_no_issues.yml
@@ -19,6 +19,5 @@
       until: not cluster_issues_res.failed
       retries: '{{ wait_cluster_has_no_issues_retries }}'
       delay: '{{ wait_cluster_has_no_issues_delay }}'
-      when: not expelled
       run_once: true
       delegate_to: '{{ control_instance.name }}'

--- a/tasks/steps/wait_members_alive.yml
+++ b/tasks/steps/wait_members_alive.yml
@@ -18,6 +18,5 @@
       until: not check_members_alive_res.failed
       retries: '{{ wait_members_alive_retries }}'
       delay: '{{ wait_members_alive_delay }}'
-      when: not expelled
       run_once: true
       delegate_to: '{{ control_instance.name }}'

--- a/unit/test_connect_to_membership.py
+++ b/unit/test_connect_to_membership.py
@@ -8,13 +8,14 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_connect_to_membership import connect_to_membership
 
 
-def call_probe_instance(console_sock, module_hostvars, play_hosts=None):
+def call_probe_instance(console_sock, module_hostvars, play_hosts=None, cluster_disabled_instances=None):
     if play_hosts is None:
         play_hosts = module_hostvars.keys()
 
     return connect_to_membership({
         'console_sock': console_sock,
         'module_hostvars': module_hostvars,
+        'cluster_disabled_instances': cluster_disabled_instances or [],
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+
 from parameterized import parameterized
 
 import module_utils.helpers as helpers
@@ -185,7 +186,7 @@ class TestEditTopology(unittest.TestCase):
             }
         ]
 
-        # now we don't don't add r2-replica
+        # now we don't add r2-replica
 
         # create replicasets with instances not known by cluster (r2-replica)
         self.instance.clear_calls('edit_topology')

--- a/unit/test_edit_topology_helpers.py
+++ b/unit/test_edit_topology_helpers.py
@@ -141,9 +141,14 @@ class TestGetInstancesToConfigure(unittest.TestCase):
                 'expelled': True,
                 'zone': 'Hogwarts',
             },
-            'instance-zone': {  # expelled, with zone
+            'instance-disabled-zone': {  # expelled, with zone
                 'replicaset_alias': 'replicaset-1',
                 'zone': 'Narnia',
+                'disabled': True,
+            },
+            'instance-not-disabled': {  # expelled, with zone
+                'replicaset_alias': 'replicaset-1',
+                'disabled': False,
             },
             'instance-1': {
                 'replicaset_alias': 'replicaset-1',
@@ -170,7 +175,8 @@ class TestGetInstancesToConfigure(unittest.TestCase):
         self.assertEqual(instances, {
             'instance-expelled': {'expelled': True},
             'instance-expelled-zone': {'expelled': True},
-            'instance-zone': {'zone': 'Narnia'},
+            'instance-disabled-zone': {'zone': 'Narnia', 'disabled': True},
+            'instance-not-disabled': {'disabled': False},
             'instance-3': {'uri': '10.0.0.103:3301'},
         })
 

--- a/unit/test_failover_promote.py
+++ b/unit/test_failover_promote.py
@@ -2,26 +2,33 @@ import sys
 import unittest
 
 from parameterized import parameterized
-import module_utils.helpers as helpers
 
+import module_utils.helpers as helpers
 from unit.instance import Instance
 
 sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_failover_promote import failover_promote
 
 
-def call_failover_promote(console_sock, params, promote_play_hosts=False,
-                          module_hostvars=None, play_hosts=None):
+def call_failover_promote(
+    console_sock,
+    params,
+    promote_play_hosts=False,
+    module_hostvars=None,
+    play_hosts=None,
+    cluster_disabled_instances=None,
+):
     return failover_promote({
         'promote_play_hosts': promote_play_hosts,
         'module_hostvars': module_hostvars,
+        'cluster_disabled_instances': cluster_disabled_instances or [],
         'play_hosts': play_hosts,
         'console_sock': console_sock,
         'failover_promote_params': params,
     })
 
 
-class TestEditTopology(unittest.TestCase):
+class TestFailoverPromote(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 

--- a/unit/test_get_cached_facts.py
+++ b/unit/test_get_cached_facts.py
@@ -26,13 +26,22 @@ class TestGetCachedFacts(unittest.TestCase):
                 'ansible_host': 'some_host',
                 'cartridge_cluster_cookie': 'some-cookie',
                 'cartridge_run_dir': 'some-run-dir',
+                'instance_info': {
+                    'cluster_disabled_instances': [],
+                },
             },
             'instance_2': {
                 'stateboard': False,
                 'random_arg': {'test': 'value'},
+                'instance_info': {
+                    'cluster_disabled_instances': ['instance_2'],
+                },
             },
             'instance_3': {
                 'random_arg': {'test': 'value'},
+                'instance_info': {
+                    'cluster_disabled_instances': ['instance_2'],
+                },
             },
         })
         self.assertFalse(res.failed, res.msg)
@@ -49,6 +58,23 @@ class TestGetCachedFacts(unittest.TestCase):
                     'stateboard': False,
                 },
                 'instance_3': {},
+            },
+            'count_disabled_instances': {
+                'instance_1': {
+                    'instance_info': {
+                        'cluster_disabled_instances': [],
+                    },
+                },
+                'instance_2': {
+                    'instance_info': {
+                        'cluster_disabled_instances': ['instance_2'],
+                    },
+                },
+                'instance_3': {
+                    'instance_info': {
+                        'cluster_disabled_instances': ['instance_2'],
+                    },
+                },
             },
             'facts_for_machines': {
                 'instance_1': {

--- a/unit/test_get_cached_facts.py
+++ b/unit/test_get_cached_facts.py
@@ -27,20 +27,21 @@ class TestGetCachedFacts(unittest.TestCase):
                 'cartridge_cluster_cookie': 'some-cookie',
                 'cartridge_run_dir': 'some-run-dir',
                 'instance_info': {
-                    'cluster_disabled_instances': [],
+                    'disabled_instances': [],
                 },
             },
             'instance_2': {
                 'stateboard': False,
                 'random_arg': {'test': 'value'},
                 'instance_info': {
-                    'cluster_disabled_instances': ['instance_2'],
+                    'disabled_instances': ['instance_2'],
                 },
             },
             'instance_3': {
+                'disabled': True,
                 'random_arg': {'test': 'value'},
                 'instance_info': {
-                    'cluster_disabled_instances': ['instance_2'],
+                    'disabled_instances': ['instance_2'],
                 },
             },
         })
@@ -57,22 +58,25 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_2': {
                     'stateboard': False,
                 },
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'count_disabled_instances': {
                 'instance_1': {
                     'instance_info': {
-                        'cluster_disabled_instances': [],
+                        'disabled_instances': [],
                     },
                 },
                 'instance_2': {
                     'instance_info': {
-                        'cluster_disabled_instances': ['instance_2'],
+                        'disabled_instances': ['instance_2'],
                     },
                 },
                 'instance_3': {
+                    'disabled': True,
                     'instance_info': {
-                        'cluster_disabled_instances': ['instance_2'],
+                        'disabled_instances': ['instance_2'],
                     },
                 },
             },
@@ -82,7 +86,9 @@ class TestGetCachedFacts(unittest.TestCase):
                     'ansible_host': 'some_host',
                 },
                 'instance_2': {},
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'connect_to_membership': {
                 'instance_1': {
@@ -92,7 +98,9 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_2': {
                     'stateboard': False,
                 },
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'alive_not_expelled_instance': {
                 'instance_1': {
@@ -103,7 +111,9 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_2': {
                     'stateboard': False,
                 },
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'control_instance': {
                 'instance_1': {
@@ -114,7 +124,9 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_2': {
                     'stateboard': False,
                 },
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'edit_topology': {
                 'instance_1': {
@@ -124,12 +136,16 @@ class TestGetCachedFacts(unittest.TestCase):
                 'instance_2': {
                     'stateboard': False,
                 },
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
             'failover_promote': {
                 'instance_1': {'expelled': True},
                 'instance_2': {'stateboard': False},
-                'instance_3': {},
+                'instance_3': {
+                    'disabled': True,
+                },
             },
         })
 

--- a/unit/test_get_control_instance.py
+++ b/unit/test_get_control_instance.py
@@ -22,7 +22,13 @@ def get_twophase_commit_versions_mock(_, advertise_uris):
 get_control_instance_lib.get_twophase_commit_versions = get_twophase_commit_versions_mock
 
 
-def call_get_control_instance(app_name, console_sock, module_hostvars=None, play_hosts=None):
+def call_get_control_instance(
+    app_name,
+    console_sock,
+    module_hostvars=None,
+    play_hosts=None,
+    cluster_disabled_instances='default',
+):
     if module_hostvars is None:
         module_hostvars = {}
 
@@ -31,6 +37,7 @@ def call_get_control_instance(app_name, console_sock, module_hostvars=None, play
 
     return get_control_instance({
         'module_hostvars': module_hostvars,
+        'cluster_disabled_instances': [] if cluster_disabled_instances == 'default' else cluster_disabled_instances,
         'play_hosts': play_hosts,
         'console_sock': console_sock,
         'app_name': app_name,

--- a/unit/test_get_disabled_instances.py
+++ b/unit/test_get_disabled_instances.py
@@ -1,0 +1,111 @@
+import sys
+import unittest
+
+import module_utils.helpers as helpers
+
+sys.modules['ansible.module_utils.helpers'] = helpers
+from library.cartridge_get_disabled_instances import count_disabled_instances
+
+
+def call_count_disabled_instances(
+    instance_infos,
+    play_hosts=None,
+):
+    module_hostvars = {
+        instance_name: {
+            'instance_info': {
+                'cluster_disabled_instances': instance_info['disabled_instances'],
+                'cluster_topology_checksum': instance_info.get('checksum', 1234567890),
+            }
+        }
+        for instance_name, instance_info
+        in instance_infos.items()
+    }
+    if play_hosts is None:
+        play_hosts = module_hostvars.keys()
+
+    return count_disabled_instances({
+        'module_hostvars': module_hostvars,
+        'play_hosts': play_hosts,
+    })
+
+
+class TestCountDisabledInstances(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_count_disabled_instances(self):
+        # Healthy cluster
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': []},
+            'instance-2': {'disabled_instances': []},
+            'instance-3': {'disabled_instances': []},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, [])
+        self.assertEqual(helpers.WARNINGS, [])
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': ['instance-2', 'instance-3'], 'checksum': 2},
+            'instance-2': {'disabled_instances': [], 'checksum': 1},
+            'instance-3': {'disabled_instances': [], 'checksum': 1},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, ['instance-2', 'instance-3'])
+        self.assertEqual(helpers.WARNINGS, [])
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': None, 'checksum': None},
+            'instance-2': {'disabled_instances': [], 'checksum': 1},
+            'instance-3': {'disabled_instances': ['instance-2'], 'checksum': 2},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, ['instance-2'])
+        self.assertEqual(helpers.WARNINGS, [])
+
+        # Split brain
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': ['instance-2', 'instance-3']},
+            'instance-2': {'disabled_instances': []},
+            'instance-3': {'disabled_instances': []},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, [])
+        self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': ['instance-2', 'instance-3']},
+            'instance-2': {'disabled_instances': ['instance-1']},
+            'instance-3': {'disabled_instances': ['instance-1']},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, ['instance-1'])
+        self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
+
+        helpers.WARNINGS = []
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': ['instance-3', 'instance-4']},
+            'instance-2': {'disabled_instances': ['instance-3', 'instance-4']},
+            'instance-3': {'disabled_instances': ['instance-1', 'instance-2']},
+            'instance-4': {'disabled_instances': ['instance-1', 'instance-2']},
+        })
+        self.assertFalse(res.failed)
+        self.assertEqual(res.fact, ['instance-1', 'instance-2', 'instance-3', 'instance-4'])
+        self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
+
+        # No correct topology config
+
+        res = call_count_disabled_instances({
+            'instance-1': {'disabled_instances': None, 'checksum': None},
+            'instance-2': {'disabled_instances': [], 'checksum': 1},
+            'instance-3': {'disabled_instances': [], 'checksum': 2},
+        })
+        self.assertTrue(res.failed)
+        self.assertEqual(res.msg, 'All instances in cluster has different topology configs')

--- a/unit/test_get_disabled_instances.py
+++ b/unit/test_get_disabled_instances.py
@@ -8,18 +8,19 @@ from library.cartridge_get_disabled_instances import count_disabled_instances
 
 
 def call_count_disabled_instances(
-    instance_infos,
+    instances_info,
     play_hosts=None,
 ):
     module_hostvars = {
         instance_name: {
             'instance_info': {
-                'cluster_disabled_instances': instance_info['disabled_instances'],
-                'cluster_topology_checksum': instance_info.get('checksum', 1234567890),
-            }
+                'disabled_instances': instance_info['disabled_instances'],
+                'topology_checksum': instance_info.get('checksum', 1234567890),
+            },
+            'disabled': instance_info.get('disabled', False),
         }
         for instance_name, instance_info
-        in instance_infos.items()
+        in instances_info.items()
     }
     if play_hosts is None:
         play_hosts = module_hostvars.keys()
@@ -44,49 +45,54 @@ class TestCountDisabledInstances(unittest.TestCase):
             'instance-3': {'disabled_instances': []},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, [])
+        self.assertEqual(res.kwargs['cluster'], [])
+        self.assertEqual(res.kwargs['inventory'], [])
         self.assertEqual(helpers.WARNINGS, [])
 
         helpers.WARNINGS = []
         res = call_count_disabled_instances({
             'instance-1': {'disabled_instances': ['instance-2', 'instance-3'], 'checksum': 2},
-            'instance-2': {'disabled_instances': [], 'checksum': 1},
+            'instance-2': {'disabled_instances': [], 'checksum': 1, 'disabled': True},
             'instance-3': {'disabled_instances': [], 'checksum': 1},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, ['instance-2', 'instance-3'])
+        self.assertEqual(res.kwargs['cluster'], ['instance-2', 'instance-3'])
+        self.assertEqual(res.kwargs['inventory'], ['instance-2'])
         self.assertEqual(helpers.WARNINGS, [])
 
         helpers.WARNINGS = []
         res = call_count_disabled_instances({
-            'instance-1': {'disabled_instances': None, 'checksum': None},
+            'instance-1': {'disabled_instances': None, 'checksum': None, 'disabled': True},
             'instance-2': {'disabled_instances': [], 'checksum': 1},
             'instance-3': {'disabled_instances': ['instance-2'], 'checksum': 2},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, ['instance-2'])
+        self.assertEqual(res.kwargs['cluster'], ['instance-2'])
+        self.assertEqual(res.kwargs['inventory'], ['instance-1'])
         self.assertEqual(helpers.WARNINGS, [])
 
         # Split brain
 
         helpers.WARNINGS = []
         res = call_count_disabled_instances({
-            'instance-1': {'disabled_instances': ['instance-2', 'instance-3']},
+            'instance-1': {'disabled_instances': ['instance-2', 'instance-3'], 'disabled': True},
             'instance-2': {'disabled_instances': []},
             'instance-3': {'disabled_instances': []},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, [])
+        self.assertEqual(res.kwargs['cluster'], [])
+        self.assertEqual(res.kwargs['inventory'], ['instance-1'])
         self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
 
         helpers.WARNINGS = []
         res = call_count_disabled_instances({
-            'instance-1': {'disabled_instances': ['instance-2', 'instance-3']},
+            'instance-1': {'disabled_instances': ['instance-2', 'instance-3'], 'disabled': True},
             'instance-2': {'disabled_instances': ['instance-1']},
             'instance-3': {'disabled_instances': ['instance-1']},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, ['instance-1'])
+        self.assertEqual(res.kwargs['cluster'], ['instance-1'])
+        self.assertEqual(res.kwargs['inventory'], ['instance-1'])
         self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
 
         helpers.WARNINGS = []
@@ -97,7 +103,8 @@ class TestCountDisabledInstances(unittest.TestCase):
             'instance-4': {'disabled_instances': ['instance-1', 'instance-2']},
         })
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact, ['instance-1', 'instance-2', 'instance-3', 'instance-4'])
+        self.assertEqual(res.kwargs['cluster'], ['instance-1', 'instance-2', 'instance-3', 'instance-4'])
+        self.assertEqual(res.kwargs['inventory'], [])
         self.assertEqual(helpers.WARNINGS, ["It seems that you have split brain in your cluster"])
 
         # No correct topology config

--- a/unit/test_get_facts_for_machines.py
+++ b/unit/test_get_facts_for_machines.py
@@ -7,12 +7,13 @@ sys.modules['ansible.module_utils.helpers'] = helpers
 from library.cartridge_get_facts_for_machines import get_facts_for_machines
 
 
-def call_get_facts_for_machine(module_hostvars, play_hosts=None):
+def call_get_facts_for_machine(module_hostvars, play_hosts=None, cluster_disabled_instances=None):
     if play_hosts is None:
         play_hosts = module_hostvars.keys()
 
     return get_facts_for_machines({
         'module_hostvars': module_hostvars,
+        'cluster_disabled_instances': cluster_disabled_instances or [],
         'play_hosts': play_hosts,
     })
 

--- a/unit/test_get_instance_info.py
+++ b/unit/test_get_instance_info.py
@@ -143,8 +143,8 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/vinyl/dir/myapp.instance-1',
                 'some/wal/dir/myapp.instance-1',
             ],
-            'cluster_disabled_instances': None,
-            'cluster_topology_checksum': None,
+            'disabled_instances': None,
+            'topology_checksum': None,
         })
 
     def test_get_instance_info_multiversion(self):
@@ -197,8 +197,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp.instance-1',
             ],
-            'cluster_disabled_instances': None,
-            'cluster_topology_checksum': None,
+            'disabled_instances': None,
+            'topology_checksum': None,
         })
 
         # cartridge_package_path isn't specified
@@ -248,8 +248,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp.instance-1',
             ],
-            'cluster_disabled_instances': None,
-            'cluster_topology_checksum': None,
+            'disabled_instances': None,
+            'topology_checksum': None,
         })
 
     def test_get_stateboard_info(self):
@@ -302,8 +302,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp-stateboard',
             ],
-            'cluster_disabled_instances': None,
-            'cluster_topology_checksum': None,
+            'disabled_instances': None,
+            'topology_checksum': None,
         })
 
     def test_get_stateboard_info_multiversion(self):
@@ -362,8 +362,8 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/vinyl/dir/myapp-stateboard',
                 'some/wal/dir/myapp-stateboard',
             ],
-            'cluster_disabled_instances': None,
-            'cluster_topology_checksum': None,
+            'disabled_instances': None,
+            'topology_checksum': None,
         })
 
     def test_paths_to_keep_on_cleanup(self):

--- a/unit/test_get_instance_info.py
+++ b/unit/test_get_instance_info.py
@@ -143,6 +143,8 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/vinyl/dir/myapp.instance-1',
                 'some/wal/dir/myapp.instance-1',
             ],
+            'cluster_disabled_instances': None,
+            'cluster_topology_checksum': None,
         })
 
     def test_get_instance_info_multiversion(self):
@@ -195,6 +197,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp.instance-1',
             ],
+            'cluster_disabled_instances': None,
+            'cluster_topology_checksum': None,
         })
 
         # cartridge_package_path isn't specified
@@ -244,6 +248,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp.instance-1',
             ],
+            'cluster_disabled_instances': None,
+            'cluster_topology_checksum': None,
         })
 
     def test_get_stateboard_info(self):
@@ -296,6 +302,8 @@ class TestGetInstanceInfo(unittest.TestCase):
             'dirs_to_remove_on_cleanup': [
                 'some/data/dir/myapp-stateboard',
             ],
+            'cluster_disabled_instances': None,
+            'cluster_topology_checksum': None,
         })
 
     def test_get_stateboard_info_multiversion(self):
@@ -354,6 +362,8 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/vinyl/dir/myapp-stateboard',
                 'some/wal/dir/myapp-stateboard',
             ],
+            'cluster_disabled_instances': None,
+            'cluster_topology_checksum': None,
         })
 
     def test_paths_to_keep_on_cleanup(self):

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -82,6 +82,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_configure_tmpfiles',
                 'cartridge_install_tarantool_for_tgz',
                 'cartridge_remove_temporary_files',
+                'cartridge_ignore_split_brain',
                 'cartridge_failover_params.fencing_enabled',
                 'edit_topology_allow_missed_instances',
                 'allow_warning_issues',


### PR DESCRIPTION
Closes #340

Sometimes you can't promote a new leader,
because you have broken instances and can't apply two-phase commit.

Now you can disable broken instances by `disabled` flag in instance config.

Since the disabled instance doesn't receive topology updates, it doesn't know that it's disabled.
So, we had to do the following to detect what instances are disabled (e.g., it's necessary to select control instance):

1. Ignore stateboards, non-running instances, and instances without a topology section (they have no information about disabled instances);
2. Collect from each instance checksum of the topology section and the list of disabled instances;
3. Determine for each instance config mismatches with the enabled (according to its version) instances;
4. If the first instance has a config mismatch with the second instance, but the second instance thinks that everything is OK, it means that the second instance didn't receive topology updates and it was disabled, so we ignore it;
5. On instances with correct configs, we collect information about disabled servers;
6. If there are several versions of disabled instances, then we raise an error that we may have a split-brain. If the `cartridge_ignore_split_brain` flag is set, we ignore this error and take the version with more voices.