### PR TITLE
Run 'instances_from_same_machine' fact set once

### DIFF
--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -84,13 +84,10 @@
   become: false
   register: facts_for_machines_res
 
-- name: 'Set "single_instances_for_each_machine" fact'
+- name: 'Set "single_instances_for_each_machine" and "instances_from_same_machine" facts'
   set_fact:
     single_instances_for_each_machine: '{{ facts_for_machines_res.single_instances_for_each_machine }}'
+    instances_from_same_machine: '{{ facts_for_machines_res.instances_from_same_machine }}'
   run_once: true
   delegate_to: localhost
   become: false
-
-- name: 'Set "instances_from_same_machine" fact'
-  set_fact:
-    instances_from_same_machine: '{{ facts_for_machines_res.instances_from_same_machine }}'


### PR DESCRIPTION
Before this patch, 'set_fact' task took a long time.

Now it runs once.