### PR TITLE
Fix scenario doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For more details about using scenario and available steps, see
 * [Configuration basics](/doc/configuration-basics.md)
 * [Role variables](/doc/variables.md)
 * [Role scenario](/doc/scenario.md)
+* [Role steps description](/doc/steps.md)
 * [Application package](/doc/package.md)
 * [Deploying TGZ package](/doc/tgz.md)
 * [Using multiversion approach](/doc/multiversion.md)

--- a/consistency/test_steps.py
+++ b/consistency/test_steps.py
@@ -28,8 +28,8 @@ class TestSteps(unittest.TestCase):
         self.doc_facts_file = os.path.join(role_dir, 'doc', 'steps.md')
         with open(self.doc_facts_file, 'r') as f:
             text = f.read()
-            begin = text.find('# Role Steps List')
-            end = text.find('# Role Steps Description')
+            begin = text.find('## Role Steps List')
+            end = text.find('## Role Variables Descriptions')
             text = text[begin:end]
             self.doc_facts = re.findall(r'\n[*-][^\[]*\[([^]]+)]', text)
 

--- a/consistency/test_steps.py
+++ b/consistency/test_steps.py
@@ -25,11 +25,11 @@ class TestSteps(unittest.TestCase):
             for f in glob.glob(os.path.join(self.entry_points_dir, 'step_*'))
         ])
 
-        self.doc_facts_file = os.path.join(role_dir, 'doc', 'scenario.md')
+        self.doc_facts_file = os.path.join(role_dir, 'doc', 'steps.md')
         with open(self.doc_facts_file, 'r') as f:
             text = f.read()
-            begin = text.find('# Variable `cartridge_scenario`')
-            end = text.find('# Option `tasks_from`')
+            begin = text.find('# Role Steps Description')
+            end = text.find('## deliver_package')
             text = text[begin:end]
             self.doc_facts = re.findall(r'\n[*-][^\[]*\[([^]]+)]', text)
 

--- a/consistency/test_steps.py
+++ b/consistency/test_steps.py
@@ -28,8 +28,8 @@ class TestSteps(unittest.TestCase):
         self.doc_facts_file = os.path.join(role_dir, 'doc', 'steps.md')
         with open(self.doc_facts_file, 'r') as f:
             text = f.read()
-            begin = text.find('# Role Steps Description')
-            end = text.find('## deliver_package')
+            begin = text.find('# Role Steps List')
+            end = text.find('# Role Steps Description')
             text = text[begin:end]
             self.doc_facts = re.findall(r'\n[*-][^\[]*\[([^]]+)]', text)
 

