### PR TITLE
Fix rolling update doc

### DIFF
--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -45,7 +45,7 @@ This playbook says: **Promote leaders directly to these instances**:
       - failover_promote
     cartridge_failover_promote_params:
       force_inconsistency: true
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-replica
         storage-2: storage-2-replica
 ```
@@ -190,7 +190,7 @@ The example rolling update playbook:
     cartridge_scenario:
       - failover_promote
     cartridge_failover_promote_params:
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-replica
         storage-2: storage-2-replica
 
@@ -216,7 +216,7 @@ The example rolling update playbook:
     cartridge_scenario:
       - failover_promote
     cartridge_failover_promote_params:
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-leader
         storage-2: storage-2-leader
 
@@ -314,7 +314,7 @@ The example rolling update playbook:
     cartridge_scenario:
       - failover_promote
     cartridge_failover_promote_params:
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-replica
         storage-2: storage-2-replica
 
@@ -339,7 +339,7 @@ The example rolling update playbook:
     cartridge_scenario:
       - failover_promote
     cartridge_failover_promote_params:
-      replicasets_leaders:
+      replicaset_leaders:
         storage-1: storage-1-leader
         storage-2: storage-2-leader
 


### PR DESCRIPTION
Before this patch, there was an incorrect example of a leader change in the rolling update document.

Now it has been fixed.