### PR TITLE
Fix instance joining when leader is not first

### DIFF
--- a/library/cartridge_edit_topology.py
+++ b/library/cartridge_edit_topology.py
@@ -316,6 +316,38 @@ def get_replicaset_params(new_replicaset, old_replicaset, old_instances, allow_m
     return replicaset_params, None
 
 
+def change_failover_priority_if_leader_not_first(replicaset_params, old_replicaset, old_instances):
+    if any([
+        not replicaset_params,
+        not old_replicaset or not old_replicaset.get('leader'),
+        not old_instances,
+    ]):
+        return replicaset_params
+
+    if replicaset_params.get('uuid') is not None and replicaset_params.get('join_servers'):
+        leader_uuid = old_replicaset.get('leader')
+        replicaset_instances = old_replicaset['instances']
+        first_instance_uuid = old_instances[replicaset_instances[0]].get('uuid')
+
+        if leader_uuid != first_instance_uuid:
+            # We can't join instances if leader not first (https://github.com/tarantool/cartridge/issues/1204)
+            del replicaset_params['join_servers']
+
+            # Count temp failover priority
+            temp_failover_priority_names = []
+            for instance_name in replicaset_instances:
+                if old_instances[instance_name]['uuid'] != leader_uuid:
+                    temp_failover_priority_names.append(instance_name)
+                else:
+                    temp_failover_priority_names = [instance_name] + temp_failover_priority_names
+
+            replicaset_params['failover_priority'] = [
+                old_instances[s]['uuid'] for s in temp_failover_priority_names
+            ]
+
+    return replicaset_params
+
+
 def get_replicasets_params(
     new_replicasets, old_replicasets,
     old_instances,
@@ -335,8 +367,42 @@ def get_replicasets_params(
                 new_replicaset['alias'], err
             )
 
+        replicaset_params = change_failover_priority_if_leader_not_first(
+            replicaset_params,
+            old_replicaset,
+            old_instances,
+        )
+
         if replicaset_params is not None:
             replicasets_params.append(replicaset_params)
+
+    return replicasets_params, None
+
+
+def get_replicasets_params_for_join_instances(
+    new_replicasets, old_replicasets,
+    old_instances,
+    allow_missed_instances,
+):
+    replicasets_params = []
+
+    for alias, cluster_replicaset in old_replicasets.items():
+        if alias not in new_replicasets:
+            continue
+
+        join_servers, err = get_join_servers(
+            new_replicasets[alias], cluster_replicaset,
+            old_instances,
+            allow_missed_instances,
+        )
+        if err is not None:
+            return None, err
+
+        if join_servers:
+            replicasets_params.append({
+                'uuid': cluster_replicaset['uuid'],
+                'join_servers': join_servers,
+            })
 
     return replicasets_params, None
 
@@ -614,32 +680,35 @@ def update_old_instances_and_replicasets(
 
 def get_topology_params(
     get_replicasets_params_func,
+    get_servers_params_func,
     new_instances, old_instances,
     new_replicasets, old_replicasets,
     allow_missed_instances,
 ):
     topology_params = {}
 
-    replicasets_params, err = get_replicasets_params_func(
-        new_replicasets, old_replicasets,
-        old_instances,
-        allow_missed_instances,
-    )
-    if err is not None:
-        return None, err
+    if get_replicasets_params_func:
+        replicasets_params, err = get_replicasets_params_func(
+            new_replicasets, old_replicasets,
+            old_instances,
+            allow_missed_instances,
+        )
+        if err is not None:
+            return None, err
 
-    if replicasets_params:
-        topology_params['replicasets'] = replicasets_params
+        if replicasets_params:
+            topology_params['replicasets'] = replicasets_params
 
-    servers_params, err = get_servers_params(
-        new_instances, old_instances,
-        allow_missed_instances,
-    )
-    if err is not None:
-        return None, err
+    if get_servers_params_func:
+        servers_params, err = get_servers_params_func(
+            new_instances, old_instances,
+            allow_missed_instances,
+        )
+        if err is not None:
+            return None, err
 
-    if servers_params:
-        topology_params['servers'] = servers_params
+        if servers_params:
+            topology_params['servers'] = servers_params
 
     return topology_params, None
 
@@ -647,6 +716,7 @@ def get_topology_params(
 def single_edit_topology_call(
     control_console,
     get_replicasets_params_func,
+    get_servers_params_func,
     new_instances, old_instances,
     new_replicasets, old_replicasets,
     allow_missed_instances,
@@ -654,6 +724,7 @@ def single_edit_topology_call(
 ):
     topology_params, err = get_topology_params(
         get_replicasets_params_func,
+        get_servers_params_func,
         new_instances, old_instances,
         new_replicasets, old_replicasets,
         allow_missed_instances,
@@ -688,6 +759,10 @@ def single_edit_topology_call(
         res, new_instances, old_instances, old_replicasets
     )
 
+    err = helpers.enrich_replicasets_with_leaders(control_console, old_replicasets)
+    if err is not None:
+        return None, err
+
     return True, None
 
 
@@ -721,6 +796,10 @@ def edit_topology(params):
     old_instances = helpers.get_cluster_instances(control_console)
     old_replicasets = helpers.get_cluster_replicasets(control_console)
 
+    err = helpers.enrich_replicasets_with_leaders(control_console, old_replicasets)
+    if err is not None:
+        return helpers.ModuleRes(failed=True, msg=err)
+
     # Check for dangerous changes
 
     if check_mode:
@@ -735,9 +814,9 @@ def edit_topology(params):
 
     # Configure replicasets and instances:
     # * Create new replicasets.
-    # * Edit existent replicasets and join new instances to them.
-    #   In this case failover_priority isn't changed since
-    #   new instances hasn't UUIDs before join.
+    # * Edit existent replicasets.
+    #   Temporary change failover_priority for replicasets with not first leader
+    #   (https://github.com/tarantool/cartridge/issues/1204)
     # * Expel instances.
     # * Configure instances that are already joined.
     #   New instances aren't configured here since they don't have
@@ -746,6 +825,24 @@ def edit_topology(params):
     changed_on_first_call, err = single_edit_topology_call(
         control_console,
         get_replicasets_params,
+        get_servers_params,
+        new_instances, old_instances,
+        new_replicasets, old_replicasets,
+        allow_missed_instances,
+        healthy_timeout,
+    )
+    if err is not None:
+        return helpers.ModuleRes(failed=True, msg=err)
+
+    # Configure replicasets:
+    # * Join new instances to existent replicasets.
+    #   In this case failover_priority isn't changed since
+    #   new instances hasn't UUIDs before join.
+
+    changed_on_second_call, err = single_edit_topology_call(
+        control_console,
+        get_replicasets_params_for_join_instances,
+        None,
         new_instances, old_instances,
         new_replicasets, old_replicasets,
         allow_missed_instances,
@@ -758,9 +855,10 @@ def edit_topology(params):
     # * Edit failover_priority of replicasets if it's needed.
     # * Configure instances that weren't configured on first `edit_topology` call.
 
-    changed_on_second_call, err = single_edit_topology_call(
+    changed_on_third_call, err = single_edit_topology_call(
         control_console,
         get_replicasets_params_for_changing_failover_priority,
+        get_servers_params,
         new_instances, old_instances,
         new_replicasets, old_replicasets,
         allow_missed_instances,
@@ -769,7 +867,11 @@ def edit_topology(params):
     if err is not None:
         return helpers.ModuleRes(failed=True, msg=err)
 
-    return helpers.ModuleRes(changed=changed_on_first_call or changed_on_second_call)
+    return helpers.ModuleRes(changed=any([
+        changed_on_first_call,
+        changed_on_second_call,
+        changed_on_third_call,
+    ]))
 
 
 if __name__ == '__main__':

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -621,7 +621,7 @@ def enrich_replicasets_with_leaders(control_console, replicasets):
         return None
 
     for replicaset_name, replicaset_params in replicasets.items():
-        replicaset_params['leader'] = leaders.get(replicaset_params['uuid'])
+        replicaset_params['leader_uuid'] = leaders.get(replicaset_params['uuid'])
 
     return None
 

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -610,6 +610,22 @@ def patch_clusterwide_config(control_console, new_sections):
     return True, None
 
 
+def enrich_replicasets_with_leaders(control_console, replicasets):
+    leaders, err = control_console.eval_res_err('''
+        return require('cartridge.failover').get_active_leaders()
+    ''')
+    if err:
+        return err
+
+    if not leaders:
+        return None
+
+    for replicaset_name, replicaset_params in replicasets.items():
+        replicaset_params['leader'] = leaders.get(replicaset_params['uuid'])
+
+    return None
+
+
 class Helpers:
     DYNAMIC_BOX_CFG_PARAMS = DYNAMIC_BOX_CFG_PARAMS
     MEMORY_SIZE_BOX_CFG_PARAMS = MEMORY_SIZE_BOX_CFG_PARAMS
@@ -645,3 +661,4 @@ class Helpers:
     read_yaml_file = staticmethod(read_yaml_file)
     get_clusterwide_config = staticmethod(get_clusterwide_config)
     patch_clusterwide_config = staticmethod(patch_clusterwide_config)
+    enrich_replicasets_with_leaders = staticmethod(enrich_replicasets_with_leaders)

--- a/molecule/join_instance/Dockerfile.j2
+++ b/molecule/join_instance/Dockerfile.j2
@@ -1,0 +1,1 @@
+../common/Dockerfile.j2

--- a/molecule/join_instance/converge.yml
+++ b/molecule/join_instance/converge.yml
@@ -1,0 +1,35 @@
+---
+
+- name: 'Force leader to core-2'
+  hosts: core-2
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_scenario:
+          - force_leaders
+
+- name: 'Add core-3 to replicaset'
+  hosts: core-3
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: "Set 'replicaset_alias' fact"
+      set_fact:
+        replicaset_alias: core
+
+- name: 'Try to join instance'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_scenario:
+          - edit_topology

--- a/molecule/join_instance/hosts.yml
+++ b/molecule/join_instance/hosts.yml
@@ -1,0 +1,70 @@
+---
+
+all:
+  children:
+    cluster:
+      vars:
+        ansible_user: root
+        ansible_connection: docker
+        become: true
+        become_user: root
+
+        cartridge_app_name: myapp
+        cartridge_cluster_cookie: secret-cookie
+        cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
+
+        cartridge_failover_params:
+          mode: stateful
+          state_provider: stateboard
+          stateboard_params:
+            uri: vm1:4001
+            password: secret-stateboard
+
+      hosts:
+        my-stateboard:
+          config:
+            listen: 0.0.0.0:4001
+            password: secret-stateboard
+          stateboard: true
+
+        core-1:
+          replicaset_alias: core
+          config:
+            advertise_uri: 'vm1:3301'
+            http_port: 8101
+
+        core-2:
+          replicaset_alias: core
+          config:
+            advertise_uri: 'vm1:3302'
+            http_port: 8102
+
+        core-3:
+          config:
+            advertise_uri: 'vm1:3303'
+            http_port: 8103
+
+      children:
+        machine_1:
+          vars:
+            ansible_host: vm1
+
+          hosts:
+            my-stateboard:
+            core-1:
+            core-2:
+            core-3:
+
+        core_replicaset:
+          hosts:
+            core-1:
+            core-2:
+            core-3:
+          vars:
+            failover_priority:
+              - core-1
+              - core-2
+            roles:
+              - app.roles.custom
+              - vshard-router
+              - failover-coordinator

--- a/molecule/join_instance/molecule.yml
+++ b/molecule/join_instance/molecule.yml
@@ -1,0 +1,1 @@
+../common/molecule/1_vm_not_idempotent.yml

--- a/molecule/join_instance/prepare.yml
+++ b/molecule/join_instance/prepare.yml
@@ -1,0 +1,9 @@
+---
+
+- name: 'Deploy cluster'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  roles:
+    - ansible-cartridge

--- a/unit/test_edit_topology.py
+++ b/unit/test_edit_topology.py
@@ -27,7 +27,7 @@ def assert_err_soft_mode(t, allow_missed_instances, res, exp_replicasets_opts, e
 
     if allow_missed_instances:
         t.assertEqual(res.failed, False)
-        t.assertEqual(res_json['warnings'], [expected_err])
+        t.assertEqual(list(set(res_json['warnings'])), [expected_err])
 
         calls = t.instance.get_calls('edit_topology')
         call = calls[0]


### PR DESCRIPTION
Closes #160

Cartridge has the bug: it's impossible to join instances to replicaset,
in which leader is not the first instance in failover priority.

To resolve this problem, the most painless way is to edit failover priority
before instances joining. So, after joining, we can change failover priority back.