--- a/cookbook/getting-started/README.md
+++ b/cookbook/getting-started/README.md
@@ -66,13 +66,13 @@ configuration step by step.
 Since version [1.8.0](https://github.com/tarantool/ansible-cartridge/releases/tag/1.8.0)
 `tarantool.cartridge` role allows to specify [scenario](/doc/scenario.md)
 that consists of steps.
-The role has pre-defined [steps](/doc/scenario.md#steps), but you can also
+The role has pre-defined [steps](/doc/steps.md), but you can also
 [write your own step](/doc/scenario.md#adding-custom-step-to-scenario) and
 use it in scenario.
 
 Using scenarios allows to perform different actions with cluster separately.
 
-The role has several common [scenarios](/doc/scenario.md#scenarios) that
+The role has several common [scenarios](/doc/scenario.md#pre-defined-scenarios) that
 can be re-used.
 It's also possible to write custom scenario and then use it in different plays.
 
@@ -165,7 +165,7 @@ diff --git a/cookbook/getting-started/hosts.yml b/cookbook/getting-started/hosts
 ### Configure instances
 
 To start and configure instance we can use
-[`configure_instances`](/doc/scenario.md#scenarios) pre-defined scenario.
+[`configure_instances`](/doc/scenario.md#pre-defined-scenarios) pre-defined scenario.
 But it also contain steps we don't need (like `deliver_package` and `update_package`).
 `update_instance` step is used only with [multiversion approach](/doc/multiversion.md),
 we don't need it too.
@@ -227,7 +227,7 @@ sudo journalctl -u myapp@core-1 | less
 When we sure that instances have started successfully it's time to join them
 to replicasets.
 
-We will use [`configure_topology`](/doc/scenario.md#scenarios) pre-defined scenario
+We will use [`configure_topology`](/doc/scenario.md#pre-defined-scenarios) pre-defined scenario
 to manage replicasets.
 
 Specify `cartridge_scenario_name` in [playbook.configure-topology.yml](./playbook.configure-topology.yml):
@@ -267,7 +267,7 @@ New topology on http://localhost:8182/admin/cluster/dashboard:
 Now we have both `vshard-storage` and `vshard-router` replicasets.
 It's time to bootstrap vshard.
 
-We need the only one [`bootstrap_vshard` step](/doc/scenario.md#bootstrap_vshard).
+We need the only one [`bootstrap_vshard` step](/doc/steps.md#step-bootstrap_vshard).
 It requires `cartridge_bootstrap_vshard` variable set to `true` to run
 vshard bootstrapping.
 
@@ -293,7 +293,7 @@ reload the page and check that `Bootstrap vshard` button was disappeared and ins
 ## What's next?
 
 * start [stateboard instance](/doc/stateboard.md);
-* check out list of [available steps](/doc/scenario.md#steps);
+* check out list of [available steps](/doc/steps.md);
 * set up [cluster configuration](/doc/variables.md#cluster-configuration)
   parameters, such as authorization, failover and application configuration.
 

--- a/doc/app_config.md
+++ b/doc/app_config.md
@@ -59,7 +59,7 @@ section-2:
 
 ## Config uploading
 
-[Step `upload_app_config`](/doc/scenario.md#upload_app_config) allows loading
+[Step `upload_app_config`](/doc/steps.md#step-upload_app_config) allows loading
 the entire config using Lua API or HTTP endpoint. To do this, you should specify
 the path to the configuration file or folder using `cartridge_app_config_path`.
 

--- a/doc/eval.md
+++ b/doc/eval.md
@@ -4,8 +4,8 @@ It could be useful to run code on instances by limit.
 
 There are two steps that allow running code snippets:
 
-* [`eval`](/doc/scenario.md#eval) runs specified snipped on each instance from play hosts.
-* [`eval_on_control_instance`](/doc/scenario.md#eval_on_control_instance) runs
+* [`eval`](/doc/steps.md#step-eval) runs specified snipped on each instance from play hosts.
+* [`eval_on_control_instance`](/doc/steps.md#step-eval_on_control_instance) runs
   specified snipped only on the control instance.
 
 By default, result is simply saved to `eval_res` variable, but if

--- a/doc/eval.md
+++ b/doc/eval.md
@@ -38,7 +38,7 @@ on eval.
 - name: Eval function from string
   hosts: cluster
   roles:
-    - ansible-cartridge
+    - tarantool.cartridge
   become: true
   become_user: root
   gather_facts: false
@@ -101,7 +101,7 @@ The code above can be ran from a file:
 - name: Eval function from string
   hosts: cluster
   roles:
-    - ansible-cartridge
+    - tarantool.cartridge
   become: true
   become_user: root
   gather_facts: false
@@ -135,7 +135,7 @@ Retries and delay can be configured:
   gather_facts: false
   tasks:
     - import_role:
-        name: ansible-cartridge
+        name: tarantool.cartridge
       vars:
         cartridge_scenario:
           - eval

--- a/doc/multiversion.md
+++ b/doc/multiversion.md
@@ -16,7 +16,7 @@ Multiversion approach:
 * each instance uses fixed version - it is achieved by using symbolic links;
 * updating instance consists of:
   * moving its link to the newest version of application
-    (see [`update_instance` step](/doc/scenario.md#update_instance));
+    (see [`update_instance` step](/doc/steps.md#step-update_instance));
   * instance restart.
 
 ## Configuration
@@ -52,7 +52,7 @@ and stateboard.
 
 Each new version is added to `cartridge_app_install_dir` and sometimes old version
 become redundant.
-To simply rotate distributions use [`rotate_dists` step](/doc/scenario.md#rotate_dists)
+To simply rotate distributions use [`rotate_dists` step](/doc/steps.md#step-rotate_dists)
 
 ## Example
 

--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -10,8 +10,8 @@ usual RPM/DEB packages.
 
 ## Leaders promotion
 
-[`failover_promote`](/doc/scenario.md#failover_promote) and
-[`force_leaders`](/doc/scenario.md#force_leaders)
+[`failover_promote`](/doc/steps.md#step-failover_promote) and
+[`force_leaders`](/doc/steps.md#step-force_leaders)
 steps can be used for leaders promotion only if stateful failover is enabled.
 
 The main difference of these steps is:
@@ -113,9 +113,9 @@ The plan is quite simple:
 
 [Multiversion approach](/doc/multiversion.md) allows updating application
 version that each instance uses with
-[`update_instance` step](/doc/scenario.md#update_instance).
+[`update_instance` step](/doc/steps.md#step-update_instance).
 
-Additionally, there is [`rotate_dists` step](/doc/scenario.md#rotate_dists) that
+Additionally, there is [`rotate_dists` step](/doc/steps.md#step-rotate_dists) that
 removes redundant distributions.
 
 Updating and restarting instance scenario can be persisted in inventory
@@ -135,7 +135,7 @@ all:
     ...
 ```
 
-**Note** that [`update_instance` step](/doc/scenario.md#update_instance) requires
+**Note** that [`update_instance` step](/doc/steps.md#step-update_instance) requires
 `cartridge_package_path` variable to set instance application link to unpacked
 distribution.
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -38,7 +38,7 @@ vars:
 ```
 
 You can use one of [pre-defined scenarios](#pre-defined-scenarios).
-Also you can find more detailed example [here](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)
+Also, you can find more detailed example [here](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)
 
 ## How to combine steps in a scenario?
 
@@ -47,23 +47,22 @@ but [steps API](/doc/steps.md) must be followed.
 
 What does it mean?
 
-Take a look at the `deliver_package` and `update_package` steps.
-They work together:
+Take a look at the [`deliver_package`](/doc/steps.md#deliver_package) and
+[`update_package`](/doc/steps.md#update_package) steps. They work together:
 
 * `deliver_package` delivers package and set `delivered_package_path` variable;
-* `update_package` installs package by `delivered_package_path`.
+* `update_package` installs package with path from `delivered_package_path`.
 
 These steps use `delivered_package_path` variable to communicate with each other.
-Each step described [here](/doc/steps.md) has some facts required
-for the step work and facts that the step produces.
+Each step has variables that are required for the step work and variables that the step produces.
+Descriptions of these variables for each step you can find in [steps doc](/doc/steps.md).
 
 ## Is it possible to add custom steps?
 
-Yes, to replace the steps of the role with your own or add new steps,
-you should use `cartridge_custom_steps_dir` option
-(see [example](#adding-custom-step-to-scenario))
-or `cartridge_custom_steps` option
-(see [example](#importing-steps-from-different-directories)).
+Yes, it's possible to add custom steps or rewrite the existing ones.
+One of `cartridge_custom_steps_dir` (see [example](#adding-custom-step-to-scenario))
+and `cartridge_custom_steps` (see [example](#importing-steps-from-different-directories))
+options should be used.
 
 ## Pre-defined scenarios
 
@@ -94,6 +93,8 @@ Steps:
 
 ### Scenario `configure_instances`
 
+This scenario contains steps for initial deployment of instances without applying topology.
+
 Steps:
 
 - [deliver_package](/doc/steps.md#deliver_package)
@@ -107,6 +108,8 @@ Steps:
 
 ### Scenario `configure_topology`
 
+This scenario contains steps for editing a topology.
+
 Steps:
 
 - [connect_to_membership](/doc/steps.md#connect_to_membership)
@@ -117,6 +120,8 @@ Steps:
 - [cleanup](/doc/steps.md#cleanup)
 
 ### Scenario `configure_app`
+
+This scenario contains steps for editing a configuration of application.
 
 Steps:
 
@@ -129,11 +134,12 @@ Steps:
 - [cleanup](/doc/steps.md#cleanup)
 
 To add new scenarios or replace the role scenarios with your own,
-you should use `cartridge_custom_scenarios` option.
+you should use `cartridge_custom_scenarios` option
+(see [example](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-tgz)).
 
 ## Using `tasks_from`
 
-You can select a step when importing a role.
+You can choose a step to run on the role import using `tasks_from` option.
 To do this, you just need to specify in the `tasks_from` option
 the name of the role step with the prefix `step_`.
 Unfortunately, using this method you cannot import custom steps
@@ -168,7 +174,7 @@ vars:
 ```
 
 It looks that we will often use this scenario.
-Save it to `cartridge_custom_scenarios` (e.g. in inventory) and then use by name:
+Save it to `cartridge_custom_scenarios` (e.g., in inventory) and then use by name:
 
 ```yaml
 # hosts.yml
@@ -225,10 +231,11 @@ Import role and specify a path to `custom_steps` directory in `cartridge_custom_
 ```
 
 Note, that:
-* [`single_instances_for_each_machine`](/doc/steps.md#role-facts-descriptions)
-  fact is used to download package once for each machine;
-* `delivered_package_path` fact is set to respect [API](/doc/steps.md#deliver_package);
+* [`single_instances_for_each_machine`](/doc/steps.md#role-variables-descriptions)
+  variable is used to download package once for each machine;
+* `delivered_package_path` variable is set to respect [API](/doc/steps.md#deliver_package);
 * previously defined `deliver_and_update_package` scenario will use our custom `deliver_package`;
+* `./custom_steps` path is relative to playbook path.
 
 ## Adding custom step to scenario
 
@@ -313,11 +320,14 @@ You can find more detailed description of rolling update [here](/doc/rolling_upd
 To replace any role scenario with a custom one, you only should define your own scenario
 in `cartridge_custom_scenarios` with the same name as the role script.
 
-For example, you can replace `configure_topology` with a scenario without `connect_to_membership` step (see
-[example for editing topology without connecting to membership](#editing-topology-without-connecting-to-membership))
+For example, you can replace `configure_topology` scenario with
+a scenario without cleanup steps:
+
 ```yaml
 cartridge_custom_scenarios:
   configure_topology:
+    - connect_to_membership
     - edit_topology
-    - cleanup_expelled
+    - wait_members_alive
+    - wait_cluster_has_no_issues
 ```

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -1,112 +1,135 @@
 # Role Scenario
 
 Any Ansible role contains tasks.
-It's usually not possible to change set of tasks and tasks sequence. This is not good!
-Sometimes we need to run only some subset of tasks,
+It's usually not possible to change set of tasks and tasks sequence.
+This is not good! Sometimes we need to run only some subset of tasks,
 execute tasks in a non-standard order or even add our own tasks.
 
 To do this, we grouped tasks in thematic sets, which we called [steps](/doc/steps.md). 
-For example, we have default step to deliver package.
-
-Next, we were allowed to choose which steps and in what order to run.
-This is done by specifying a list of **step** names, which we called **scenario**.
-For example, scenario can consist two steps:
-- `deliver_package` to deliver package;
-- `update_package` to extract delivered package.
+Steps can be combined in list of **steps**, which we called **scenario**.
 
 **Let's summarize:**
 1. Scenario consists of steps;
 2. Step consists of tasks.
 
-So, using a scenarios, you can:
+## How to specify a scenario?
 
-- run the specified steps in any order
-  by [`cartridge_scenario` variable](#configure-steps-to-launch)
-  or by [`tasks_from` option](#using-tasks_from).
-  Note that [API](/doc/steps.md) must be followed;
-- replace the steps of the role with your own or add new steps
-  by `cartridge_custom_steps_dir` or `cartridge_custom_steps` variables;
-- run prepared scenario (steps list)
-  by [`cartridge_scenario_name` variable](#configure-scenario-list-of-steps-to-launch);
-- replace the scenario (steps list) of the role with your own or
-  add new scenarios by `cartridge_custom_scenarios` variables.
-
-## Configure steps to launch
-
-To configure the list of steps to be launched,
-you should specify a list of steps names in `cartridge_scenario` variable.
-Full list of steps with descriptions your can find in [steps doc](/doc/steps.md).
-For example, you can specify scenario for package update:
+### Define a **scenario** (list of **steps**):
 
 ```yaml
+# playbook.yml
 vars:
   cartridge_scenario:
-    - deliver_package
-    - update_package
-    - update_instance
-    - restart_instance
-    - wait_instance_started
+    - step_1
+    - step_2
 ```
 
-To replace the steps of the role with your own or add new steps,
+### Define a **scenario name** (identifier of some previously defined scenario):
+
+```yaml
+# hosts.yml
+cartridge_custom_scenarios:
+  my_scenario:
+    - step_1
+    - step_2
+# playbook.yml
+vars:
+  cartridge_scenario_name: my_scenario
+```
+
+You can use one of [pre-defined scenarios](#pre-defined-scenarios).
+Also you can find more detailed example [here](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)
+
+## How to combine steps in a scenario?
+
+Generally, you can place steps in any order,
+but [steps API](/doc/steps.md) must be followed.
+
+What does it mean?
+
+Take a look at the `deliver_package` and `update_package` steps.
+They work together:
+
+* `deliver_package` delivers package and set `delivered_package_path` variable;
+* `update_package` installs package by `delivered_package_path`.
+
+These steps use `delivered_package_path` variable to communicate with each other.
+Each step described [here](/doc/steps.md) has some facts required
+for the step work and facts that the step produces.
+
+## Is it possible to add custom steps?
+
+Yes, to replace the steps of the role with your own or add new steps,
 you should use `cartridge_custom_steps_dir` option
 (see [example](#adding-custom-step-to-scenario))
 or `cartridge_custom_steps` option
 (see [example](#importing-steps-from-different-directories)).
 
-## Configure scenario (list of steps) to launch
+## Pre-defined scenarios
 
-Also, to configure the list of steps to be launched,
-you can specify a name of defined (by the role or by you) scenario
-in `cartridge_scenario_name` variable.
+### Scenario `default`
 
-There are the role scenarios (scenarios with `default` name is default):
-- `default`:
-  - [deliver_package](/doc/steps.md#deliver_package)
-  - [update_package](/doc/steps.md#update_package)
-  - [update_instance](/doc/steps.md#update_instance)
-  - [configure_instance](/doc/steps.md#configure_instance)
-  - [restart_instance](/doc/steps.md#restart_instance)
-  - [wait_instance_started](/doc/steps.md#wait_instance_started)
-  - [connect_to_membership](/doc/steps.md#connect_to_membership)
-  - [edit_topology](/doc/steps.md#edit_topology)
-  - [cleanup_expelled](/doc/steps.md#cleanup_expelled)
-  - [configure_auth](/doc/steps.md#configure_auth)
-  - [upload_app_config](/doc/steps.md#upload_app_config)
-  - [configure_app_config](/doc/steps.md#configure_app_config)
-  - [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
-  - [configure_failover](/doc/steps.md#configure_failover)
-  - [wait_members_alive](/doc/steps.md#wait_members_alive)
-  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-  - [cleanup](/doc/steps.md#cleanup)
-- `configure_instances`:
-  - [deliver_package](/doc/steps.md#deliver_package)
-  - [update_package](/doc/steps.md#update_package)
-  - [update_instance](/doc/steps.md#update_instance)
-  - [configure_instance](/doc/steps.md#configure_instance)
-  - [restart_instance](/doc/steps.md#restart_instance)
-  - [wait_instance_started](/doc/steps.md#wait_instance_started)
-  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-  - [cleanup](/doc/steps.md#cleanup)
-- `configure_topology`:
-  - [connect_to_membership](/doc/steps.md#connect_to_membership)
-  - [edit_topology](/doc/steps.md#edit_topology)
-  - [cleanup_expelled](/doc/steps.md#cleanup_expelled)
-  - [wait_members_alive](/doc/steps.md#wait_members_alive)
-  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-  - [cleanup](/doc/steps.md#cleanup)
-- `configure_app`:
-  - [configure_auth](/doc/steps.md#configure_auth)
-  - [configure_app_config](/doc/steps.md#configure_app_config)
-  - [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
-  - [configure_failover](/doc/steps.md#configure_failover)
-  - [wait_members_alive](/doc/steps.md#wait_members_alive)
-  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-  - [cleanup](/doc/steps.md#cleanup)
+This scenario is used by default.
+It contains a complete set of steps for deploying the application.
+
+Steps:
+
+- [deliver_package](/doc/steps.md#deliver_package)
+- [update_package](/doc/steps.md#update_package)
+- [update_instance](/doc/steps.md#update_instance)
+- [configure_instance](/doc/steps.md#configure_instance)
+- [restart_instance](/doc/steps.md#restart_instance)
+- [wait_instance_started](/doc/steps.md#wait_instance_started)
+- [connect_to_membership](/doc/steps.md#connect_to_membership)
+- [edit_topology](/doc/steps.md#edit_topology)
+- [cleanup_expelled](/doc/steps.md#cleanup_expelled)
+- [configure_auth](/doc/steps.md#configure_auth)
+- [upload_app_config](/doc/steps.md#upload_app_config)
+- [configure_app_config](/doc/steps.md#configure_app_config)
+- [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
+- [configure_failover](/doc/steps.md#configure_failover)
+- [wait_members_alive](/doc/steps.md#wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#cleanup)
+
+### Scenario `configure_instances`
+
+Steps:
+
+- [deliver_package](/doc/steps.md#deliver_package)
+- [update_package](/doc/steps.md#update_package)
+- [update_instance](/doc/steps.md#update_instance)
+- [configure_instance](/doc/steps.md#configure_instance)
+- [restart_instance](/doc/steps.md#restart_instance)
+- [wait_instance_started](/doc/steps.md#wait_instance_started)
+- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#cleanup)
+
+### Scenario `configure_topology`
+
+Steps:
+
+- [connect_to_membership](/doc/steps.md#connect_to_membership)
+- [edit_topology](/doc/steps.md#edit_topology)
+- [cleanup_expelled](/doc/steps.md#cleanup_expelled)
+- [wait_members_alive](/doc/steps.md#wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#cleanup)
+
+### Scenario `configure_app`
+
+Steps:
+
+- [configure_auth](/doc/steps.md#configure_auth)
+- [configure_app_config](/doc/steps.md#configure_app_config)
+- [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
+- [configure_failover](/doc/steps.md#configure_failover)
+- [wait_members_alive](/doc/steps.md#wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#cleanup)
 
 To add new scenarios or replace the role scenarios with your own,
-you should use `cartridge_custom_scenarios` option
-(see [example](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)).
+you should use `cartridge_custom_scenarios` option.
 
 ## Using `tasks_from`
 
@@ -131,54 +154,43 @@ For example:
 
 # Examples
 
-## Adding custom step to scenario
+## Writing a scenario using default steps
 
-You can create your own step and include it to scenario. Let's create `./custom_steps/special_magic.yml`. After that,
-you can add `special_magic` step to scenario. Just pass path to a directory where your custom steps are placed:
-
-```yaml
-- name: Deploy application
-  hosts: all
-  vars:
-    cartridge_custom_steps_dir: "./custom_steps"
-    cartridge_scenario:
-      - restart_instance
-      - special_magic
-  roles:
-    - tarantool.cartridge
-```
-
-## Importing steps from different directories
-
-If you want to import steps by full paths, `cartridge_custom_steps` parameter can be useful. It allows specifying
-mapping between step name and path to file to import:
+Imagine, we want to deliver the package on machines and install it.
+Let's write a simple scenario:
 
 ```yaml
-cartridge_custom_steps:
-  - name: 'common_special_task'
-    file: './common/special_task.yml'
+# playbook.yml
+vars:
+  cartridge_scenario:
+    - deliver_package
+    - update_package
 ```
 
-## Override task from default scenario
+It looks that we will often use this scenario.
+Save it to `cartridge_custom_scenarios` (e.g. in inventory) and then use by name:
 
-Sometimes we need to use default scenario, but change some steps realizations.
+```yaml
+# hosts.yml
+cartridge_custom_scenarios:
+  deliver_and_update_package:
+    - deliver_package
+    - update_package
+```
 
-For example, in default scenario package specified by `cartridge_package_path` is simple copied to remote host by
-step `deliver_package`. We might want to deliver package to remote machine by our own way. Let's do it!
+```yaml
+# playbook.yml
+vars:
+  cartridge_scenario_name: deliver_and_update_package
+```
 
-Generally, we just need to override default `deliver_package` step.
+## Rewriting default steps
 
-Let's take a look on it's [API](#deliver_package). It requires two variables:
+What if we want to download the package from some repository,
+but `deliver_package` step only copies the package from the local machine?
 
-- `cartridge_package_path` that we simply specify in vars;
-- `single_instances_for_each_machine` that allows us to run this task once per each machine.
-
-As a result of this module we should set `delivered_package_path` variable
-(a path of package on a remote machine).
-
-Now, choose a directory where our custom steps are placed, for example `./custom_steps`.
-
-Then create `./custom_steps/deliver_package.yml` and describe a way to deliver package:
+It's possible to rewrite default steps.
+Create `custom_steps` directory and add `deliver_package.yml` step there:
 
 ```yaml
 # ./custom_steps/deliver_package.yml
@@ -199,7 +211,7 @@ Then create `./custom_steps/deliver_package.yml` and describe a way to deliver p
         delivered_package_path: '{{ downloaded_package.dest }}'
 ```
 
-Import role and say where to find our custom steps:
+Import role and specify a path to `custom_steps` directory in `cartridge_custom_steps_dir` variable:
 
 ```yaml
 # deploy_application.yml
@@ -212,31 +224,41 @@ Import role and say where to find our custom steps:
     - tarantool.cartridge
 ```
 
-## Editing topology without connecting to membership
+Note, that:
+* [`single_instances_for_each_machine`](/doc/steps.md#role-facts-descriptions)
+  fact is used to download package once for each machine;
+* `delivered_package_path` fact is set to respect [API](/doc/steps.md#deliver_package);
+* previously defined `deliver_and_update_package` scenario will use our custom `deliver_package`;
 
-Now there is a big problem on deploying huge clusters - [`connect_to_membership` step](#connect_to_membership) is too
-long. Using scenario, we can solve this problem until it isn't solved in `cartridge`.
+## Adding custom step to scenario
 
-In variable `connect_to_membership` is used in [`set_control_instance` step](#set_control_instance) to find some instance
-that is already in a cluster. This instance should be used for joining other instances (otherwise two different clusters
-are created). This instance is called `control_instance` and is used for editing topology and configuring cluster (auth,
-config and so on). Generally, `connect_to_membership` step can be skipped if you definitely know some instance that is
-already joined to cluster. The solution is to set `cartridge_control_instance` variable manually and
-remove `connect_to_membership` step from scenario:
+You can create your own step and include it to scenario.
+Let's create `./custom_steps/special_magic.yml`. After that,
+you can add `special_magic` step to scenario.
+Just pass path to a directory where your custom steps are placed:
 
 ```yaml
-# edit_topology_playbook.yml
-
-- name: Edit topology by core 1
+- name: Deploy application
   hosts: all
   vars:
+    cartridge_custom_steps_dir: "./custom_steps"
     cartridge_scenario:
-      - edit_topology
-    cartridge_control_instance:
-      name: core_1
-      console_sock: '/var/run/tarantool/core_1.control'
+      - deliver_package
+      - special_magic
+      - update_package
   roles:
     - tarantool.cartridge
+```
+
+## Importing steps from different directories
+
+If you want to import steps by full paths, `cartridge_custom_steps` parameter can be useful. It allows specifying
+mapping between step name and path to file to import:
+
+```yaml
+cartridge_custom_steps:
+  - name: 'common_special_task'
+    file: './common/special_task.yml'
 ```
 
 ## Add a custom scenario to gradually update to a new version of TGZ
@@ -283,6 +305,8 @@ Then you can use them in your playbook:
     cartridge_scenario_name: "update_instance_tgz"
   roles: tarantool.cartridge
 ```
+
+You can find more detailed description of rolling update [here](/doc/rolling_update.md).
 
 ## Replace a role scenario with a custom scenario
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -1,72 +1,120 @@
 # Role Scenario
 
-The role uses a scenario to determine what to do.
-Any scenario consists of the previously defined steps.
-Using a scenario, you can:
+Any Ansible role contains tasks.
+It's usually not possible to change set of tasks and tasks sequence. This is not good!
+Sometimes it's needed to add or delete some tasks, execute some in a non-standard order.
 
-- run the specified steps in any order, but API must be followed
-  (with `cartridge_scenario` or `tasks_from`);
+To do this, we grouped tasks in thematic sets, which we called [steps](/doc/steps.md). 
+For example, we have default step to deliver package.
+
+Next, we were allowed to choose which steps and in what order to run.
+This is done by specifying a list of step names, which we called scenario.
+For example, scenario can consist two steps:
+- `deliver_package` to deliver package;
+- `update_package` to extract delivered package.
+
+> Let's summarize:
+> 1. Scenario consists of steps; 
+> 2. Step consists of tasks.
+
+So, using a scenarios, you can:
+
+- run the specified steps in any order
+  by [`cartridge_scenario` variable](#configure-steps-to-launch)
+  or by [`tasks_from` option](#using-tasks_from).
+  Note that [API](/doc/steps.md) must be followed;
 - replace the steps of the role with your own or add new steps
-  (with `cartridge_custom_steps_dir` or `cartridge_custom_steps`).
+  by `cartridge_custom_steps_dir` or `cartridge_custom_steps` variables;
+- run prepared scenario (steps list)
+  by [`cartridge_scenario_name` variable](#configure-scenario-list-of-steps-to-launch);
+- replace the scenario (steps list) of the role with your own or
+  add new scenarios by `cartridge_custom_scenarios` variables.
 
-## Steps
+## Configure steps to launch
 
-It's possible to specify what steps should be launched by `cartridge_scenario` variable or `tasks_from` option.
+To configure the list of steps to be launched,
+you should specify a list of steps names in `cartridge_scenario` variable.
+Full list of steps with descriptions your can find in [steps doc](/doc/steps.md).
+For example, you can specify scenario for package update:
 
-### Variable `cartridge_scenario`
+```yaml
+vars:
+  cartridge_scenario:
+    - deliver_package
+    - update_package
+    - update_instance
+    - restart_instance
+    - wait_instance_started
+```
 
-To specify `cartridge_scenario`, you can use the following options:
+To replace the steps of the role with your own or add new steps,
+you should use `cartridge_custom_steps_dir` option
+(see [example](#adding-custom-step-to-scenario))
+or `cartridge_custom_steps` option
+(see [example](#importing-steps-from-different-directories)).
 
-- specify `cartridge_scenario` directly;
-- specify a name of defined (by the role or by you) scenario by `cartridge_scenario_name`.
+## Configure scenario (list of steps) to launch
 
-If you want to specify `cartridge_scenario` variable, you should specify names of steps.
-The default scenario includes the following steps:
+Also, to configure the list of steps to be launched,
+you can specify a name of defined (by the role or by you) scenario
+in `cartridge_scenario_name` variable.
 
-- [deliver_package](#deliver_package)
-- [update_package](#update_package)
-- [update_instance](#update_instance)
-- [configure_instance](#configure_instance)
-- [restart_instance](#restart_instance)
-- [wait_instance_started](#wait_instance_started)
-- [connect_to_membership](#connect_to_membership)
-- [edit_topology](#edit_topology)
-- [cleanup_expelled](#cleanup_expelled)
-- [configure_auth](#configure_auth)
-- [upload_app_config](#upload_app_config)
-- [configure_app_config](#configure_app_config)
-- [bootstrap_vshard](#bootstrap_vshard)
-- [configure_failover](#configure_failover)
-- [wait_members_alive](#wait_members_alive)
-- [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
-- [cleanup](#cleanup)
+There are the role scenarios (scenarios with `default` name is default):
+- `default`:
+  - [deliver_package](/doc/steps.md#deliver_package)
+  - [update_package](/doc/steps.md#update_package)
+  - [update_instance](/doc/steps.md#update_instance)
+  - [configure_instance](/doc/steps.md#configure_instance)
+  - [restart_instance](/doc/steps.md#restart_instance)
+  - [wait_instance_started](/doc/steps.md#wait_instance_started)
+  - [connect_to_membership](/doc/steps.md#connect_to_membership)
+  - [edit_topology](/doc/steps.md#edit_topology)
+  - [cleanup_expelled](/doc/steps.md#cleanup_expelled)
+  - [configure_auth](/doc/steps.md#configure_auth)
+  - [upload_app_config](/doc/steps.md#upload_app_config)
+  - [configure_app_config](/doc/steps.md#configure_app_config)
+  - [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
+  - [configure_failover](/doc/steps.md#configure_failover)
+  - [wait_members_alive](/doc/steps.md#wait_members_alive)
+  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+  - [cleanup](/doc/steps.md#cleanup)
+- `configure_instances`:
+  - [deliver_package](/doc/steps.md#deliver_package)
+  - [update_package](/doc/steps.md#update_package)
+  - [update_instance](/doc/steps.md#update_instance)
+  - [configure_instance](/doc/steps.md#configure_instance)
+  - [restart_instance](/doc/steps.md#restart_instance)
+  - [wait_instance_started](/doc/steps.md#wait_instance_started)
+  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+  - [cleanup](/doc/steps.md#cleanup)
+- `configure_topology`:
+  - [connect_to_membership](/doc/steps.md#connect_to_membership)
+  - [edit_topology](/doc/steps.md#edit_topology)
+  - [cleanup_expelled](/doc/steps.md#cleanup_expelled)
+  - [wait_members_alive](/doc/steps.md#wait_members_alive)
+  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+  - [cleanup](/doc/steps.md#cleanup)
+- `configure_app`:
+  - [configure_auth](/doc/steps.md#configure_auth)
+  - [configure_app_config](/doc/steps.md#configure_app_config)
+  - [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
+  - [configure_failover](/doc/steps.md#configure_failover)
+  - [wait_members_alive](/doc/steps.md#wait_members_alive)
+  - [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
+  - [cleanup](/doc/steps.md#cleanup)
 
-More scenarios you can see in [scenarios](#scenarios) section.
+To add new scenarios or replace the role scenarios with your own,
+you should use `cartridge_custom_scenarios` option
+(see [example](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)).
 
-There are additional steps that are not included in the default scenario, but can be used in a custom one:
+## Using `tasks_from`
 
-- [set_control_instance](#set_control_instance)
-- [rotate_dists](#rotate_dists)
-- [failover_promote](#failover_promote)
-- [force_leaders](#force_leaders)
-- [eval](#eval)
-- [eval_on_control_instance](#eval_on_control_instance)
-- [stop_instance](#stop_instance)
-- [start_instance](#start_instance)
-- [restart_instance_force](#restart_instance_force)
-- [patch_instance_in_runtime](#patch_instance_in_runtime)
-- [cleanup_instance_files](#cleanup_instance_files)
-
-To replace the steps of the role with your own or add new steps, you should use `cartridge_custom_steps_dir`
-or `cartridge_custom_steps` options (see [examples](#examples)).
-
-### Option `tasks_from`
-
-You can also select a step when importing a role.
+You can select a step when importing a role.
 To do this, you just need to specify in the `tasks_from` option
 the name of the role step with the prefix `step_`.
 Unfortunately, using this method you cannot import custom steps
 (defined by `cartridge_custom_steps_dir` or `cartridge_custom_steps` options).
+Also, it's impossible to use scenarios.
 
 For example:
 
@@ -80,40 +128,9 @@ For example:
         tasks_from: step_deliver_package
 ```
 
-## Scenarios
+# Examples
 
-In addition to the default scenario (see [steps](#steps)), there are also the following scenarios:
-- `configure_instances`:
-  - [deliver_package](#deliver_package)
-  - [update_package](#update_package)
-  - [update_instance](#update_instance)
-  - [configure_instance](#configure_instance)
-  - [restart_instance](#restart_instance)
-  - [wait_instance_started](#wait_instance_started)
-  - [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
-  - [cleanup](#cleanup)
-- `configure_topology`:
-  - [connect_to_membership](#connect_to_membership)
-  - [edit_topology](#edit_topology)
-  - [cleanup_expelled](#cleanup_expelled)
-  - [wait_members_alive](#wait_members_alive)
-  - [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
-  - [cleanup](#cleanup)
-- `configure_app`:
-  - [configure_auth](#configure_auth)
-  - [configure_app_config](#configure_app_config)
-  - [bootstrap_vshard](#bootstrap_vshard)
-  - [configure_failover](#configure_failover)
-  - [wait_members_alive](#wait_members_alive)
-  - [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
-  - [cleanup](#cleanup)
-
-To add new scenarios or replace the role scenarios with your own, you should use `cartridge_custom_scenarios` option
-(see [example](#add-a-custom-scenario-to-gradually-update-to-a-new-version-of-TGZ)).
-
-## Examples
-
-### Adding custom step to scenario
+## Adding custom step to scenario
 
 You can create your own step and include it to scenario. Let's create `./custom_steps/special_magic.yml`. After that,
 you can add `special_magic` step to scenario. Just pass path to a directory where your custom steps are placed:
@@ -130,7 +147,7 @@ you can add `special_magic` step to scenario. Just pass path to a directory wher
     - tarantool.cartridge
 ```
 
-### Importing steps from different directories
+## Importing steps from different directories
 
 If you want to import steps by full paths, `cartridge_custom_steps` parameter can be useful. It allows specifying
 mapping between step name and path to file to import:
@@ -141,7 +158,7 @@ cartridge_custom_steps:
     file: './common/special_task.yml'
 ```
 
-### Override task from default scenario
+## Override task from default scenario
 
 Sometimes we need to use default scenario, but change some steps realizations.
 
@@ -194,7 +211,7 @@ Import role and say where to find our custom steps:
     - tarantool.cartridge
 ```
 
-### Editing topology without connecting to membership
+## Editing topology without connecting to membership
 
 Now there is a big problem on deploying huge clusters - [`connect_to_membership` step](#connect_to_membership) is too
 long. Using scenario, we can solve this problem until it isn't solved in `cartridge`.
@@ -221,7 +238,7 @@ remove `connect_to_membership` step from scenario:
     - tarantool.cartridge
 ```
 
-### Add a custom scenario to gradually update to a new version of TGZ
+## Add a custom scenario to gradually update to a new version of TGZ
 
 If you are using multiversion, then most likely you are upgrading to the new version of the package gradually:
 first storages, then routers, etc. To do this, the same scenario to update the package version is used several times.
@@ -266,7 +283,7 @@ Then you can use them in your playbook:
   roles: tarantool.cartridge
 ```
 
-### Replace a role scenario with a custom scenario
+## Replace a role scenario with a custom scenario
 
 To replace any role scenario with a custom one, you only should define your own scenario
 in `cartridge_custom_scenarios` with the same name as the role script.
@@ -279,594 +296,3 @@ cartridge_custom_scenarios:
     - edit_topology
     - cleanup_expelled
 ```
-
-## Role Facts Descriptions
-
-Some of useful facts are established during preparation, so you can use them at any step:
-
-- `instance_info` - information for a current instance. It's a dictionary with fields:
-  - `app_conf_file` - path to file with application config;
-  - `conf_file` - path to file with instance config;
-  - `instance_id` - ID of instance (e.g. for section name in config file);
-  - `console_sock` - path to control socket of instance;
-  - `pid_file` - path to pid file of instance;
-  - `work_dir` - path to working directory of instance;
-  - `tmpfiles_conf` - path to config file of temporary files;
-  - `dist_dir` - path to directory of distributed package;
-  - `instance_dist_dir` - path to instance link to distributed package;
-- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine. Can be used,
-  for example, in `delegate_to`;
-- `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
-  - `name` - name of step;
-  - `path` - path to YAML file of step.
-
-## Role Steps Description
-
-### deliver_package
-
-Delivery of the application package to physical machines.
-
-Input facts (set by role):
-
-- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine.
-
-Input facts (set by config):
-
-- `cartridge_package_path` - path to file of package to delivery.
-
-Output facts:
-
-- `delivered_package_path` - remote path to file of delivered package.
-
-### update_package
-
-Install the delivered package on physical machines.
-
-Input facts (set by role):
-
-- `delivered_package_path` - remote path to file of delivered package.
-  Is set on role preparation if `cartridge_delivered_package_path` is specified;
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
-- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine;
-- `needs_restart` - if instance should be restarted to apply code or configuration changes
-  (to determine if it's should be checked if instance should be restarted).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology
-  (to determine if it's should be checked if instance should be restarted);
-- `restarted` - if instance should be restarted or not (user forced decision)
-  (to determine if it's should be checked if instance should be restarted);
-- `cartridge_app_name` - application name;
-- `cartridge_enable_tarantool_repo` - indicates if Tarantool repository should be enabled;
-- `cartridge_install_tarantool_for_tgz` - indicates if Tarantool should be enabled when use TGZ package;
-- `cartridge_create_user_group_for_tgz` - flag indicates
-  that specified user and group should be created;
-- `cartridge_multiversion` - indicates that multiple package versions is enabled;
-- `cartridge_configure_tmpfiles` - indicates that tmpfiles config should be configured;
-- `cartridge_configure_systemd_unit_files` - indicates that systemd Unit files should be configured;
-- `cartridge_app_user` - user which will own the links;
-- `cartridge_app_group` - group which will own the links;
-- `cartridge_run_dir` - path to directory of instances sockets;
-- `cartridge_data_dir` - path to directory of instance data;
-- `cartridge_memtx_dir` - path to memtx directory of instance;
-- `cartridge_vinyl_dir` - path to vinyl directory of instance;
-- `cartridge_wal_dir` - path to wal directory of instance;
-- `cartridge_conf_dir` - path to directory of instances application configs;
-- `cartridge_app_install_dir` - path to directory with application distributions;
-- `cartridge_app_instances_dir` - path to directory with instances links to
-  distributions (see [multiversion approach doc](/doc/multiversion.md)).
-
-Output facts:
-
-- `package_info` - information about delivered package. It's a dictionary with fields:
-  - `name` - application name;
-  - `tnt_version` - version of Tarantool required by application;
-  - `type` - type of package (`rpm`, `deb` or `tgz`).
-- `systemd_units_info` - information for systemd Units files. It's a dictionary with fields:
-  - `stateboard_name` - ID of stateboard instance;
-  - `app_unit_file` - filename of application Unit file;
-  - `stateboard_unit_file` - filename of stateboard Unit file;
-  - `instance_work_dir` - path to working directory of instance;
-  - `stateboard_work_dir` - path to working directory of stateboard;
-  - `instance_memtx_dir` - path to memtx directory of instance;
-  - `stateboard_memtx_dir` - path to memtx directory of stateboard;
-  - `instance_vinyl_dir` - path to vinyl directory of instance;
-  - `stateboard_vinyl_dir` - path to vinyl directory of stateboard;
-  - `instance_wal_dir` - path to wal directory of instance;
-  - `stateboard_wal_dir` - path to wal directory of stateboard;
-  - `instance_pid_file` - path to pid file of instance;
-  - `stateboard_pid_file` - path to pid file of stateboard;
-  - `instance_console_sock` - path to control socket of instance;
-  - `stateboard_console_sock` - path to control socket of stateboard;
-  - `instance_entrypoint` - path to Lua entrypoint file of instance;
-  - `stateboard_entrypoint` - path to Lua entrypoint file of stateboard;
-  - `instance_tarantool_binary` - path Tarantool binary file of instance;
-  - `stateboard_tarantool_binary` - path Tarantool binary file of stateboard;
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
-
-### update_instance
-
-Update instance links for a new version of package (if
-[multiversion approach](/doc/multiversion.md) is enabled).
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
-- `needs_restart` - if instance should be restarted to apply code or configuration changes
-  (to determine if it's should be checked if instance should be restarted).
-
-Input facts (set by config):
-
-- `cartridge_package_path` - should be specified to compute app distribution directory
-  (otherwise, `update_instance` is skipped);
-- `expelled` - indicates if instance must be expelled from topology;
-- `restarted` - if instance should be restarted or not (user forced decision);
-- `cartridge_multiversion` - indicates that
-  [multiversion approach](/doc/multiversion.md) is enabled;
-- `cartridge_app_user` - user which will own the links;
-- `cartridge_app_group` - group which will own the links.
-
-Output facts:
-
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
-
-### configure_instance
-
-Configure instance in runtime and change instance config.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions));
-- `needs_restart` - if instance should be restarted to apply code or configuration changes
-  (to determine if it's should be checked if instance should be restarted).
-
-Input facts (set by config):
-
-- `config` - instance configuration ([more details here](/doc/instances.md));
-- `restarted` - if instance should be restarted or not (user forced decision);
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `cartridge_app_name` - application name;
-- `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
-- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
-- `cartridge_defaults` - default configuration parameters values for instances;
-- `cartridge_app_user` - user which will own the links;
-- `cartridge_app_group` - group which will own the links;
-- `cartridge_systemd_dir` - directory where systemd-unit files should be placed;
-- `cartridge_extra_env` - environment variables for instance service.
-
-Output facts:
-
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
-
-### restart_instance
-
-Restart and enable instance systemd service if it should be restarted.
-
-Input facts (set by role):
-
-- `needs_restart` - if instance should be restarted to apply code or configuration changes;
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
-- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
-- `restarted` - if instance should be restarted or not (user forced decision).
-
-### wait_instance_started
-
-Wait until an instance is fully started.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `instance_start_retries` - retries to check that all instances become started;
-- `instance_start_delay` - delay before retry to check that all instances become started;
-- [DEPRECATED] `instance_start_timeout` - time in seconds to wait for instance to be started;
-- `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap.
-
-### connect_to_membership
-
-Connect an instance to membership.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `cartridge_app_name` - application name;
-- `config` - instance configuration ([more details here](/doc/instances.md));
-- `connect_to_membership_retries` - retries to connect to membership;
-- `connect_to_membership_delay` - delay before retry to connect to membership.
-
-Output facts:
-
-- `alive_not_expelled_instance` - information about one not expelled instance
-  ([more details here](#role-facts-descriptions)).
-
-### set_control_instance
-
-Find some instance that can be used for editing topology and configuring cluster.
-This is instance that is:
-
-* described in inventory;
-* have `alive` status in membership;
-* if there are some instances already joined to cluster, then one of them is used,
-  otherwise, any instance that should be joined during current play is chosen;
-* control instance should have minimal Cartridge version across all suitable
-  instances (because Cartridge two-phase commit should be called by instance
-  that has lowest version).
-
-Steps that require control instance (such as [`edit_topology`](#edit_topology))
-call `set_control_instance` implicitly if `control_instance` fact isn't set.
-
-`control_instance` fact can be set by user via `cartridge_control_instance` variable.
-In this case `control_instance` fact is initialized on preparation step.
-
-**This step should be launched only after `connect_to_membership` step. Otherwise, 2 clusters may be created!**
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `replicaset_alias` - replicaset alias, will be displayed in Web UI;
-
-Output facts:
-
-- `control_instance` - information about control instance, that should be used for
-  managing topology and configuring cluster. It's a dictionary with fields:
-  - `name` - instance name (Ansible host);
-  - `console_sock` - path to control socket of instance.
-
-- `alive_not_expelled_instance` - information about one not expelled instance. It's a dictionary with fields:
-  - `name` - instance name (Ansible host);
-  - `console_sock` - path to control socket of instance.
-
-### edit_topology
-
-Edit topology of replicasets.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `replicaset_alias` - replicaset alias, will be displayed in Web UI;
-- `roles` - roles to be enabled on the replicaset;
-- `failover_priority` - failover priority order;
-- `all_rw` - indicates that that all servers in the replicaset should be read-write;
-- `weight` - vshard replicaset weight;
-- `vshard_group` - vshard group;
-- `twophase_netbox_call_timeout` - time in seconds to wait netbox call
-  while two-phase commit (Cartridge 2.5+ is required);
-- `twophase_upload_config_timeout` - time in seconds to wait config upload
-  while two-phase commit (Cartridge 2.5+ is required);
-- `twophase_apply_config_timeout` - time in seconds to wait config apply
-  while two-phase commit (Cartridge 2.5+ is required);
-- `edit_topology_healthy_timeout` - time in seconds to wait until a cluster become healthy after editing topology;
-- [DEPRECATED] `edit_topology_timeout` - the same timeout as `edit_topology_healthy_timeout`.
-
-### cleanup_expelled
-
-Cleanup files if instance is expelled.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-
-### configure_auth
-
-Configure application authentication settings.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `cartridge_auth` - authorization configuration.
-
-### upload_app_config
-
-Upload application configuration (mode details in [application config doc](/doc/app_config.md#config-uploading)).
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `cartridge_app_config_path` - path to application config to upload;
-- `cartridge_app_config_upload_mode` - mode of config uploading (`lua`, `http` or `tdg`);
-- `cartridge_app_config_upload_url` - url of instance to upload config
-  (`http://127.0.0.1:{control_instance.http_port}/admin/config` by default);
-- `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
-- `cartridge_tdg_token` - token to upload config by HTTP in TDG.
-
-### configure_app_config
-
-Configure application configuration.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `cartridge_app_config` - application config sections to patch.
-
-### bootstrap_vshard
-
-Bootstrap VShard in cluster.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance));
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `expelled` - indicates if instance must be expelled from topology;
-- `stateboard` - indicates that the instance is a stateboard;
-- `cartridge_bootstrap_vshard` - indicates if vshard should be bootstrapped;
-- `bootstrap_vshard_retries` - retries to bootstrap vshard;
-- `bootstrap_vshard_delay` - delay before retry to bootstrap vshard;
-- `instance_discover_buckets_retries` - retries to check that instances discover buckets;
-- `instance_discover_buckets_delay` - delay before retry to check that instances discover buckets;
-- [DEPRECATED] `instance_discover_buckets_timeout` - time in seconds to wait for instance to discover buckets;
-- `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap;
-
-### configure_failover
-
-Configure application failover.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `cartridge_failover_params` - failover parameters;
-- [DEPRECATED] `cartridge_failover` - indicates if eventual failover should be enabled or disabled.
-
-### wait_members_alive
-
-Waits until all cluster instances become alive and come to a specified state
-(by default, it's `RolesConfigured`).
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `allowed_members_states` - list of allowed states. If empty then instance state isn't checked;
-- `wait_members_alive_retries` - retries to check that all instances become alive;
-- `wait_members_alive_delay` - delay to retry instances status check.
-
-### wait_cluster_has_no_issues
-
-Waits until the cluster has no issues.
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance)).
-
-Input facts (set by config):
-
-- `wait_cluster_has_no_issues_retries` - retries to check that cluster has no issues;
-- `wait_cluster_has_no_issues_delay` - delay to retry cluster issues check;
-- `allow_warning_issues` - allow issues with `warning` level;
-- `show_issues` - log cluster issues as a warnings;
-
-### cleanup
-
-Removes temporary files specified in `temporary_files` list.
-By default, `temporary_files` is an empty list. The role,
-depending on the scenario, can add the following files to this list:
-
-- path to delivered package (`delivered_package_path` variable value);
-- path to repository setup script.
-
-In addition, you can add any files to this list by specifying `temporary_files` in configuration or in any custom step.
-For example, you can make a step like this:
-
-```yaml
-- name: 'Add my temporary file'
-  set_fact:
-    temporary_files: "{{ temporary_files + ['/tmp/my_file'] }}"
-```
-
-Input facts (set by role):
-
-- `temporary_files` - list of temporary files to remove.
-
-Input facts (set by config):
-
-- `cartridge_remove_temporary_files` - indicates if temporary files should be removed.
-
-### rotate_dists
-
-Rotate application distributions.
-
-When [multiversion approach](/doc/multiversion.md) is used, each new application
-version is added to `cartridge_app_install_dir`.
-This step removes redundant distributions.
-
-Input facts (set by config):
-
-- `cartridge_app_name` - application name;
-- `cartridge_app_install_dir` - path to directory where application distributions
-  are placed;
-- `cartridge_keep_num_latest_dists` - number of dists that should be kept.
-
-Output facts:
-
-- `dists_dirs_to_remove` - list of distribution directories paths that
-  were removed.
-
-### failover_promote
-
-[Promotes leaders](/doc/rolling_update.md#using-failover_promote-step) according to specified
-[`cartridge_failover_promote_params`](/doc/rolling_update.md#leaders-promotion).
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance));
-
-Input facts (set by config):
-
-- `cartridge_failover_promote_params` - promote leaders params. More details in
-  [rolling update doc](/doc/rolling_update.md#leaders-promotion).
-
-### force_leaders
-
-[Promotes leaders](/doc/rolling_update.md#using-force_leaders-step)
-to current play hosts (instances specified in limit).
-More details in [rolling update doc](/doc/rolling_update.md).
-
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance));
-
-Input facts (set by config):
-
-- `cartridge_failover_promote_params` - promote leaders params.
-  In fact, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
-  More details in [rolling update doc](/doc/rolling_update.md).
-
-### eval
-
-[Eval code](/doc/eval.md) on instance.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
-  `cartridge_eval_body` is specified);
-- `cartridge_eval_body` - code to eval;
-- `cartridge_eval_args` - function arguments;
-- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
-- `cartridge_eval_retries` number of eval retries;
-- `cartridge_eval_delay` - eval retries delay.
-
-### eval_on_control_instance
-
-[Eval code](/doc/eval.md) on control instance.
-
-Input facts (set by role):
-
-- `control_instance` - information about control instance ([more details here](#set_control_instance));
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
-  `cartridge_eval_body` is specified);
-- `cartridge_eval_body` - code to eval;
-- `cartridge_eval_args` - function arguments;
-- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
-- `cartridge_eval_retries` number of eval retries;
-- `cartridge_eval_delay` - eval retries delay.
-
-### stop_instance
-
-Stop and disable instance systemd service.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-### start_instance
-
-Start and enable instance systemd service.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-### restart_instance_force
-
-Restart and enable instance systemd service without any conditions.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-### patch_instance_in_runtime
-
-Patch dynamic (see [parameters](https://www.tarantool.io/en/doc/latest/reference/configuration/#configuration-parameters)
-with `Dynamic: yes`) instance parameters in runtime only
-(now it's possible to change only `box` config parameters).
-If the none-dynamic parameter is specified,
-nothing will be changed, and an error will be returned.
-
-**Note** that memory size can be only increased in runtime.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `cartridge_runtime_params` - new instance parameters ([more details here](/doc/instances.md));
-- `expelled` - indicates if instance must be expelled from topology.
-
-### cleanup_instance_files
-
-Clean up data of stopped instance.
-If instance is running, an error will be returned.
-
-Input facts (set by role):
-
-- `instance_info` - information for a current instance ([more details here](#role-facts-descriptions)).
-
-Input facts (set by config):
-
-- `cartridge_paths_to_keep_on_cleanup` - list of full paths or relative paths
-  to work/memtx/vinyl/wal directory that should be kept on instance cleanup
-  (it's possible to use bash patterns, e.g. `*.control`).

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -13,9 +13,9 @@ For example, scenario can consist two steps:
 - `deliver_package` to deliver package;
 - `update_package` to extract delivered package.
 
-> Let's summarize:
-> 1. Scenario consists of steps; 
-> 2. Step consists of tasks.
+**Let's summarize:**
+1. Scenario consists of steps;
+2. Step consists of tasks.
 
 So, using a scenarios, you can:
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -47,8 +47,8 @@ but [steps API](/doc/steps.md) must be followed.
 
 What does it mean?
 
-Take a look at the [`deliver_package`](/doc/steps.md#deliver_package) and
-[`update_package`](/doc/steps.md#update_package) steps. They work together:
+Take a look at the [`deliver_package`](/doc/steps.md#step-deliver_package) and
+[`update_package`](/doc/steps.md#step-update_package) steps. They work together:
 
 * `deliver_package` delivers package and set `delivered_package_path` variable;
 * `update_package` installs package with path from `delivered_package_path`.
@@ -73,23 +73,23 @@ It contains a complete set of steps for deploying the application.
 
 Steps:
 
-- [deliver_package](/doc/steps.md#deliver_package)
-- [update_package](/doc/steps.md#update_package)
-- [update_instance](/doc/steps.md#update_instance)
-- [configure_instance](/doc/steps.md#configure_instance)
-- [restart_instance](/doc/steps.md#restart_instance)
-- [wait_instance_started](/doc/steps.md#wait_instance_started)
-- [connect_to_membership](/doc/steps.md#connect_to_membership)
-- [edit_topology](/doc/steps.md#edit_topology)
-- [cleanup_expelled](/doc/steps.md#cleanup_expelled)
-- [configure_auth](/doc/steps.md#configure_auth)
-- [upload_app_config](/doc/steps.md#upload_app_config)
-- [configure_app_config](/doc/steps.md#configure_app_config)
-- [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
-- [configure_failover](/doc/steps.md#configure_failover)
-- [wait_members_alive](/doc/steps.md#wait_members_alive)
-- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-- [cleanup](/doc/steps.md#cleanup)
+- [deliver_package](/doc/steps.md#step-deliver_package)
+- [update_package](/doc/steps.md#step-update_package)
+- [update_instance](/doc/steps.md#step-update_instance)
+- [configure_instance](/doc/steps.md#step-configure_instance)
+- [restart_instance](/doc/steps.md#step-restart_instance)
+- [wait_instance_started](/doc/steps.md#step-wait_instance_started)
+- [connect_to_membership](/doc/steps.md#step-connect_to_membership)
+- [edit_topology](/doc/steps.md#step-edit_topology)
+- [cleanup_expelled](/doc/steps.md#step-cleanup_expelled)
+- [configure_auth](/doc/steps.md#step-configure_auth)
+- [upload_app_config](/doc/steps.md#step-upload_app_config)
+- [configure_app_config](/doc/steps.md#step-configure_app_config)
+- [bootstrap_vshard](/doc/steps.md#step-bootstrap_vshard)
+- [configure_failover](/doc/steps.md#step-configure_failover)
+- [wait_members_alive](/doc/steps.md#step-wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#step-wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#step-cleanup)
 
 ### Scenario `configure_instances`
 
@@ -97,14 +97,14 @@ This scenario contains steps for initial deployment of instances without applyin
 
 Steps:
 
-- [deliver_package](/doc/steps.md#deliver_package)
-- [update_package](/doc/steps.md#update_package)
-- [update_instance](/doc/steps.md#update_instance)
-- [configure_instance](/doc/steps.md#configure_instance)
-- [restart_instance](/doc/steps.md#restart_instance)
-- [wait_instance_started](/doc/steps.md#wait_instance_started)
-- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-- [cleanup](/doc/steps.md#cleanup)
+- [deliver_package](/doc/steps.md#step-deliver_package)
+- [update_package](/doc/steps.md#step-update_package)
+- [update_instance](/doc/steps.md#step-update_instance)
+- [configure_instance](/doc/steps.md#step-configure_instance)
+- [restart_instance](/doc/steps.md#step-restart_instance)
+- [wait_instance_started](/doc/steps.md#step-wait_instance_started)
+- [wait_cluster_has_no_issues](/doc/steps.md#step-wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#step-cleanup)
 
 ### Scenario `configure_topology`
 
@@ -112,12 +112,12 @@ This scenario contains steps for editing a topology.
 
 Steps:
 
-- [connect_to_membership](/doc/steps.md#connect_to_membership)
-- [edit_topology](/doc/steps.md#edit_topology)
-- [cleanup_expelled](/doc/steps.md#cleanup_expelled)
-- [wait_members_alive](/doc/steps.md#wait_members_alive)
-- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-- [cleanup](/doc/steps.md#cleanup)
+- [connect_to_membership](/doc/steps.md#step-connect_to_membership)
+- [edit_topology](/doc/steps.md#step-edit_topology)
+- [cleanup_expelled](/doc/steps.md#step-cleanup_expelled)
+- [wait_members_alive](/doc/steps.md#step-wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#step-wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#step-cleanup)
 
 ### Scenario `configure_app`
 
@@ -125,13 +125,13 @@ This scenario contains steps for editing a configuration of application.
 
 Steps:
 
-- [configure_auth](/doc/steps.md#configure_auth)
-- [configure_app_config](/doc/steps.md#configure_app_config)
-- [bootstrap_vshard](/doc/steps.md#bootstrap_vshard)
-- [configure_failover](/doc/steps.md#configure_failover)
-- [wait_members_alive](/doc/steps.md#wait_members_alive)
-- [wait_cluster_has_no_issues](/doc/steps.md#wait_cluster_has_no_issues)
-- [cleanup](/doc/steps.md#cleanup)
+- [configure_auth](/doc/steps.md#step-configure_auth)
+- [configure_app_config](/doc/steps.md#step-configure_app_config)
+- [bootstrap_vshard](/doc/steps.md#step-bootstrap_vshard)
+- [configure_failover](/doc/steps.md#step-configure_failover)
+- [wait_members_alive](/doc/steps.md#step-wait_members_alive)
+- [wait_cluster_has_no_issues](/doc/steps.md#step-wait_cluster_has_no_issues)
+- [cleanup](/doc/steps.md#step-cleanup)
 
 To add new scenarios or replace the role scenarios with your own,
 you should use `cartridge_custom_scenarios` option
@@ -233,7 +233,7 @@ Import role and specify a path to `custom_steps` directory in `cartridge_custom_
 Note, that:
 * [`single_instances_for_each_machine`](/doc/steps.md#role-variables-descriptions)
   variable is used to download package once for each machine;
-* `delivered_package_path` variable is set to respect [API](/doc/steps.md#deliver_package);
+* `delivered_package_path` variable is set to respect [API](/doc/steps.md#step-deliver_package);
 * previously defined `deliver_and_update_package` scenario will use our custom `deliver_package`;
 * `./custom_steps` path is relative to playbook path.
 

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -217,11 +217,11 @@ Import role and say where to find our custom steps:
 Now there is a big problem on deploying huge clusters - [`connect_to_membership` step](#connect_to_membership) is too
 long. Using scenario, we can solve this problem until it isn't solved in `cartridge`.
 
-In fact `connect_to_membership` is used in [`set_control_instance` step](#set_control_instance) to find some instance
+In variable `connect_to_membership` is used in [`set_control_instance` step](#set_control_instance) to find some instance
 that is already in a cluster. This instance should be used for joining other instances (otherwise two different clusters
 are created). This instance is called `control_instance` and is used for editing topology and configuring cluster (auth,
 config and so on). Generally, `connect_to_membership` step can be skipped if you definitely know some instance that is
-already joined to cluster. The solution is to set `cartridge_control_instance` fact manually and
+already joined to cluster. The solution is to set `cartridge_control_instance` variable manually and
 remove `connect_to_membership` step from scenario:
 
 ```yaml

--- a/doc/scenario.md
+++ b/doc/scenario.md
@@ -2,13 +2,14 @@
 
 Any Ansible role contains tasks.
 It's usually not possible to change set of tasks and tasks sequence. This is not good!
-Sometimes it's needed to add or delete some tasks, execute some in a non-standard order.
+Sometimes we need to run only some subset of tasks,
+execute tasks in a non-standard order or even add our own tasks.
 
 To do this, we grouped tasks in thematic sets, which we called [steps](/doc/steps.md). 
 For example, we have default step to deliver package.
 
 Next, we were allowed to choose which steps and in what order to run.
-This is done by specifying a list of step names, which we called scenario.
+This is done by specifying a list of **step** names, which we called **scenario**.
 For example, scenario can consist two steps:
 - `deliver_package` to deliver package;
 - `update_package` to extract delivered package.

--- a/doc/stateboard.md
+++ b/doc/stateboard.md
@@ -10,11 +10,11 @@ A stateboard instance is started as a systemd service named `<app_name>-stateboa
 
 Stateboard instance is started and configured by the same steps as other
 instances.
-Pre-defined [configure_instances scenario](/doc/scenario.md#scenarios)
+Pre-defined [configure_instances scenario](/doc/scenario.md#pre-defined-scenarios)
 can be used for this.
 
 To specify stateboard parameters in application failover params
-[configure_failover step](/doc/scenario.md#configure_failover) should be used.
+[configure_failover step](/doc/steps.md#step-configure_failover) should be used.
 
 ## Configuring stateboard instance
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -1,6 +1,6 @@
-# Role Facts Descriptions
+# Role Variables Descriptions
 
-Some of useful facts establishes during preparation, so you can use them at any step:
+Some of useful variables establishes during preparation, so you can use them at any step:
 
 - `instance_info` - information for a current instance. It's a dictionary with fields:
   - `app_conf_file` - path to file with application config;

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -4,44 +4,44 @@ Here are described steps that can be combined in the role scenarios.
 Each step description says what variables are required for the step and
 what variables are set by step.
 
-# Role Steps List
+## Role Steps List
 
 List of steps from default scenario:
 
-- [deliver_package](#deliver_package)
-- [update_package](#update_package)
-- [update_instance](#update_instance)
-- [configure_instance](#configure_instance)
-- [restart_instance](#restart_instance)
-- [wait_instance_started](#wait_instance_started)
-- [connect_to_membership](#connect_to_membership)
-- [edit_topology](#edit_topology)
-- [cleanup_expelled](#cleanup_expelled)
-- [configure_auth](#configure_auth)
-- [upload_app_config](#upload_app_config)
-- [configure_app_config](#configure_app_config)
-- [bootstrap_vshard](#bootstrap_vshard)
-- [configure_failover](#configure_failover)
-- [wait_members_alive](#wait_members_alive)
-- [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
-- [cleanup](#cleanup)
+- [deliver_package](#step-deliver_package)
+- [update_package](#step-update_package)
+- [update_instance](#step-update_instance)
+- [configure_instance](#step-configure_instance)
+- [restart_instance](#step-restart_instance)
+- [wait_instance_started](#step-wait_instance_started)
+- [connect_to_membership](#step-connect_to_membership)
+- [edit_topology](#step-edit_topology)
+- [cleanup_expelled](#step-cleanup_expelled)
+- [configure_auth](#step-configure_auth)
+- [upload_app_config](#step-upload_app_config)
+- [configure_app_config](#step-configure_app_config)
+- [bootstrap_vshard](#step-bootstrap_vshard)
+- [configure_failover](#step-configure_failover)
+- [wait_members_alive](#step-wait_members_alive)
+- [wait_cluster_has_no_issues](#step-wait_cluster_has_no_issues)
+- [cleanup](#step-cleanup)
 
 Additional steps that are not included in the default scenario,
 but can be used in a custom one:
 
-- [set_control_instance](#set_control_instance)
-- [rotate_dists](#rotate_dists)
-- [failover_promote](#failover_promote)
-- [force_leaders](#force_leaders)
-- [eval](#eval)
-- [eval_on_control_instance](#eval_on_control_instance)
-- [stop_instance](#stop_instance)
-- [start_instance](#start_instance)
-- [restart_instance_force](#restart_instance_force)
-- [patch_instance_in_runtime](#patch_instance_in_runtime)
-- [cleanup_instance_files](#cleanup_instance_files)
+- [set_control_instance](#step-set_control_instance)
+- [rotate_dists](#step-rotate_dists)
+- [failover_promote](#step-failover_promote)
+- [force_leaders](#step-force_leaders)
+- [eval](#step-eval)
+- [eval_on_control_instance](#step-eval_on_control_instance)
+- [stop_instance](#step-stop_instance)
+- [start_instance](#step-start_instance)
+- [restart_instance_force](#step-restart_instance_force)
+- [patch_instance_in_runtime](#step-patch_instance_in_runtime)
+- [cleanup_instance_files](#step-cleanup_instance_files)
 
-# Role Variables Descriptions
+## Role Variables Descriptions
 
 Some of useful variables always establishes during role preparation, so them can be used by any step:
 
@@ -70,9 +70,7 @@ Some of useful variables always establishes during role preparation, so them can
   - `name` - name of step;
   - `path` - path to YAML file of step.
 
-# Role Steps Description
-
-## deliver_package
+## Step `deliver_package`
 
 Delivery of the application package to physical machines.
 
@@ -84,14 +82,14 @@ Output variables:
 
 - `delivered_package_path` - remote path to file of delivered package.
 
-## update_package
+## Step `update_package`
 
 Install the delivered package on physical machines.
 
 variables from steps completed before:
 
 - `delivered_package_path` - remote path to file of delivered package.
-  It's set in [deliver_package](#deliver_package) step. Also, it's set on role
+  It's set in [deliver_package](#step-deliver_package) step. Also, it's set on role
   preparation if `cartridge_delivered_package_path` is specified.
 
 Input variables from config:
@@ -124,7 +122,7 @@ Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
-## update_instance
+## Step `update_instance`
 
 Update instance links for a new version of package (if
 [multiversion approach](/doc/multiversion.md) is enabled).
@@ -144,7 +142,7 @@ Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
-## configure_instance
+## Step `configure_instance`
 
 Configure instance in runtime and change instance config.
 
@@ -167,15 +165,15 @@ Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
-## restart_instance
+## Step `restart_instance`
 
 Restart and enable instance systemd service if it should be restarted.
 
 variables from steps completed before:
 
 - `needs_restart` - if instance should be restarted to apply code or
-  configuration changes. It's set in [update_package](#update_package),
-  [update_instance](#update_instance) and [configure_instance](#configure_instance)
+  configuration changes. It's set in [update_package](#step-update_package),
+  [update_instance](#step-update_instance) and [configure_instance](#step-configure_instance)
   steps.
 
 Input variables from config:
@@ -184,7 +182,7 @@ Input variables from config:
 - `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
 - `restarted` - if instance should be restarted or not (user forced decision).
 
-## wait_instance_started
+## Step `wait_instance_started`
 
 Wait until an instance is fully started.
 
@@ -197,7 +195,7 @@ Input variables from config:
 - [DEPRECATED] `instance_start_timeout` - time in seconds to wait for instance to be started;
 - `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap.
 
-## connect_to_membership
+## Step `connect_to_membership`
 
 Connect an instance to membership.
 
@@ -210,7 +208,7 @@ Input variables from config:
 - `connect_to_membership_retries` - retries to connect to membership;
 - `connect_to_membership_delay` - delay before retry to connect to membership.
 
-## set_control_instance
+## Step `set_control_instance`
 
 Find some instance that can be used for editing topology and configuring cluster.
 This is instance that is:
@@ -223,7 +221,7 @@ This is instance that is:
   instances (because Cartridge two-phase commit should be called by instance
   that has lowest version).
 
-Steps that require control instance (such as [`edit_topology`](#edit_topology))
+Steps that require control instance (such as [`edit_topology`](#step-edit_topology))
 call `set_control_instance` implicitly if `control_instance` variable isn't set.
 
 `control_instance` variable can be set by user via `cartridge_control_instance` variable.
@@ -244,11 +242,11 @@ Output variables:
   - `name` - instance name (Ansible host);
   - `console_sock` - path to control socket of instance.
 
-## edit_topology
+## Step `edit_topology`
 
 Edit topology of replicasets.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -269,7 +267,7 @@ Input variables from config:
 - `edit_topology_healthy_timeout` - time in seconds to wait until a cluster become healthy after editing topology;
 - [DEPRECATED] `edit_topology_timeout` - the same timeout as `edit_topology_healthy_timeout`.
 
-## cleanup_expelled
+## Step `cleanup_expelled`
 
 Cleanup files if instance is expelled.
 
@@ -277,21 +275,21 @@ Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 
-## configure_auth
+## Step `configure_auth`
 
 Configure application authentication settings.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
 - `cartridge_auth` - authorization configuration.
 
-## upload_app_config
+## Step `upload_app_config`
 
 Upload application configuration (mode details in [application config doc](/doc/app_config.md#config-uploading)).
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -302,21 +300,21 @@ Input variables from config:
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
 - `cartridge_tdg_token` - token to upload config by HTTP in TDG.
 
-## configure_app_config
+## Step `configure_app_config`
 
 Configure application configuration.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
 - `cartridge_app_config` - application config sections to patch.
 
-## bootstrap_vshard
+## Step `bootstrap_vshard`
 
 Bootstrap VShard in cluster.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -330,23 +328,23 @@ Input variables from config:
 - [DEPRECATED] `instance_discover_buckets_timeout` - time in seconds to wait for instance to discover buckets;
 - `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap;
 
-## configure_failover
+## Step `configure_failover`
 
 Configure application failover.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
 - `cartridge_failover_params` - failover parameters;
 - [DEPRECATED] `cartridge_failover` - indicates if eventual failover should be enabled or disabled.
 
-## wait_members_alive
+## Step `wait_members_alive`
 
 Waits until all cluster instances become alive and come to a specified state
 (by default, it's `RolesConfigured`).
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -354,11 +352,11 @@ Input variables from config:
 - `wait_members_alive_retries` - retries to check that all instances become alive;
 - `wait_members_alive_delay` - delay to retry instances status check.
 
-## wait_cluster_has_no_issues
+## Step `wait_cluster_has_no_issues`
 
 Waits until the cluster has no issues.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -367,15 +365,15 @@ Input variables from config:
 - `allow_warning_issues` - allow issues with `warning` level;
 - `show_issues` - log cluster issues as a warnings;
 
-## cleanup
+## Step `cleanup`
 
 Removes temporary files specified in `temporary_files` list.
 By default, `temporary_files` is an empty list. The role,
 depending on the scenario, can add the following files to this list:
 
 - path to delivered package (`delivered_package_path` variable value
-  from [deliver_package](#deliver_package) step);
-- path to repository setup script (from [update_package](#update_package) step).
+  from [deliver_package](#step-deliver_package) step);
+- path to repository setup script (from [update_package](#step-update_package) step).
 
 In addition, you can add any files to this list by specifying `temporary_files` in configuration or in any custom step.
 For example, you can make a step like this:
@@ -394,7 +392,7 @@ Input variables from config:
 
 - `cartridge_remove_temporary_files` - indicates if temporary files should be removed.
 
-## rotate_dists
+## Step `rotate_dists`
 
 Rotate application distributions.
 
@@ -414,25 +412,25 @@ Output variables:
 - `dists_dirs_to_remove` - list of distribution directories paths that
   were removed.
 
-## failover_promote
+## Step `failover_promote`
 
 [Promotes leaders](/doc/rolling_update.md#using-failover_promote-step) according to specified
 [`cartridge_failover_promote_params`](/doc/rolling_update.md#leaders-promotion).
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
 - `cartridge_failover_promote_params` - promote leaders params. More details in
   [rolling update doc](/doc/rolling_update.md#leaders-promotion).
 
-## force_leaders
+## Step `force_leaders`
 
 [Promotes leaders](/doc/rolling_update.md#using-force_leaders-step)
 to current play hosts (instances specified in limit).
 More details in [rolling update doc](/doc/rolling_update.md).
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -440,7 +438,7 @@ Input variables from config:
   In variable, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
   More details in [rolling update doc](/doc/rolling_update.md).
 
-## eval
+## Step `eval`
 
 [Eval code](/doc/eval.md) on instance.
 
@@ -454,11 +452,11 @@ Input variables from config:
 - `cartridge_eval_retries` number of eval retries;
 - `cartridge_eval_delay` - eval retries delay.
 
-## eval_on_control_instance
+## Step `eval_on_control_instance`
 
 [Eval code](/doc/eval.md) on control instance.
 
-*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+*If `control_instance` is not defined then [set_control_instance](#step-set_control_instance) will run.*
 
 Input variables from config:
 
@@ -470,19 +468,19 @@ Input variables from config:
 - `cartridge_eval_retries` number of eval retries;
 - `cartridge_eval_delay` - eval retries delay.
 
-## stop_instance
+## Step `stop_instance`
 
 Stop and disable instance systemd service.
 
-## start_instance
+## Step `start_instance`
 
 Start and enable instance systemd service.
 
-## restart_instance_force
+## Step `restart_instance_force`
 
 Restart and enable instance systemd service without any conditions.
 
-## patch_instance_in_runtime
+## Step `patch_instance_in_runtime`
 
 Patch dynamic (see [parameters](https://www.tarantool.io/en/doc/latest/reference/configuration/#configuration-parameters)
 with `Dynamic: yes`) instance parameters in runtime only
@@ -497,7 +495,7 @@ Input variables from config:
 - `cartridge_runtime_params` - new instance parameters ([more details here](/doc/instances.md));
 - `expelled` - indicates if instance must be expelled from topology.
 
-## cleanup_instance_files
+## Step `cleanup_instance_files`
 
 Clean up data of stopped instance.
 If instance is running, an error will be returned.

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -1,0 +1,496 @@
+# Role Facts Descriptions
+
+Some of useful facts establishes during preparation, so you can use them at any step:
+
+- `instance_info` - information for a current instance. It's a dictionary with fields:
+  - `app_conf_file` - path to file with application config;
+  - `conf_file` - path to file with instance config;
+  - `instance_id` - ID of instance (e.g. for section name in config file);
+  - `console_sock` - path to control socket of instance;
+  - `pid_file` - path to pid file of instance;
+  - `work_dir` - path to working directory of instance;
+  - `memtx_dir` - path to memtx directory of instance;
+  - `vinyl_dir` - path to vinyl directory of instance;
+  - `wal_dir` - path to wal directory of instance;
+  - `systemd_service` - name to systemd service;
+  - `systemd_service_dir` - path to directory of systemd service extensions;
+  - `systemd_service_env_file` - path to file of systemd service environment extensions;
+  - `tmpfiles_conf` - path to config file of temporary files;
+  - `dist_dir` - path to directory of distributed package;
+  - `instance_dist_dir` - path to instance link to distributed package;
+  - `paths_to_remove_on_expel` - paths that will be removed on instance expel;
+  - `files_to_remove_on_cleanup` - files that will be removed on instance cleanup;
+  - `dirs_to_remove_on_cleanup` - dirs that will be removed on instance cleanup;
+- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine,
+  for example, can be used in `delegate_to`;
+- `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
+  - `name` - name of step;
+  - `path` - path to YAML file of step.
+
+# Role Steps Description
+
+List of steps from default scenario:
+
+- [deliver_package](#deliver_package)
+- [update_package](#update_package)
+- [update_instance](#update_instance)
+- [configure_instance](#configure_instance)
+- [restart_instance](#restart_instance)
+- [wait_instance_started](#wait_instance_started)
+- [connect_to_membership](#connect_to_membership)
+- [edit_topology](#edit_topology)
+- [cleanup_expelled](#cleanup_expelled)
+- [configure_auth](#configure_auth)
+- [upload_app_config](#upload_app_config)
+- [configure_app_config](#configure_app_config)
+- [bootstrap_vshard](#bootstrap_vshard)
+- [configure_failover](#configure_failover)
+- [wait_members_alive](#wait_members_alive)
+- [wait_cluster_has_no_issues](#wait_cluster_has_no_issues)
+- [cleanup](#cleanup)
+
+Additional steps that are not included in the default scenario,
+but can be used in a custom one:
+
+- [set_control_instance](#set_control_instance)
+- [rotate_dists](#rotate_dists)
+- [failover_promote](#failover_promote)
+- [force_leaders](#force_leaders)
+- [eval](#eval)
+- [eval_on_control_instance](#eval_on_control_instance)
+- [stop_instance](#stop_instance)
+- [start_instance](#start_instance)
+- [restart_instance_force](#restart_instance_force)
+- [patch_instance_in_runtime](#patch_instance_in_runtime)
+- [cleanup_instance_files](#cleanup_instance_files)
+
+## deliver_package
+
+Delivery of the application package to physical machines.
+
+Input facts from config:
+
+- `cartridge_package_path` - path to file of package to delivery.
+
+Output facts:
+
+- `delivered_package_path` - remote path to file of delivered package.
+
+## update_package
+
+Install the delivered package on physical machines.
+
+Specific input facts, set by role:
+
+- `delivered_package_path` - remote path to file of delivered package.
+  Is set on role preparation if `cartridge_delivered_package_path` is specified.
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology
+  (to determine if it's should be checked if instance should be restarted);
+- `restarted` - if instance should be restarted or not (user forced decision)
+  (to determine if it's should be checked if instance should be restarted);
+- `cartridge_app_name` - application name;
+- `cartridge_enable_tarantool_repo` - indicates if Tarantool repository should be enabled;
+- `cartridge_install_tarantool_for_tgz` - indicates if Tarantool should be enabled when use TGZ package;
+- `cartridge_create_user_group_for_tgz` - flag indicates
+  that specified user and group should be created;
+- `cartridge_multiversion` - indicates that multiple package versions is enabled;
+- `cartridge_configure_tmpfiles` - indicates that tmpfiles config should be configured;
+- `cartridge_configure_systemd_unit_files` - indicates that systemd Unit files should be configured;
+- `cartridge_app_user` - user which will own the links;
+- `cartridge_app_group` - group which will own the links;
+- `cartridge_run_dir` - path to directory of instances sockets;
+- `cartridge_data_dir` - path to directory of instance data;
+- `cartridge_memtx_dir` - path to memtx directory of instance;
+- `cartridge_vinyl_dir` - path to vinyl directory of instance;
+- `cartridge_wal_dir` - path to wal directory of instance;
+- `cartridge_conf_dir` - path to directory of instances application configs;
+- `cartridge_app_install_dir` - path to directory with application distributions;
+- `cartridge_app_instances_dir` - path to directory with instances links to
+  distributions (see [multiversion approach doc](/doc/multiversion.md)).
+
+Output facts:
+
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+
+## update_instance
+
+Update instance links for a new version of package (if
+[multiversion approach](/doc/multiversion.md) is enabled).
+
+Input facts from config:
+
+- `cartridge_package_path` - should be specified to compute app distribution directory
+  (otherwise, `update_instance` is skipped);
+- `expelled` - indicates if instance must be expelled from topology;
+- `restarted` - if instance should be restarted or not (user forced decision);
+- `cartridge_multiversion` - indicates that
+  [multiversion approach](/doc/multiversion.md) is enabled;
+- `cartridge_app_user` - user which will own the links;
+- `cartridge_app_group` - group which will own the links.
+
+Output facts:
+
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+
+## configure_instance
+
+Configure instance in runtime and change instance config.
+
+Input facts from config:
+
+- `config` - instance configuration ([more details here](/doc/instances.md));
+- `restarted` - if instance should be restarted or not (user forced decision);
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `cartridge_app_name` - application name;
+- `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
+- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
+- `cartridge_defaults` - default configuration parameters values for instances;
+- `cartridge_app_user` - user which will own the links;
+- `cartridge_app_group` - group which will own the links;
+- `cartridge_systemd_dir` - directory where systemd-unit files should be placed;
+- `cartridge_extra_env` - environment variables for instance service.
+
+Output facts:
+
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+
+## restart_instance
+
+Restart and enable instance systemd service if it should be restarted.
+
+Specific input facts, set by role:
+
+- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+
+Input facts from config:
+
+- `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
+- `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
+- `restarted` - if instance should be restarted or not (user forced decision).
+
+## wait_instance_started
+
+Wait until an instance is fully started.
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `instance_start_retries` - retries to check that all instances become started;
+- `instance_start_delay` - delay before retry to check that all instances become started;
+- [DEPRECATED] `instance_start_timeout` - time in seconds to wait for instance to be started;
+- `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap.
+
+## connect_to_membership
+
+Connect an instance to membership.
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `cartridge_app_name` - application name;
+- `config` - instance configuration ([more details here](/doc/instances.md));
+- `connect_to_membership_retries` - retries to connect to membership;
+- `connect_to_membership_delay` - delay before retry to connect to membership.
+
+## set_control_instance
+
+Find some instance that can be used for editing topology and configuring cluster.
+This is instance that is:
+
+* described in inventory;
+* have `alive` status in membership;
+* if there are some instances already joined to cluster, then one of them is used,
+  otherwise, any instance that should be joined during current play is chosen;
+* control instance should have minimal Cartridge version across all suitable
+  instances (because Cartridge two-phase commit should be called by instance
+  that has lowest version).
+
+Steps that require control instance (such as [`edit_topology`](#edit_topology))
+call `set_control_instance` implicitly if `control_instance` fact isn't set.
+
+`control_instance` fact can be set by user via `cartridge_control_instance` variable.
+In this case `control_instance` fact is initialized on preparation step.
+
+**This step should be launched only after `connect_to_membership` step. Otherwise, 2 clusters may be created!**
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `replicaset_alias` - replicaset alias, will be displayed in Web UI;
+
+Output facts:
+
+- `control_instance` - information about control instance, that should be used for
+  managing topology and configuring cluster. It's a dictionary with fields:
+  - `name` - instance name (Ansible host);
+  - `console_sock` - path to control socket of instance.
+
+## edit_topology
+
+Edit topology of replicasets.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `replicaset_alias` - replicaset alias, will be displayed in Web UI;
+- `roles` - roles to be enabled on the replicaset;
+- `failover_priority` - failover priority order;
+- `all_rw` - indicates that that all servers in the replicaset should be read-write;
+- `weight` - vshard replicaset weight;
+- `vshard_group` - vshard group;
+- `twophase_netbox_call_timeout` - time in seconds to wait netbox call
+  while two-phase commit (Cartridge 2.5+ is required);
+- `twophase_upload_config_timeout` - time in seconds to wait config upload
+  while two-phase commit (Cartridge 2.5+ is required);
+- `twophase_apply_config_timeout` - time in seconds to wait config apply
+  while two-phase commit (Cartridge 2.5+ is required);
+- `edit_topology_healthy_timeout` - time in seconds to wait until a cluster become healthy after editing topology;
+- [DEPRECATED] `edit_topology_timeout` - the same timeout as `edit_topology_healthy_timeout`.
+
+## cleanup_expelled
+
+Cleanup files if instance is expelled.
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+
+## configure_auth
+
+Configure application authentication settings.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_auth` - authorization configuration.
+
+## upload_app_config
+
+Upload application configuration (mode details in [application config doc](/doc/app_config.md#config-uploading)).
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_app_config_path` - path to application config to upload;
+- `cartridge_app_config_upload_mode` - mode of config uploading (`lua`, `http` or `tdg`);
+- `cartridge_app_config_upload_url` - url of instance to upload config
+  (`http://127.0.0.1:{control_instance.http_port}/admin/config` by default);
+- `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
+- `cartridge_tdg_token` - token to upload config by HTTP in TDG.
+
+## configure_app_config
+
+Configure application configuration.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_app_config` - application config sections to patch.
+
+## bootstrap_vshard
+
+Bootstrap VShard in cluster.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `expelled` - indicates if instance must be expelled from topology;
+- `stateboard` - indicates that the instance is a stateboard;
+- `cartridge_bootstrap_vshard` - indicates if vshard should be bootstrapped;
+- `bootstrap_vshard_retries` - retries to bootstrap vshard;
+- `bootstrap_vshard_delay` - delay before retry to bootstrap vshard;
+- `instance_discover_buckets_retries` - retries to check that instances discover buckets;
+- `instance_discover_buckets_delay` - delay before retry to check that instances discover buckets;
+- [DEPRECATED] `instance_discover_buckets_timeout` - time in seconds to wait for instance to discover buckets;
+- `cartridge_wait_buckets_discovery` - indicates if routers should wait for buckets discovery after vshard bootstrap;
+
+## configure_failover
+
+Configure application failover.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_failover_params` - failover parameters;
+- [DEPRECATED] `cartridge_failover` - indicates if eventual failover should be enabled or disabled.
+
+## wait_members_alive
+
+Waits until all cluster instances become alive and come to a specified state
+(by default, it's `RolesConfigured`).
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `allowed_members_states` - list of allowed states. If empty then instance state isn't checked;
+- `wait_members_alive_retries` - retries to check that all instances become alive;
+- `wait_members_alive_delay` - delay to retry instances status check.
+
+## wait_cluster_has_no_issues
+
+Waits until the cluster has no issues.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `wait_cluster_has_no_issues_retries` - retries to check that cluster has no issues;
+- `wait_cluster_has_no_issues_delay` - delay to retry cluster issues check;
+- `allow_warning_issues` - allow issues with `warning` level;
+- `show_issues` - log cluster issues as a warnings;
+
+## cleanup
+
+Removes temporary files specified in `temporary_files` list.
+By default, `temporary_files` is an empty list. The role,
+depending on the scenario, can add the following files to this list:
+
+- path to delivered package (`delivered_package_path` variable value);
+- path to repository setup script.
+
+In addition, you can add any files to this list by specifying `temporary_files` in configuration or in any custom step.
+For example, you can make a step like this:
+
+```yaml
+- name: 'Add my temporary file'
+  set_fact:
+    temporary_files: "{{ temporary_files + ['/tmp/my_file'] }}"
+```
+
+Input facts (set by role):
+
+- `temporary_files` - list of temporary files to remove.
+
+Input facts from config:
+
+- `cartridge_remove_temporary_files` - indicates if temporary files should be removed.
+
+## rotate_dists
+
+Rotate application distributions.
+
+When [multiversion approach](/doc/multiversion.md) is used, each new application
+version is added to `cartridge_app_install_dir`.
+This step removes redundant distributions.
+
+Input facts from config:
+
+- `cartridge_app_name` - application name;
+- `cartridge_app_install_dir` - path to directory where application distributions
+  are placed;
+- `cartridge_keep_num_latest_dists` - number of dists that should be kept.
+
+Output facts:
+
+- `dists_dirs_to_remove` - list of distribution directories paths that
+  were removed.
+
+## failover_promote
+
+[Promotes leaders](/doc/rolling_update.md#using-failover_promote-step) according to specified
+[`cartridge_failover_promote_params`](/doc/rolling_update.md#leaders-promotion).
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_failover_promote_params` - promote leaders params. More details in
+  [rolling update doc](/doc/rolling_update.md#leaders-promotion).
+
+## force_leaders
+
+[Promotes leaders](/doc/rolling_update.md#using-force_leaders-step)
+to current play hosts (instances specified in limit).
+More details in [rolling update doc](/doc/rolling_update.md).
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_failover_promote_params` - promote leaders params.
+  In fact, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
+  More details in [rolling update doc](/doc/rolling_update.md).
+
+## eval
+
+[Eval code](/doc/eval.md) on instance.
+
+Input facts from config:
+
+- `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
+  `cartridge_eval_body` is specified);
+- `cartridge_eval_body` - code to eval;
+- `cartridge_eval_args` - function arguments;
+- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
+- `cartridge_eval_retries` number of eval retries;
+- `cartridge_eval_delay` - eval retries delay.
+
+## eval_on_control_instance
+
+[Eval code](/doc/eval.md) on control instance.
+
+*If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
+
+Input facts from config:
+
+- `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
+  `cartridge_eval_body` is specified);
+- `cartridge_eval_body` - code to eval;
+- `cartridge_eval_args` - function arguments;
+- `cartridge_eval_with_retries` - flag indicates that eval should be performed with retries;
+- `cartridge_eval_retries` number of eval retries;
+- `cartridge_eval_delay` - eval retries delay.
+
+## stop_instance
+
+Stop and disable instance systemd service.
+
+## start_instance
+
+Start and enable instance systemd service.
+
+## restart_instance_force
+
+Restart and enable instance systemd service without any conditions.
+
+## patch_instance_in_runtime
+
+Patch dynamic (see [parameters](https://www.tarantool.io/en/doc/latest/reference/configuration/#configuration-parameters)
+with `Dynamic: yes`) instance parameters in runtime only
+(now it's possible to change only `box` config parameters).
+If the none-dynamic parameter is specified,
+nothing will be changed, and an error will be returned.
+
+**Note** that memory size can be only increased in runtime.
+
+Input facts from config:
+
+- `cartridge_runtime_params` - new instance parameters ([more details here](/doc/instances.md));
+- `expelled` - indicates if instance must be expelled from topology.
+
+## cleanup_instance_files
+
+Clean up data of stopped instance.
+If instance is running, an error will be returned.
+
+Input facts from config:
+
+- `cartridge_paths_to_keep_on_cleanup` - list of full paths or relative paths
+  to work/memtx/vinyl/wal directory that should be kept on instance cleanup
+  (it's possible to use bash patterns, e.g. `*.control`).

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -27,7 +27,7 @@ Some of useful facts establishes during preparation, so you can use them at any 
   - `name` - name of step;
   - `path` - path to YAML file of step.
 
-# Role Steps Description
+# Role Steps List
 
 List of steps from default scenario:
 
@@ -64,15 +64,17 @@ but can be used in a custom one:
 - [patch_instance_in_runtime](#patch_instance_in_runtime)
 - [cleanup_instance_files](#cleanup_instance_files)
 
+# Role Steps Description
+
 ## deliver_package
 
 Delivery of the application package to physical machines.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_package_path` - path to file of package to delivery.
 
-Output facts:
+Output variables:
 
 - `delivered_package_path` - remote path to file of delivered package.
 
@@ -80,13 +82,13 @@ Output facts:
 
 Install the delivered package on physical machines.
 
-Facts from steps completed before:
+variables from steps completed before:
 
 - `delivered_package_path` - remote path to file of delivered package.
   It's set in [deliver_package](#deliver_package) step. Also, it's set on role
   preparation if `cartridge_delivered_package_path` is specified.
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology
   (to determine if it's should be checked if instance should be restarted);
@@ -112,7 +114,7 @@ Input facts from config:
 - `cartridge_app_instances_dir` - path to directory with instances links to
   distributions (see [multiversion approach doc](/doc/multiversion.md)).
 
-Output facts:
+Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
@@ -121,7 +123,7 @@ Output facts:
 Update instance links for a new version of package (if
 [multiversion approach](/doc/multiversion.md) is enabled).
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_package_path` - should be specified to compute app distribution directory
   (otherwise, `update_instance` is skipped);
@@ -132,7 +134,7 @@ Input facts from config:
 - `cartridge_app_user` - user which will own the links;
 - `cartridge_app_group` - group which will own the links.
 
-Output facts:
+Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
@@ -140,7 +142,7 @@ Output facts:
 
 Configure instance in runtime and change instance config.
 
-Input facts from config:
+Input variables from config:
 
 - `config` - instance configuration ([more details here](/doc/instances.md));
 - `restarted` - if instance should be restarted or not (user forced decision);
@@ -155,7 +157,7 @@ Input facts from config:
 - `cartridge_systemd_dir` - directory where systemd-unit files should be placed;
 - `cartridge_extra_env` - environment variables for instance service.
 
-Output facts:
+Output variables:
 
 - `needs_restart` - if instance should be restarted to apply code or configuration changes.
 
@@ -163,14 +165,14 @@ Output facts:
 
 Restart and enable instance systemd service if it should be restarted.
 
-Facts from steps completed before:
+variables from steps completed before:
 
 - `needs_restart` - if instance should be restarted to apply code or
   configuration changes. It's set in [update_package](#update_package),
   [update_instance](#update_instance) and [configure_instance](#configure_instance)
   steps.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances (is needed to check if configuration file was changed);
 - `cartridge_not_save_cookie_in_app_config` - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
@@ -180,7 +182,7 @@ Input facts from config:
 
 Wait until an instance is fully started.
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
@@ -193,7 +195,7 @@ Input facts from config:
 
 Connect an instance to membership.
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
@@ -216,20 +218,20 @@ This is instance that is:
   that has lowest version).
 
 Steps that require control instance (such as [`edit_topology`](#edit_topology))
-call `set_control_instance` implicitly if `control_instance` fact isn't set.
+call `set_control_instance` implicitly if `control_instance` variable isn't set.
 
-`control_instance` fact can be set by user via `cartridge_control_instance` variable.
-In this case `control_instance` fact is initialized on preparation step.
+`control_instance` variable can be set by user via `cartridge_control_instance` variable.
+In this case `control_instance` variable is initialized on preparation step.
 
 **This step should be launched only after `connect_to_membership` step. Otherwise, 2 clusters may be created!**
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `replicaset_alias` - replicaset alias, will be displayed in Web UI;
 
-Output facts:
+Output variables:
 
 - `control_instance` - information about control instance, that should be used for
   managing topology and configuring cluster. It's a dictionary with fields:
@@ -242,7 +244,7 @@ Edit topology of replicasets.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
@@ -265,7 +267,7 @@ Input facts from config:
 
 Cleanup files if instance is expelled.
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 
@@ -275,7 +277,7 @@ Configure application authentication settings.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_auth` - authorization configuration.
 
@@ -285,7 +287,7 @@ Upload application configuration (mode details in [application config doc](/doc/
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_app_config_path` - path to application config to upload;
 - `cartridge_app_config_upload_mode` - mode of config uploading (`lua`, `http` or `tdg`);
@@ -300,7 +302,7 @@ Configure application configuration.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_app_config` - application config sections to patch.
 
@@ -310,7 +312,7 @@ Bootstrap VShard in cluster.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
@@ -328,7 +330,7 @@ Configure application failover.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_failover_params` - failover parameters;
 - [DEPRECATED] `cartridge_failover` - indicates if eventual failover should be enabled or disabled.
@@ -340,7 +342,7 @@ Waits until all cluster instances become alive and come to a specified state
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `allowed_members_states` - list of allowed states. If empty then instance state isn't checked;
 - `wait_members_alive_retries` - retries to check that all instances become alive;
@@ -352,7 +354,7 @@ Waits until the cluster has no issues.
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `wait_cluster_has_no_issues_retries` - retries to check that cluster has no issues;
 - `wait_cluster_has_no_issues_delay` - delay to retry cluster issues check;
@@ -378,11 +380,11 @@ For example, you can make a step like this:
     temporary_files: "{{ temporary_files + ['/tmp/my_file'] }}"
 ```
 
-Input facts (set by role):
+Input variables (set by role):
 
 - `temporary_files` - list of temporary files to remove.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_remove_temporary_files` - indicates if temporary files should be removed.
 
@@ -394,14 +396,14 @@ When [multiversion approach](/doc/multiversion.md) is used, each new application
 version is added to `cartridge_app_install_dir`.
 This step removes redundant distributions.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_app_name` - application name;
 - `cartridge_app_install_dir` - path to directory where application distributions
   are placed;
 - `cartridge_keep_num_latest_dists` - number of dists that should be kept.
 
-Output facts:
+Output variables:
 
 - `dists_dirs_to_remove` - list of distribution directories paths that
   were removed.
@@ -413,7 +415,7 @@ Output facts:
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_failover_promote_params` - promote leaders params. More details in
   [rolling update doc](/doc/rolling_update.md#leaders-promotion).
@@ -426,17 +428,17 @@ More details in [rolling update doc](/doc/rolling_update.md).
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_failover_promote_params` - promote leaders params.
-  In fact, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
+  In variable, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
   More details in [rolling update doc](/doc/rolling_update.md).
 
 ## eval
 
 [Eval code](/doc/eval.md) on instance.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
   `cartridge_eval_body` is specified);
@@ -452,7 +454,7 @@ Input facts from config:
 
 *If `control_instance` is not defined then [set_control_instance](#set_control_instance) will run.*
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_eval_file` - path to file with Lua code to eval (isn't used if
   `cartridge_eval_body` is specified);
@@ -484,7 +486,7 @@ nothing will be changed, and an error will be returned.
 
 **Note** that memory size can be only increased in runtime.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_runtime_params` - new instance parameters ([more details here](/doc/instances.md));
 - `expelled` - indicates if instance must be expelled from topology.
@@ -494,7 +496,7 @@ Input facts from config:
 Clean up data of stopped instance.
 If instance is running, an error will be returned.
 
-Input facts from config:
+Input variables from config:
 
 - `cartridge_paths_to_keep_on_cleanup` - list of full paths or relative paths
   to work/memtx/vinyl/wal directory that should be kept on instance cleanup

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -1,31 +1,8 @@
-# Role Variables Descriptions
+# Role Steps
 
-Some of useful variables establishes during preparation, so you can use them at any step:
-
-- `instance_info` - information for a current instance. It's a dictionary with fields:
-  - `app_conf_file` - path to file with application config;
-  - `conf_file` - path to file with instance config;
-  - `instance_id` - ID of instance (e.g. for section name in config file);
-  - `console_sock` - path to control socket of instance;
-  - `pid_file` - path to pid file of instance;
-  - `work_dir` - path to working directory of instance;
-  - `memtx_dir` - path to memtx directory of instance;
-  - `vinyl_dir` - path to vinyl directory of instance;
-  - `wal_dir` - path to wal directory of instance;
-  - `systemd_service` - name to systemd service;
-  - `systemd_service_dir` - path to directory of systemd service extensions;
-  - `systemd_service_env_file` - path to file of systemd service environment extensions;
-  - `tmpfiles_conf` - path to config file of temporary files;
-  - `dist_dir` - path to directory of distributed package;
-  - `instance_dist_dir` - path to instance link to distributed package;
-  - `paths_to_remove_on_expel` - paths that will be removed on instance expel;
-  - `files_to_remove_on_cleanup` - files that will be removed on instance cleanup;
-  - `dirs_to_remove_on_cleanup` - dirs that will be removed on instance cleanup;
-- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine,
-  for example, can be used in `delegate_to`;
-- `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
-  - `name` - name of step;
-  - `path` - path to YAML file of step.
+Here are described steps that can be combined in the role scenarios.
+Each step description says what variables are required for the step and
+what variables are set by step.
 
 # Role Steps List
 
@@ -63,6 +40,35 @@ but can be used in a custom one:
 - [restart_instance_force](#restart_instance_force)
 - [patch_instance_in_runtime](#patch_instance_in_runtime)
 - [cleanup_instance_files](#cleanup_instance_files)
+
+# Role Variables Descriptions
+
+Some of useful variables always establishes during role preparation, so them can be used by any step:
+
+- `instance_info` - information for a current instance. It's a dictionary with fields:
+  - `app_conf_file` - path to file with application config;
+  - `conf_file` - path to file with instance config;
+  - `instance_id` - ID of instance (e.g. for section name in config file);
+  - `console_sock` - path to control socket of instance;
+  - `pid_file` - path to pid file of instance;
+  - `work_dir` - path to working directory of instance;
+  - `memtx_dir` - path to memtx directory of instance;
+  - `vinyl_dir` - path to vinyl directory of instance;
+  - `wal_dir` - path to wal directory of instance;
+  - `systemd_service` - name to systemd service;
+  - `systemd_service_dir` - path to directory of systemd service extensions;
+  - `systemd_service_env_file` - path to file of systemd service environment extensions;
+  - `tmpfiles_conf` - path to config file of temporary files;
+  - `dist_dir` - path to directory of distributed package;
+  - `instance_dist_dir` - path to instance link to distributed package;
+  - `paths_to_remove_on_expel` - paths that will be removed on instance expel;
+  - `files_to_remove_on_cleanup` - files that will be removed on instance cleanup;
+  - `dirs_to_remove_on_cleanup` - dirs that will be removed on instance cleanup;
+- `single_instances_for_each_machine` - list of instances (Ansible hosts), one for each physical machine,
+  for example, can be used in `delegate_to`;
+- `scenario_steps` - description of scenario steps. Each step is a dictionary with fields:
+  - `name` - name of step;
+  - `path` - path to YAML file of step.
 
 # Role Steps Description
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -80,10 +80,11 @@ Output facts:
 
 Install the delivered package on physical machines.
 
-Specific input facts, set by role:
+Facts from steps completed before:
 
 - `delivered_package_path` - remote path to file of delivered package.
-  Is set on role preparation if `cartridge_delivered_package_path` is specified.
+  It's set in [deliver_package](#deliver_package) step. Also, it's set on role
+  preparation if `cartridge_delivered_package_path` is specified.
 
 Input facts from config:
 
@@ -162,9 +163,12 @@ Output facts:
 
 Restart and enable instance systemd service if it should be restarted.
 
-Specific input facts, set by role:
+Facts from steps completed before:
 
-- `needs_restart` - if instance should be restarted to apply code or configuration changes.
+- `needs_restart` - if instance should be restarted to apply code or
+  configuration changes. It's set in [update_package](#update_package),
+  [update_instance](#update_instance) and [configure_instance](#configure_instance)
+  steps.
 
 Input facts from config:
 
@@ -361,8 +365,9 @@ Removes temporary files specified in `temporary_files` list.
 By default, `temporary_files` is an empty list. The role,
 depending on the scenario, can add the following files to this list:
 
-- path to delivered package (`delivered_package_path` variable value);
-- path to repository setup script.
+- path to delivered package (`delivered_package_path` variable value
+  from [deliver_package](#deliver_package) step);
+- path to repository setup script (from [update_package](#update_package) step).
 
 In addition, you can add any files to this list by specifying `temporary_files` in configuration or in any custom step.
 For example, you can make a step like this:

--- a/doc/topology.md
+++ b/doc/topology.md
@@ -109,7 +109,7 @@ and disabled.
 
 After that, all instance files
 (configuration file, socket and working directory)
-are removed on [`cleanup_expelled`](/doc/scenario.md#cleanup_expelled) step.
+are removed on [`cleanup_expelled`](/doc/steps.md#step-cleanup_expelled) step.
 
 ## Advertise URIs changing
 

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -11,7 +11,7 @@ vshard bootstrapping, and failover.
 * `cartridge_not_save_cookie_in_app_config` (`boolean`, default: `false`) - flag indicates that cluster cookie shouldn't be persisted in application configuration file;
 * `cartridge_remove_temporary_files` (`boolean`, optional, default: `false`):
   indicates if temporary files should be removed
-  (more details in description of [`cleanup` step API](/doc/scenario.md#cleanup));
+  (more details in description of [`cleanup` step API](/doc/steps.md#step-cleanup));
 * `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, optional, default: `[]`) -
   list of full paths or relative paths to work/memtx/vinyl/wal
   directory that should be kept on instance cleanup


### PR DESCRIPTION
Closes #363 

It was difficult to read scenario document and find information in it.

Now the description of the steps has been moved to a separate file.
Also, unnecessary facts were removed from the descriptions of the steps.