### PR TITLE
Add `restore` step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 ### Project ###
 
+# Dependencies
 packages/
 .rocks
+
+# Ignore backups fetched in molecule test
+molecule/*/backups/
 
 ### Vagrant ###
 
@@ -264,6 +268,3 @@ $RECYCLE.BIN/
 # Ignore all local history of files
 .history
 .ionide
-
-# Ignore backups fetched in molecule test
-molecule/backup/backups/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -204,6 +204,8 @@ cartridge_eval_delay: 5
 cartridge_remote_backups_dir: /opt/tarantool/backups
 cartridge_fetch_backups: false
 cartridge_fetch_backups_dir: backups/
+cartridge_restore_archive_path: null
+cartridge_force_restore: false
 
 # Edit topology check
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
 cartridge_ignore_split_brain: false
 cartridge_paths_to_keep_on_cleanup: []
+cartridge_paths_to_keep_on_restore: []
 
 # Role scenario configuration
 
@@ -204,8 +205,9 @@ cartridge_eval_delay: 5
 cartridge_remote_backups_dir: /opt/tarantool/backups
 cartridge_fetch_backups: false
 cartridge_fetch_backups_dir: backups/
-cartridge_restore_archive_path: null
+cartridge_restore_backup_path: null
 cartridge_force_restore: false
+cartridge_ignore_alien_backup: false
 
 # Edit topology check
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
 cartridge_ignore_split_brain: false
 cartridge_paths_to_keep_on_cleanup: []
-cartridge_paths_to_keep_on_restore: []
 
 # Role scenario configuration
 
@@ -207,7 +206,9 @@ cartridge_fetch_backups: false
 cartridge_fetch_backups_dir: backups/
 cartridge_restore_backup_path: null
 cartridge_force_restore: false
-cartridge_ignore_alien_backup: false
+cartridge_allow_alien_backup: false
+cartridge_skip_cleanup_on_restore: false
+cartridge_paths_to_keep_before_restore: []
 
 # Edit topology check
 

--- a/doc/backups.md
+++ b/doc/backups.md
@@ -51,7 +51,7 @@ For a stateboard instance only snapshot files and instance configuration file wi
 
 To restore you can use the `restore` step. It contains three stages:
 
-* find TGZ backup or folder with backup ([details here](#find-backup));
+* find TGZ backup or directory with backup ([details here](#find-backup));
 * check for conflicting files ([details here](#check-for-conflicting-files));
 * replace current files with files from backup ([details here](#replace-current-files-with-files-from-backup)).
 
@@ -59,13 +59,13 @@ Examples of restoring from backup, you can see [below](#using-restore-step).
 
 ### Find backup
 
-1. You can pass path of backup by `cartridge_restore_backup_path` variable.
-   Just set the value of this variable to full path of TGZ or folder backup.
+1. You can pass path to backup by `cartridge_restore_backup_path` variable.
+   Path to a TGZ archive or a directory with backup can be specified.
 2. If `cartridge_restore_backup_path` variable is omitted, the role
-   will look in the `cartridge_remote_backups_dir` folder
+   will look in the `cartridge_remote_backups_dir` directory
    (by default `/opt/tarantool/backups`) for the backup
-   whose name is the most recent alphabetically and contains the instance ID.
-3. If no file or folder is selected, an error will occur.
+   whose name contains the instance ID and is the latest alphabetically (with the biggest date).
+3. If no file or directory is selected, an error will occur.
 
 You can see examples of using the described variables [below](#using-restore-step).
 
@@ -77,16 +77,17 @@ After selecting a backup, `restore` step checks the following:
   (in order to overwrite such files, set the `cartridge_force_restore` flag);
 - probably the selected backup belongs to the instance that is currently being
   restored (in order to allow recovery from such backup, set the
-  `cartridge_ignore_alien_backup` flag).
+  `cartridge_allow_alien_backup` flag).
 
 You can see examples of using the described variables [below](#using-restore-step).
 
 ### Replace current files with files from backup
 
-After all checks have been passed, step deletes the instance files
-that are in the system (except for `.tarantool.cookie` and files that
-match the templates from `cartridge_paths_to_keep_on_restore` list),
-and unpack files from selected backup.
+After all checks have been passed, step make two actions:
+1. If `cartridge_skip_cleanup_on_restore` is not set, step deletes the instance
+   files that are in the system (except for `.tarantool.cookie` and files that
+   match the templates from `cartridge_paths_to_keep_before_restore` list);
+2. Step unpacks files from selected backup.
 
 You can see examples of using the described variables [below](#using-restore-step).
 
@@ -271,7 +272,7 @@ You can select backup manually by `cartridge_restore_backup_path` variable:
 ```
 
 By default, only `.tarantool.cookie` will be kept in working directory.
-If you want to keep some more files, you can put in `cartridge_paths_to_keep_on_restore`
+If you want to keep some more files, you can put in `cartridge_paths_to_keep_before_restore`
 variable some bash patterns:
 
 ```yaml
@@ -285,7 +286,7 @@ variable some bash patterns:
       import_role:
         name: tarantool.cartridge
       vars:
-        cartridge_paths_to_keep_on_restore:
+        cartridge_paths_to_keep_before_restore:
           - 'config'
           - '*.log'
         cartridge_scenario:

--- a/doc/backups.md
+++ b/doc/backups.md
@@ -64,8 +64,8 @@ Examples of restoring from backup, you can see [below](#using-restore-step).
 2. If `cartridge_restore_backup_path` variable is omitted, the role
    will look in the `cartridge_remote_backups_dir` directory
    (by default `/opt/tarantool/backups`) for the backup
-   whose name contains the instance ID and is the latest alphabetically (with the biggest date).
-3. If no file or directory is selected, an error will occur.
+   whose name contains the instance ID and is the latest alphabetically (with the latest date).
+3. If not found any file or directory backup that belongs to given instance, an error will occur.
 
 You can see examples of using the described variables [below](#using-restore-step).
 

--- a/doc/backups.md
+++ b/doc/backups.md
@@ -7,7 +7,8 @@ The instance backup process contains three stages:
   * [`box.snapshot()`](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_snapshot/) is called;
   * [`box.backup.start()`](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_backup/start/) is called;
   * `instance_backup_files` variable is set ([list of instance files](#instance-files) to back up);
-  * `backup_files_from_machine` variable is set (list of files to back up for all instances on the same machine as a current one);
+  * `backup_files_from_machine` variable is set (list of files to back up for
+    all instances on the same machine as a current one);
 * Creating and fetching the backup archive:
   * all backup files are packed into the TGZ archive placed in [`cartridge_remote_backups_dir`](/doc/variables.md#backups-configuration);
   * all paths inside the archive are relative to `/`;
@@ -15,7 +16,8 @@ The instance backup process contains three stages:
   * fetching an archive from the remote machine to
     [`cartridge_fetch_backups_dir`](/doc/variables.md#backups-configuration)
     if [`cartridge_fetch_backups`](/doc/variables.md#backups-configuration) is `true`;
-  * `fetched_backup_archive_path` is set if [`cartridge_fetch_backups`](/doc/variables.md#backups-configuration) is `true` (path to the fetched instance backup archive on the local machine);
+  * `fetched_backup_archive_path` is set if [`cartridge_fetch_backups`](/doc/variables.md#backups-configuration)
+    is `true` (path to the fetched instance backup archive on the local machine);
 * Stopping backup:
   * [`box.backup.stop()`](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_backup/stop/) is called.
 
@@ -31,7 +33,8 @@ There are three steps that allows to create a backup:
 
 These files are added to an archive for each instance (excluding the stateboard):
 
-* snapshot and vinyl files returned by [`box.backup.start()`](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_backup/start/);
+* snapshot and vinyl files returned by
+  [`box.backup.start()`](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_backup/start/);
 * cluster-wide config and its backup;
 * instance configuration file;
 * application configuration file.
@@ -41,7 +44,51 @@ For a stateboard instance only snapshot files and instance configuration file wi
 ## How to use backup steps?
 
 * `backup` step can be used for performing all three backup stages, see [example](#using-backup-step);
-* `backup_start` + `backup_stop` steps can be used to perform some custom actions with instance files list, see [example](#using-backup_start-and-backup_stop).
+* `backup_start` + `backup_stop` steps can be used to perform some custom actions
+  with instance files list, see [example](#using-backup_start-and-backup_stop).
+
+## How to restore from saved backup?
+
+To restore you can use the `restore` step. It contains three stages:
+
+* find TGZ backup or folder with backup ([details here](#find-backup));
+* check for conflicting files ([details here](#check-for-conflicting-files));
+* replace current files with files from backup ([details here](#replace-current-files-with-files-from-backup)).
+
+Examples of restoring from backup, you can see [below](#using-restore-step).
+
+### Find backup
+
+1. You can pass path of backup by `cartridge_restore_backup_path` variable.
+   Just set the value of this variable to full path of TGZ or folder backup.
+2. If `cartridge_restore_backup_path` variable is omitted, the role
+   will look in the `cartridge_remote_backups_dir` folder
+   (by default `/opt/tarantool/backups`) for the backup
+   whose name is the most recent alphabetically and contains the instance ID.
+3. If no file or folder is selected, an error will occur.
+
+You can see examples of using the described variables [below](#using-restore-step).
+
+### Check for conflicting files
+
+After selecting a backup, `restore` step checks the following:
+- files in the selected backup do not conflict with files in the system,
+  taking into account that some files will be deleted
+  (in order to overwrite such files, set the `cartridge_force_restore` flag);
+- probably the selected backup belongs to the instance that is currently being
+  restored (in order to allow recovery from such backup, set the
+  `cartridge_ignore_alien_backup` flag).
+
+You can see examples of using the described variables [below](#using-restore-step).
+
+### Replace current files with files from backup
+
+After all checks have been passed, step deletes the instance files
+that are in the system (except for `.tarantool.cookie` and files that
+match the templates from `cartridge_paths_to_keep_on_restore` list),
+and unpack files from selected backup.
+
+You can see examples of using the described variables [below](#using-restore-step).
 
 ## Examples
 
@@ -70,7 +117,6 @@ It can be used to create backup archive for each instance and fetch all archives
           - backup
         cartridge_fetch_backups: true
         cartridge_fetch_backups_dir: ./my_backups
-
 ```
 
 After running this playbook, we have such archive on local machine:
@@ -78,40 +124,45 @@ After running this playbook, we have such archive on local machine:
 ```bash
 ├── playbook.yml
 └── my_backups
-    ├── myapp-stateboard.2021-07-09-133438.tar.gz
+    ├── myapp-stateboard.2021-07-09-133438.tar.gz
     ├── myapp.instance-1.2021-07-09-133438.tar.gz
-    └── myapp.instance-2.2021-07-09-133438.tar.gz
-
+    └── myapp.instance-2.2021-07-09-133438.tar.gz
 ```
 
-On the remote machines, backups are placed in `/opt/backups/` directory.
+On the remote machines, backups are placed in `/opt/tarantool/backups/` directory.
 
 On each instance the following variables will be set:
 
-```json
-instance-1: {
-    "instance_backup_files": [
-        "/opt/memtx/myapp.instance-1/00000000000000000008.snap",
-        "/opt/vinyl/myapp.instance-1/00000000000000000000.vylog",
-        "/opt/data/myapp.instance-1/config",
-        "/opt/conf.d/myapp.instance-1.yml",
-        "/opt/conf.d/myapp.yml"
-    ],
-    "backup_archive_path": "/opt/backups/myapp.instance-1.2021-07-09-133438.tar.gz",
-    "fetched_backup_archive_path": "/path/to/playbook/my_backups/myapp.instance-1.2021-07-09-133438.tar.gz"
-}
+- my-stateboard:
 
-my-stateboard: {
-    "instance_backup_files": [
-        "/opt/memtx/myapp-stateboard/00000000000000000049.snap",
-        "/opt/conf.d/myapp-stateboard.yml"
-    ],
-    "backup_archive_path": "/opt/backups/myapp-stateboard.2021-07-09-133438.tar.gz",
-    "fetched_backup_archive_path": "/path/to/playbook/my_backups/myapp-stateboard.2021-07-09-133438.tar.gz"
-}
+  ```json
+  {
+      "instance_backup_files": [
+          "/opt/memtx/myapp-stateboard/00000000000000000049.snap",
+          "/opt/conf.d/myapp-stateboard.yml"
+      ],
+      "backup_archive_path": "/opt/tarantool/backups/myapp-stateboard.2021-07-09-133438.tar.gz",
+      "fetched_backup_archive_path": "/path/to/playbook/my_backups/myapp-stateboard.2021-07-09-133438.tar.gz"
+  }
+  ```
 
-...
-```
+- instance-1:
+
+  ```json
+  {
+      "instance_backup_files": [
+          "/opt/memtx/myapp.instance-1/00000000000000000008.snap",
+          "/opt/vinyl/myapp.instance-1/00000000000000000000.vylog",
+          "/opt/data/myapp.instance-1/config",
+          "/opt/conf.d/myapp.instance-1.yml",
+          "/opt/conf.d/myapp.yml"
+      ],
+      "backup_archive_path": "/opt/tarantool/backups/myapp.instance-1.2021-07-09-133438.tar.gz",
+      "fetched_backup_archive_path": "/path/to/playbook/my_backups/myapp.instance-1.2021-07-09-133438.tar.gz"
+  }
+  ```
+
+- ...
 
 ### Using `backup_start` and `backup_stop`
 
@@ -132,7 +183,7 @@ Let's imagine that we want to archive backup files not for each instance, but fo
   tasks:
     - name: 'Create backups dir'
       file:
-        path: '/opt/backups'
+        path: '/opt/tarantool/backups'
         owner: '{{ cartridge_app_user }}'
         group: '{{ cartridge_app_group }}'
         state: directory
@@ -147,7 +198,7 @@ Let's imagine that we want to archive backup files not for each instance, but fo
 
     - name: 'Create archives with backups by machines'
       archive:
-        dest: /opt/backups/{{ cartridge_app_name }}.{{ ansible_host }}.tar.gz
+        dest: /opt/tarantool/backups/{{ cartridge_app_name }}.{{ ansible_host }}.tar.gz
         path: '{{ backup_files_from_machine }}'
       when: inventory_hostname in single_instances_for_each_machine
 
@@ -162,7 +213,7 @@ Let's imagine that we want to archive backup files not for each instance, but fo
 I will produce such archives:
 
 ```
-[root@vm1 /]# tar -ztf /opt/backups/myapp.vm1.tar.gz
+[root@vm1 /]# tar -ztf /opt/tarantool/backups/myapp.vm1.tar.gz
 memtx/myapp.instance-1/00000000000000000004.snap
 data/myapp.instance-1/config/auth.yml
 data/myapp.instance-1/config/vshard_groups.yml
@@ -172,11 +223,90 @@ conf.d/myapp.yml
 memtx/myapp-stateboard/00000000000000000049.snap
 conf.d/myapp-stateboard.yml
 
-[root@vm2 /]# tar -ztf /opt/backups/myapp.vm2.tar.gz
+[root@vm2 /]# tar -ztf /opt/tarantool/backups/myapp.vm2.tar.gz
 memtx/myapp.instance-2/00000000000000000004.snap
 data/myapp.instance-2/config/auth.yml
 data/myapp.instance-2/config/vshard_groups.yml
 data/myapp.instance-2/config/topology.yml
 conf.d/myapp.instance-2.yml
 conf.d/myapp.yml
+```
+
+### Using `restore` step
+
+If you want to restore an instance from the latest TGZ backup
+from `cartridge_remote_backups_dir`, just run restore step:
+
+```yaml
+- name: 'Restore instance-1 from latest backup'
+  hosts: instance-1
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Restore'
+      import_role:
+        name: tarantool.cartridge
+      vars:
+        cartridge_scenario:
+          - restore
+```
+
+You can select backup manually by `cartridge_restore_backup_path` variable:
+
+```yaml
+- name: 'Restore instance-1 from selected backup'
+  hosts: instance-1
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Restore'
+      import_role:
+        name: tarantool.cartridge
+      vars:
+        cartridge_restore_backup_path: '/opt/tarantool/backups/myapp.instance-1.2021-07-09-133438/'
+        cartridge_scenario:
+          - restore
+```
+
+By default, only `.tarantool.cookie` will be kept in working directory.
+If you want to keep some more files, you can put in `cartridge_paths_to_keep_on_restore`
+variable some bash patterns:
+
+```yaml
+- name: 'Restore instance-1, but keep clusterwide config and logs'
+  hosts: instance-1
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Restore'
+      import_role:
+        name: tarantool.cartridge
+      vars:
+        cartridge_paths_to_keep_on_restore:
+          - 'config'
+          - '*.log'
+        cartridge_scenario:
+          - restore
+```
+
+If application config was changed, but you want to replace it with config
+from backup, you should set `cartridge_force_restore` flag.
+
+```yaml
+- name: 'Restore instance-1 with application config replacement'
+  hosts: instance-1
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Restore'
+      import_role:
+        name: tarantool.cartridge
+      vars:
+        cartridge_force_restore: true
+        cartridge_scenario:
+          - restore
 ```

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -577,18 +577,19 @@ Stop started [backup](/doc/backups.md) on the instance.
 
 ### Step `restore`
 
-Restore each instance from a [backup](#step-backup) archive.
+[Restore](/doc/backups.md#how-to-restore-from-saved-backup) each instance from a [backup](#step-backup) archive.
 
 Input variables from config:
 
-- `cartridge_paths_to_keep_on_restore` - list of full paths or relative paths
+- `cartridge_paths_to_keep_before_restore` - list of full paths or relative paths
   to work/memtx/vinyl/wal directory that should be kept on instance restore
   (`.tarantool.cookie` will be kept independently of this variable);
   it's possible to use bash patterns, e.g. `*.control`.
 - `cartridge_restore_backup_path` - path to the instance backup archive on the remote machine;
 - `cartridge_remote_backups_dir` - directory with backups on the remote;
 - `cartridge_force_restore` - flag indicates that conflicting files should be overwritten;
-- `cartridge_ignore_alien_backup` - flag indicates that backup of instance with another name can be used.
+- `cartridge_allow_alien_backup` - flag indicates that backup of instance with another name can be used;
+- `cartridge_skip_cleanup_on_restore` - flag indicates that cleanup before restoring should be skipped.
 
 ## Step `check_new_topology`
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -533,8 +533,8 @@ If instance is running, an error will be returned.
 
 Input variables from config:
 
-- `cartridge_paths_to_keep_on_cleanup` - list of full paths or relative paths
-  to work/memtx/vinyl/wal directory that should be kept on instance cleanup
+- `cartridge_paths_to_keep_on_cleanup` - list of paths that are absolute or relative
+  to `work/memtx/vinyl/wal` directory that should be kept on instance cleanup
   (`config` and `.tarantool.cookie` will be kept independently of this variable);
   it's possible to use bash patterns, e.g. `*.control`.
 
@@ -581,8 +581,8 @@ Stop started [backup](/doc/backups.md) on the instance.
 
 Input variables from config:
 
-- `cartridge_paths_to_keep_before_restore` - list of full paths or relative paths
-  to work/memtx/vinyl/wal directory that should be kept on instance restore
+- `cartridge_paths_to_keep_before_restore` - list of paths that are absolute or relative
+  to `work/memtx/vinyl/wal` directory that shouldn't be removed before instance restore
   (`.tarantool.cookie` will be kept independently of this variable);
   it's possible to use bash patterns, e.g. `*.control`.
 - `cartridge_restore_backup_path` - path to the instance backup archive on the remote machine;

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -535,7 +535,8 @@ Input variables from config:
 
 - `cartridge_paths_to_keep_on_cleanup` - list of full paths or relative paths
   to work/memtx/vinyl/wal directory that should be kept on instance cleanup
-  (it's possible to use bash patterns, e.g. `*.control`).
+  (`config` and `.tarantool.cookie` will be kept independently of this variable);
+  it's possible to use bash patterns, e.g. `*.control`.
 
 ### Step `backup`
 
@@ -580,9 +581,14 @@ Restore each instance from a [backup](#step-backup) archive.
 
 Input variables from config:
 
-- `cartridge_restore_archive_path` - path to the instance backup archive on the remote machine;
+- `cartridge_paths_to_keep_on_restore` - list of full paths or relative paths
+  to work/memtx/vinyl/wal directory that should be kept on instance restore
+  (`.tarantool.cookie` will be kept independently of this variable);
+  it's possible to use bash patterns, e.g. `*.control`.
+- `cartridge_restore_backup_path` - path to the instance backup archive on the remote machine;
 - `cartridge_remote_backups_dir` - directory with backups on the remote;
-- `cartridge_force_restore` -  flag indicates that conflicting files should be overwritten.
+- `cartridge_force_restore` - flag indicates that conflicting files should be overwritten;
+- `cartridge_ignore_alien_backup` - flag indicates that backup of instance with another name can be used.
 
 ## Step `check_new_topology`
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -43,6 +43,7 @@ but can be used in a custom one:
 - [backup](#step-backup)
 - [backup_start](#step-backup_start)
 - [backup_stop](#step-backup_stop)
+- [restore](#step-restore)
 - [check_new_topology](#step-check_new_topology)
 
 ## Role Variables Descriptions
@@ -538,7 +539,7 @@ Input variables from config:
 
 ### Step `backup`
 
-Create a [backup](/doc/backup.md) archive for each instance and fetch it on the local machine.
+Create a [backup](/doc/backups.md) archive for each instance and fetch it on the local machine.
 
 Input variables from config:
 
@@ -558,7 +559,7 @@ Output facts:
 
 ### Step `backup_start`
 
-Start a [backup](/doc/backup.md) process on the instance.
+Start a [backup](/doc/backups.md) process on the instance.
 
 Input variables from config:
 
@@ -571,7 +572,17 @@ Output facts:
 
 ### Step `backup_stop`
 
-Stop started [backup](/doc/backup.md) on the instance.
+Stop started [backup](/doc/backups.md) on the instance.
+
+### Step `restore`
+
+Restore each instance from a [backup](#step-backup) archive.
+
+Input variables from config:
+
+- `cartridge_restore_archive_path` - path to the instance backup archive on the remote machine;
+- `cartridge_remote_backups_dir` - directory with backups on the remote;
+- `cartridge_force_restore` -  flag indicates that conflicting files should be overwritten.
 
 ## Step `check_new_topology`
 

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -15,8 +15,13 @@ failover.
 - `cartridge_ignore_split_brain` (`boolean`, default: `false`): flag indicates that detected split
   brain should be ignored on preparation stage;
 - `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, default: `[]`): list of full paths or
-  relative paths to work/memtx/vinyl/wal directory that should be kept on instance cleanup (it's
-  possible to use bash patterns, e.g. `*.control`).
+  relative paths to work/memtx/vinyl/wal directory that should be kept on instance cleanup (`config`
+  and` .tarantool.cookie` will be kept independently of this variable); it's possible to use bash
+  patterns, e.g. `*.control`;
+- `cartridge_paths_to_keep_on_restore` (`list-of-strings`, default: `[]`): list of full paths or
+  relative paths to work/memtx/vinyl/wal directory that should be kept on instance
+  restore (`.tarantool.cookie` will be kept independently of this variable); it's possible to use
+  bash patterns, e.g. `*.control`.
 
 ## Role scenario configuration
 
@@ -208,4 +213,6 @@ For more details see [scenario documentation](/doc/scenario.md).
 - `cartridge_restore_archive_path` (`string`): path to the instance backup archive on the remote
   machine;
 - `cartridge_force_restore` (`boolean`, default: `false`): flag indicates that conflicting files
-  should be overwritten.
+  should be overwritten;
+- `cartridge_ignore_alien_backup` (`boolean`, default: `false`): flag indicates that backup of
+  instance with another name can be used.

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -210,9 +210,11 @@ For more details see [scenario documentation](/doc/scenario.md).
   machine;
 - `cartridge_force_restore` (`boolean`, default: `false`): flag indicates that conflicting files
   should be overwritten;
-- `cartridge_ignore_alien_backup` (`boolean`, default: `false`): flag indicates that backup of
+- `cartridge_allow_alien_backup` (`boolean`, default: `false`): flag indicates that backup of
   instance with another name can be used;
-- `cartridge_paths_to_keep_on_restore` (`list-of-strings`, default: `[]`): list of full paths or
+- `cartridge_skip_cleanup_on_restore` (`boolean`, default: `false`): flag indicates that cleanup
+  before restoring should be skipped;
+- `cartridge_paths_to_keep_before_restore` (`list-of-strings`, default: `[]`): list of full paths or
   relative paths to work/memtx/vinyl/wal directory that should be kept on instance
   restore (`.tarantool.cookie` will be kept independently of this variable); it's possible to use
   bash patterns, e.g. `*.control`.

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -14,10 +14,10 @@ failover.
   of [`cleanup` step API](/doc/steps.md#step-cleanup));
 - `cartridge_ignore_split_brain` (`boolean`, default: `false`): flag indicates that detected split
   brain should be ignored on preparation stage;
-- `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, default: `[]`): list of full paths or
-  relative paths to work/memtx/vinyl/wal directory that should be kept on instance cleanup (`config`
-  and` .tarantool.cookie` will be kept independently of this variable); it's possible to use bash
-  patterns, e.g. `*.control`.
+- `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, default: `[]`): list of paths that are
+  absolute or relative to `work/memtx/vinyl/wal` directory that should be kept on instance
+  cleanup (`config` and` .tarantool.cookie` will be kept independently of this variable); it's
+  possible to use bash patterns, e.g. `*.control`.
 
 ## Role scenario configuration
 
@@ -214,7 +214,7 @@ For more details see [scenario documentation](/doc/scenario.md).
   instance with another name can be used;
 - `cartridge_skip_cleanup_on_restore` (`boolean`, default: `false`): flag indicates that cleanup
   before restoring should be skipped;
-- `cartridge_paths_to_keep_before_restore` (`list-of-strings`, default: `[]`): list of full paths or
-  relative paths to work/memtx/vinyl/wal directory that should be kept on instance
-  restore (`.tarantool.cookie` will be kept independently of this variable); it's possible to use
-  bash patterns, e.g. `*.control`.
+- `cartridge_paths_to_keep_before_restore` (`list-of-strings`, default: `[]`): list of paths that
+  are absolute or relative to `work/memtx/vinyl/wal` directory that shouldn't be removed before
+  instance restore (`.tarantool.cookie` will be kept independently of this variable); it's possible
+  to use bash patterns, e.g. `*.control`.

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -17,11 +17,7 @@ failover.
 - `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, default: `[]`): list of full paths or
   relative paths to work/memtx/vinyl/wal directory that should be kept on instance cleanup (`config`
   and` .tarantool.cookie` will be kept independently of this variable); it's possible to use bash
-  patterns, e.g. `*.control`;
-- `cartridge_paths_to_keep_on_restore` (`list-of-strings`, default: `[]`): list of full paths or
-  relative paths to work/memtx/vinyl/wal directory that should be kept on instance
-  restore (`.tarantool.cookie` will be kept independently of this variable); it's possible to use
-  bash patterns, e.g. `*.control`.
+  patterns, e.g. `*.control`.
 
 ## Role scenario configuration
 
@@ -210,9 +206,13 @@ For more details see [scenario documentation](/doc/scenario.md).
 - `cartridge_fetch_backups_dir` (`string`, default: `backups/`): a directory on the local machine
   where backups should be fetched if `cartridge_fetch_backups` is `true`; this path is relative to
   the playbook path.
-- `cartridge_restore_archive_path` (`string`): path to the instance backup archive on the remote
+- `cartridge_restore_backup_path` (`string`): path to the instance backup archive on the remote
   machine;
 - `cartridge_force_restore` (`boolean`, default: `false`): flag indicates that conflicting files
   should be overwritten;
 - `cartridge_ignore_alien_backup` (`boolean`, default: `false`): flag indicates that backup of
-  instance with another name can be used.
+  instance with another name can be used;
+- `cartridge_paths_to_keep_on_restore` (`list-of-strings`, default: `[]`): list of full paths or
+  relative paths to work/memtx/vinyl/wal directory that should be kept on instance
+  restore (`.tarantool.cookie` will be kept independently of this variable); it's possible to use
+  bash patterns, e.g. `*.control`.

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -203,5 +203,9 @@ For more details see [scenario documentation](/doc/scenario.md).
 - `cartridge_fetch_backups` (`boolean`, default: `false`): flag indicates that backups should be
   fetched on the local machine;
 - `cartridge_fetch_backups_dir` (`string`, default: `backups/`): a directory on the local machine
-  where backups should be fetched if `cartridge_fetch_backups` is `true`. This path is relative to
+  where backups should be fetched if `cartridge_fetch_backups` is `true`; this path is relative to
   the playbook path.
+- `cartridge_restore_archive_path` (`string`): path to the instance backup archive on the remote
+  machine;
+- `cartridge_force_restore` (`boolean`, default: `false`): flag indicates that conflicting files
+  should be overwritten.

--- a/library/cartridge_backup_instance.py
+++ b/library/cartridge_backup_instance.py
@@ -44,11 +44,17 @@ def backup_start(control_console, params):
 
         if not is_stateboard then
             local work_dir = confapplier.get_workdir()
-            local config_names = {'config', 'config.backup', 'config.yml', 'config.backup.yml'}
-            for _, config_name in ipairs(config_names) do
-                local config_path = fio.pathjoin(work_dir, config_name)
-                if fio.path.exists(config_path) then
-                    table.insert(paths, config_path)
+            local work_dir_files = {
+                'config',
+                'config.backup',
+                'config.yml',
+                'config.backup.yml',
+                '.tarantool.cookie',
+            }
+            for _, work_dir_file in ipairs(work_dir_files) do
+                local work_dir_file_path = fio.pathjoin(work_dir, work_dir_file)
+                if fio.path.exists(work_dir_file_path) then
+                    table.insert(paths, work_dir_file_path)
                 end
             end
         end
@@ -102,9 +108,6 @@ def call_backup(params):
 
     if not helpers.box_cfg_was_called(control_console):
         return helpers.ModuleRes(failed=True, msg="box.cfg wasn't called yet")
-
-    backup_files = None
-    backup_archive_path = None
 
     # STOP ONLY
     if stop_only:

--- a/library/cartridge_backup_instance.py
+++ b/library/cartridge_backup_instance.py
@@ -1,6 +1,6 @@
-import time
-import tarfile
 import os
+import tarfile
+import time
 
 from ansible.module_utils.helpers import Helpers as helpers
 
@@ -95,7 +95,7 @@ def call_backup(params):
     start_only = params['start_only']
     stop_only = params['stop_only']
 
-    assert not(start_only and stop_only), "impossible to use 'start_only' with 'stop_only'"
+    assert not (start_only and stop_only), "impossible to use 'start_only' with 'stop_only'"
 
     console_sock = params['console_sock']
     control_console = helpers.get_control_console(console_sock)

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -94,6 +94,8 @@ FACTS_BY_TARGETS = {
         'cartridge_remote_backups_dir',
         'cartridge_fetch_backups',
         'cartridge_fetch_backups_dir',
+        'cartridge_restore_archive_path',
+        'cartridge_force_restore',
     ],
     'count_disabled_instances': [
         'instance_info',

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -47,7 +47,7 @@ FACTS_BY_TARGETS = {
         'cartridge_remove_temporary_files',
         'cartridge_ignore_split_brain',
         'cartridge_paths_to_keep_on_cleanup',
-        'cartridge_paths_to_keep_on_restore',
+        'cartridge_paths_to_keep_before_restore',
         'cartridge_run_dir',
         'cartridge_scenario',
         'cartridge_scenario_name',
@@ -97,7 +97,8 @@ FACTS_BY_TARGETS = {
         'cartridge_fetch_backups_dir',
         'cartridge_restore_backup_path',
         'cartridge_force_restore',
-        'cartridge_ignore_alien_backup',
+        'cartridge_allow_alien_backup',
+        'cartridge_skip_cleanup_on_restore',
     ],
     'count_disabled_instances': [
         'instance_info',

--- a/library/cartridge_get_cached_facts.py
+++ b/library/cartridge_get_cached_facts.py
@@ -47,6 +47,7 @@ FACTS_BY_TARGETS = {
         'cartridge_remove_temporary_files',
         'cartridge_ignore_split_brain',
         'cartridge_paths_to_keep_on_cleanup',
+        'cartridge_paths_to_keep_on_restore',
         'cartridge_run_dir',
         'cartridge_scenario',
         'cartridge_scenario_name',
@@ -94,8 +95,9 @@ FACTS_BY_TARGETS = {
         'cartridge_remote_backups_dir',
         'cartridge_fetch_backups',
         'cartridge_fetch_backups_dir',
-        'cartridge_restore_archive_path',
+        'cartridge_restore_backup_path',
         'cartridge_force_restore',
+        'cartridge_ignore_alien_backup',
     ],
     'count_disabled_instances': [
         'instance_info',

--- a/library/cartridge_get_instance_info.py
+++ b/library/cartridge_get_instance_info.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import fnmatch
 import os
 
 from ansible.module_utils.helpers import Helpers as helpers
@@ -56,19 +55,10 @@ def get_multiversion_dist_dir(install_dir, package_path):
     return os.path.join(install_dir, package_name_version)
 
 
-def filter_paths_by_glob_list(paths_list, regex_list):
+def filter_paths_by_glob_list(paths_list, glob_list):
     new_list = []
     for path in paths_list:
-        should_kept = False
-        for path_to_keep in regex_list:
-            norm_path = os.path.normpath(path)
-            base_name = os.path.basename(path)
-
-            if fnmatch.fnmatch(norm_path, path_to_keep) or fnmatch.fnmatch(base_name, path_to_keep):
-                should_kept = True
-                break
-
-        if not should_kept:
+        if not helpers.glob_list_match(path, glob_list):
             new_list.append(path)
 
     return new_list

--- a/library/cartridge_restore_instance.py
+++ b/library/cartridge_restore_instance.py
@@ -1,16 +1,51 @@
+import grp
+import hashlib
 import os
+import pwd
 import shutil
 import tarfile
 
 from ansible.module_utils.helpers import Helpers as helpers
 
 argument_spec = {
-    'console_sock': {'required': True, 'type': 'str'},
-    'restore_archive_path': {'required': False, 'type': 'str'},
+    'instance_info': {'required': True, 'type': 'dict'},
+    'app_user': {'required': True, 'type': 'str'},
+    'app_group': {'required': True, 'type': 'str'},
+    'paths_to_keep_on_restore': {'required': False, 'type': 'list', 'default': []},
+    'restore_backup_path': {'required': False, 'type': 'str'},
     'remote_backups_dir': {'required': False, 'type': 'str'},
-    'instance_id': {'required': False, 'type': 'str'},
-    'force_restore': {'required': False, 'type': 'bool', 'default': True},
+    'force_restore': {'required': False, 'type': 'bool', 'default': False},
+    'ignore_alien_backups': {'required': False, 'type': 'bool', 'default': False},
 }
+
+
+###########
+# Helpers #
+###########
+
+def make_dirs(path, uid, gid, mode=0o755):
+    if os.path.exists(path):
+        return
+
+    path = path.rstrip(os.path.sep)
+
+    head, tail = os.path.split(path)
+    if not tail:
+        head, tail = os.path.split(head)
+
+    if head and tail:
+        make_dirs(head, uid, gid, mode)
+
+    os.mkdir(path, mode)
+    os.chown(path, uid, gid)
+
+
+def md5(fd):
+    hash_md5 = hashlib.md5()
+    for chunk in iter(lambda: fd.read(4096), b""):
+        hash_md5.update(chunk)
+    fd.close()
+    return hash_md5.hexdigest()
 
 
 #############################
@@ -18,37 +53,66 @@ argument_spec = {
 #############################
 
 
-def get_tgz_conflicting_files(archive_path):
-    with tarfile.open(archive_path, 'r:gz') as tar:
-        conflicting_files = []
+def is_path_to_remove(path, paths_to_remove, paths_to_keep):
+    if helpers.glob_list_match(path, paths_to_keep):
+        return False
 
+    for path_to_remove in paths_to_remove:
+        if path.startswith(path_to_remove):
+            return True
+
+    return False
+
+
+def get_tgz_conflicting_files(backup_path, ignore_func, instance_id):
+    conflicting_files = []
+    is_backup_of_correct_instance = False
+
+    with tarfile.open(backup_path, 'r:gz') as tar:
         for src_member in tar.getmembers():
             full_dst = os.path.join('/', src_member.name)
+
+            if instance_id in full_dst:
+                is_backup_of_correct_instance = True
 
             if src_member.isdir() or not os.path.exists(full_dst):
                 continue
 
-            if os.stat(full_dst).st_size != src_member.size:
+            if ignore_func(full_dst):
+                continue
+
+            src_md5 = md5(tar.extractfile(src_member))
+            dst_md5 = md5(open(full_dst, "rb"))
+            if src_md5 != dst_md5:
                 conflicting_files.append(full_dst)
 
-    return conflicting_files
+    return conflicting_files, is_backup_of_correct_instance
 
 
-def get_folder_conflicting_files(archive_path):
+def get_folder_conflicting_files(backup_path, ignore_func, instance_id):
     conflicting_files = []
+    is_backup_of_correct_instance = False
 
-    for root, _, files in os.walk(archive_path):
+    for root, _, files in os.walk(backup_path):
         for src in files:
             full_src = os.path.join(root, src)
-            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+            full_dst = os.path.join('/', os.path.relpath(full_src, backup_path))
+
+            if instance_id in full_dst:
+                is_backup_of_correct_instance = True
 
             if not os.path.exists(full_dst):
                 continue
 
-            if os.stat(full_src).st_size != os.stat(full_dst).st_size:
+            if ignore_func(full_dst):
+                continue
+
+            src_md5 = md5(open(full_src, "rb"))
+            dst_md5 = md5(open(full_dst, "rb"))
+            if src_md5 != dst_md5:
                 conflicting_files.append(full_dst)
 
-    return conflicting_files
+    return conflicting_files, is_backup_of_correct_instance
 
 
 ####################
@@ -56,27 +120,32 @@ def get_folder_conflicting_files(archive_path):
 ####################
 
 
-def unpack_tgz(archive_path):
-    with tarfile.open(archive_path, 'r:gz') as tar:
+def unpack_tgz(backup_path, uid, gid):
+    with tarfile.open(backup_path, 'r:gz') as tar:
+        for src_member in tar.getmembers():
+            dir_path = os.path.dirname(os.path.join('/', src_member.name))
+            make_dirs(dir_path, uid, gid)
+
         tar.extractall('/')
 
     return True, None
 
 
-def move_files(archive_path):
-    for root, dirs, files in os.walk(archive_path):
+def move_files(backup_path, uid, gid):
+    for root, dirs, files in os.walk(backup_path):
         for src in dirs:
             full_src = os.path.join(root, src)
-            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+            full_dst = os.path.join('/', os.path.relpath(full_src, backup_path))
 
             if os.path.exists(full_dst):
                 continue
 
-            os.makedirs(full_dst, os.stat(full_src).st_mode)
+            src_stat = os.stat(full_src)
+            make_dirs(full_dst, uid, gid, src_stat.st_mode)
 
         for src in files:
             full_src = os.path.join(root, src)
-            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+            full_dst = os.path.join('/', os.path.relpath(full_src, backup_path))
 
             if os.path.exists(full_dst):
                 os.remove(full_dst)
@@ -86,6 +155,8 @@ def move_files(archive_path):
             else:
                 shutil.copy(full_src, full_dst)
 
+            os.chown(full_dst, uid, gid)
+
     return True, None
 
 
@@ -94,20 +165,20 @@ def move_files(archive_path):
 ####################
 
 
-def get_archive_path(restore_archive_path, remote_backups_dir, instance_id):
-    if restore_archive_path:
-        if not os.path.exists(restore_archive_path):
+def get_backup_path(restore_backup_path, remote_backups_dir, instance_id):
+    if restore_backup_path:
+        if not os.path.exists(restore_backup_path):
             return None, (
                 "Backup '%s' not found. "
-                "Specify another path to backup (by 'cartridge_restore_archive_path') or "
-                "keep empty to find backup in folder with backups." % restore_archive_path
+                "Specify another path to backup (by 'cartridge_restore_backup_path') or "
+                "keep empty to find backup in folder with backups." % restore_backup_path
             )
-        return restore_archive_path, None
+        return restore_backup_path, None
 
     if not os.path.exists(remote_backups_dir):
         return None, (
             "Folder with backups (%s) not found."
-            "Specify path to backup (by 'cartridge_restore_archive_path') or "
+            "Specify path to backup (by 'cartridge_restore_backup_path') or "
             "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
         )
 
@@ -123,52 +194,104 @@ def get_archive_path(restore_archive_path, remote_backups_dir, instance_id):
 
     return None, (
         "Impossible to find backup of current instance in folder with backups (%s). "
-        "Specify path to backup (by 'cartridge_restore_archive_path') or "
+        "Specify path to backup (by 'cartridge_restore_backup_path') or "
         "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
     )
 
 
-def get_specific_format_funcs(archive_path):
-    if os.path.isdir(archive_path):
+def get_specific_format_funcs(backup_path):
+    if os.path.isdir(backup_path):
         return get_folder_conflicting_files, move_files, None
-    elif archive_path.endswith('.tar.gz'):
+    elif backup_path.endswith('.tar.gz'):
         return get_tgz_conflicting_files, unpack_tgz, None
 
     return None, None, 'Unknown format of backup, supported formats: TGZ, folder.'
 
 
-def restore_archive(archive_path, force_restore):
-    get_conflicting_files_func, unpack_func, err = get_specific_format_funcs(archive_path)
+def cleanup_files(paths_to_remove, paths_to_keep):
+    for path_to_remove in paths_to_remove:
+        if not os.path.exists(path_to_remove) or helpers.glob_list_match(path_to_remove, paths_to_keep):
+            continue
+
+        if os.path.isdir(path_to_remove):
+            shutil.rmtree(path_to_remove)
+        else:
+            os.remove(path_to_remove)
+
+
+def restore_archive(
+    backup_path,
+    instance_id,
+    paths_to_remove,
+    paths_to_keep,
+    force_restore,
+    ignore_alien_backups,
+    app_user,
+    app_group,
+):
+    paths_to_keep = paths_to_keep + ['.tarantool.cookie']
+
+    get_conflicting_files_func, unpack_func, err = get_specific_format_funcs(backup_path)
     if err:
         return None, err
 
-    conflicting_files = get_conflicting_files_func(archive_path)
+    conflicting_files, is_backup_of_correct_instance = get_conflicting_files_func(
+        backup_path,
+        lambda path: is_path_to_remove(path, paths_to_remove, paths_to_keep),
+        instance_id,
+    )
+
+    if not is_backup_of_correct_instance:
+        msg = "Seems that selected backup of another instance. "
+        if ignore_alien_backups:
+            msg += "This error ignored, because the 'cartridge_ignore_alien_backups' flag is set."
+            helpers.warn(msg)
+        else:
+            msg += "If you are sure that this backup is correct, set 'cartridge_ignore_alien_backups' flag."
+            return None, msg
+
     if conflicting_files:
-        msg = "Some files already exist and have a different size than in the archive: %s. "
+        msg = "Some files already exist and have a different md5 sum than in the backup: %s. "
         msg %= ', '.join(conflicting_files)
         if force_restore:
-            msg += "They have been overwritten."
+            msg += "They have been overwritten, because the 'cartridge_force_restore' flag is set."
             helpers.warn(msg)
         else:
             msg += "Remove them or set 'cartridge_force_restore' flag to overwrite."
             return None, msg
 
-    return unpack_func(archive_path)
+    cleanup_files(paths_to_remove, paths_to_keep)
+
+    uid = pwd.getpwnam(app_user).pw_uid
+    gid = grp.getgrnam(app_group).gr_gid
+
+    return unpack_func(backup_path, uid, gid)
 
 
 def call_restore(params):
-    if helpers.is_instance_running(params['console_sock']):
+    instance_info = params['instance_info']
+
+    if helpers.is_instance_running(instance_info['console_sock']):
         return helpers.ModuleRes(failed=True, msg="instance shouldn't be running")
 
-    archive_path, err = get_archive_path(
-        params['restore_archive_path'],
+    backup_path, err = get_backup_path(
+        params['restore_backup_path'],
         params['remote_backups_dir'],
-        params['instance_id'],
+        instance_info['instance_id'],
     )
     if err:
         return helpers.ModuleRes(failed=True, msg=err)
 
-    changed, err = restore_archive(archive_path, params['force_restore'])
+    changed, err = restore_archive(
+        backup_path,
+        instance_info['instance_id'],
+        instance_info['paths_to_remove_on_expel'],
+        params['paths_to_keep_on_restore'],
+        params['force_restore'],
+        params['ignore_alien_backups'],
+        params['app_user'],
+        params['app_group'],
+    )
     if err:
         return helpers.ModuleRes(failed=True, msg=err)
 

--- a/library/cartridge_restore_instance.py
+++ b/library/cartridge_restore_instance.py
@@ -1,0 +1,179 @@
+import os
+import shutil
+import tarfile
+
+from ansible.module_utils.helpers import Helpers as helpers
+
+argument_spec = {
+    'console_sock': {'required': True, 'type': 'str'},
+    'restore_archive_path': {'required': False, 'type': 'str'},
+    'remote_backups_dir': {'required': False, 'type': 'str'},
+    'instance_id': {'required': False, 'type': 'str'},
+    'force_restore': {'required': False, 'type': 'bool', 'default': True},
+}
+
+
+#############################
+# Conflicting files getters #
+#############################
+
+
+def get_tgz_conflicting_files(archive_path):
+    with tarfile.open(archive_path, 'r:gz') as tar:
+        conflicting_files = []
+
+        for src_member in tar.getmembers():
+            full_dst = os.path.join('/', src_member.name)
+
+            if src_member.isdir() or not os.path.exists(full_dst):
+                continue
+
+            if os.stat(full_dst).st_size != src_member.size:
+                conflicting_files.append(full_dst)
+
+    return conflicting_files
+
+
+def get_folder_conflicting_files(archive_path):
+    conflicting_files = []
+
+    for root, _, files in os.walk(archive_path):
+        for src in files:
+            full_src = os.path.join(root, src)
+            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+
+            if not os.path.exists(full_dst):
+                continue
+
+            if os.stat(full_src).st_size != os.stat(full_dst).st_size:
+                conflicting_files.append(full_dst)
+
+    return conflicting_files
+
+
+####################
+# Unpack functions #
+####################
+
+
+def unpack_tgz(archive_path):
+    with tarfile.open(archive_path, 'r:gz') as tar:
+        tar.extractall('/')
+
+    return True, None
+
+
+def move_files(archive_path):
+    for root, dirs, files in os.walk(archive_path):
+        for src in dirs:
+            full_src = os.path.join(root, src)
+            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+
+            if os.path.exists(full_dst):
+                continue
+
+            os.makedirs(full_dst, os.stat(full_src).st_mode)
+
+        for src in files:
+            full_src = os.path.join(root, src)
+            full_dst = os.path.join('/', os.path.relpath(full_src, archive_path))
+
+            if os.path.exists(full_dst):
+                os.remove(full_dst)
+
+            if os.path.islink(full_src):
+                os.symlink(os.readlink(full_src), full_dst)
+            else:
+                shutil.copy(full_src, full_dst)
+
+    return True, None
+
+
+####################
+# Common functions #
+####################
+
+
+def get_archive_path(restore_archive_path, remote_backups_dir, instance_id):
+    if restore_archive_path:
+        if not os.path.exists(restore_archive_path):
+            return None, (
+                "Backup '%s' not found. "
+                "Specify another path to backup (by 'cartridge_restore_archive_path') or "
+                "keep empty to find backup in folder with backups." % restore_archive_path
+            )
+        return restore_archive_path, None
+
+    if not os.path.exists(remote_backups_dir):
+        return None, (
+            "Folder with backups (%s) not found."
+            "Specify path to backup (by 'cartridge_restore_archive_path') or "
+            "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
+        )
+
+    for path in sorted(os.listdir(remote_backups_dir), reverse=True):
+        full_path = os.path.join(remote_backups_dir, path)
+
+        if not os.path.isfile(full_path):
+            continue
+
+        if instance_id in full_path:
+            helpers.warn("Backup '%s' was selected from folder with backups to restore instance" % full_path)
+            return full_path, None
+
+    return None, (
+        "Impossible to find backup of current instance in folder with backups (%s). "
+        "Specify path to backup (by 'cartridge_restore_archive_path') or "
+        "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
+    )
+
+
+def get_specific_format_funcs(archive_path):
+    if os.path.isdir(archive_path):
+        return get_folder_conflicting_files, move_files, None
+    elif archive_path.endswith('.tar.gz'):
+        return get_tgz_conflicting_files, unpack_tgz, None
+
+    return None, None, 'Unknown format of backup, supported formats: TGZ, folder.'
+
+
+def restore_archive(archive_path, force_restore):
+    get_conflicting_files_func, unpack_func, err = get_specific_format_funcs(archive_path)
+    if err:
+        return None, err
+
+    conflicting_files = get_conflicting_files_func(archive_path)
+    if conflicting_files:
+        msg = "Some files already exist and have a different size than in the archive: %s. "
+        msg %= ', '.join(conflicting_files)
+        if force_restore:
+            msg += "They have been overwritten."
+            helpers.warn(msg)
+        else:
+            msg += "Remove them or set 'cartridge_force_restore' flag to overwrite."
+            return None, msg
+
+    return unpack_func(archive_path)
+
+
+def call_restore(params):
+    if helpers.is_instance_running(params['console_sock']):
+        return helpers.ModuleRes(failed=True, msg="instance shouldn't be running")
+
+    archive_path, err = get_archive_path(
+        params['restore_archive_path'],
+        params['remote_backups_dir'],
+        params['instance_id'],
+    )
+    if err:
+        return helpers.ModuleRes(failed=True, msg=err)
+
+    changed, err = restore_archive(archive_path, params['force_restore'])
+    if err:
+        return helpers.ModuleRes(failed=True, msg=err)
+
+    return helpers.ModuleRes(changed=changed)
+
+
+if __name__ == '__main__':
+    helpers.execute_module(argument_spec, call_restore)

--- a/library/cartridge_restore_instance.py
+++ b/library/cartridge_restore_instance.py
@@ -2,6 +2,7 @@ import grp
 import hashlib
 import os
 import pwd
+import re
 import shutil
 import tarfile
 
@@ -11,11 +12,12 @@ argument_spec = {
     'instance_info': {'required': True, 'type': 'dict'},
     'app_user': {'required': True, 'type': 'str'},
     'app_group': {'required': True, 'type': 'str'},
-    'paths_to_keep_on_restore': {'required': False, 'type': 'list', 'default': []},
+    'paths_to_keep_before_restore': {'required': False, 'type': 'list', 'default': []},
     'restore_backup_path': {'required': False, 'type': 'str'},
     'remote_backups_dir': {'required': False, 'type': 'str'},
     'force_restore': {'required': False, 'type': 'bool', 'default': False},
-    'ignore_alien_backups': {'required': False, 'type': 'bool', 'default': False},
+    'allow_alien_backups': {'required': False, 'type': 'bool', 'default': False},
+    'skip_cleanup_on_restore': {'required': False, 'type': 'bool', 'default': False},
 }
 
 
@@ -40,7 +42,7 @@ def make_dirs(path, uid, gid, mode=0o755):
     os.chown(path, uid, gid)
 
 
-def md5(fd):
+def md5_buffer(fd):
     hash_md5 = hashlib.md5()
     for chunk in iter(lambda: fd.read(4096), b""):
         hash_md5.update(chunk)
@@ -48,12 +50,30 @@ def md5(fd):
     return hash_md5.hexdigest()
 
 
+def is_path_of_instance(path, instance_id):
+    # Expected one of variant:
+    # /opt/backups/myapp.i-1.tar.gz
+    # /opt/backups/myapp.i-1.2020-01-01.tar.gz
+    # /opt/backups/myapp.i-1.2020-01-01-010101.tar.gz
+    # /opt/backups/myapp.i-1.1627650508.tar.gz
+    # /opt/backups/backup.myapp.i-1.tar.gz
+    # /opt/backups/myapp.i-1/
+    # ...
+    instance_id = instance_id.replace(".", r"\.")
+    path = path.strip(os.path.sep)
+    m = re.search(r'%s(\W(\d{4}\W\d{2}\W\d{2}(\W\d{6})?|\d{6,}))?(.tar.gz|/|$)' % instance_id, path, re.I | re.U)
+    return m is not None
+
+
 #############################
 # Conflicting files getters #
 #############################
 
 
-def is_path_to_remove(path, paths_to_remove, paths_to_keep):
+def is_path_to_remove(path, paths_to_remove, paths_to_keep, skip_cleanup_on_restore):
+    if skip_cleanup_on_restore:
+        return False
+
     if helpers.glob_list_match(path, paths_to_keep):
         return False
 
@@ -72,7 +92,7 @@ def get_tgz_conflicting_files(backup_path, ignore_func, instance_id):
         for src_member in tar.getmembers():
             full_dst = os.path.join('/', src_member.name)
 
-            if instance_id in full_dst:
+            if is_path_of_instance(full_dst, instance_id):
                 is_backup_of_correct_instance = True
 
             if src_member.isdir() or not os.path.exists(full_dst):
@@ -81,15 +101,15 @@ def get_tgz_conflicting_files(backup_path, ignore_func, instance_id):
             if ignore_func(full_dst):
                 continue
 
-            src_md5 = md5(tar.extractfile(src_member))
-            dst_md5 = md5(open(full_dst, "rb"))
+            src_md5 = md5_buffer(tar.extractfile(src_member))
+            dst_md5 = md5_buffer(open(full_dst, "rb"))
             if src_md5 != dst_md5:
                 conflicting_files.append(full_dst)
 
     return conflicting_files, is_backup_of_correct_instance
 
 
-def get_folder_conflicting_files(backup_path, ignore_func, instance_id):
+def get_dir_conflicting_files(backup_path, ignore_func, instance_id):
     conflicting_files = []
     is_backup_of_correct_instance = False
 
@@ -98,7 +118,7 @@ def get_folder_conflicting_files(backup_path, ignore_func, instance_id):
             full_src = os.path.join(root, src)
             full_dst = os.path.join('/', os.path.relpath(full_src, backup_path))
 
-            if instance_id in full_dst:
+            if is_path_of_instance(full_dst, instance_id):
                 is_backup_of_correct_instance = True
 
             if not os.path.exists(full_dst):
@@ -107,8 +127,8 @@ def get_folder_conflicting_files(backup_path, ignore_func, instance_id):
             if ignore_func(full_dst):
                 continue
 
-            src_md5 = md5(open(full_src, "rb"))
-            dst_md5 = md5(open(full_dst, "rb"))
+            src_md5 = md5_buffer(open(full_src, "rb"))
+            dst_md5 = md5_buffer(open(full_dst, "rb"))
             if src_md5 != dst_md5:
                 conflicting_files.append(full_dst)
 
@@ -171,15 +191,15 @@ def get_backup_path(restore_backup_path, remote_backups_dir, instance_id):
             return None, (
                 "Backup '%s' not found. "
                 "Specify another path to backup (by 'cartridge_restore_backup_path') or "
-                "keep empty to find backup in folder with backups." % restore_backup_path
+                "keep empty to find backup in directory with backups ('remote_backups_dir')." % restore_backup_path
             )
         return restore_backup_path, None
 
     if not os.path.exists(remote_backups_dir):
         return None, (
-            "Folder with backups (%s) not found."
+            "Directory with backups (%s) not found."
             "Specify path to backup (by 'cartridge_restore_backup_path') or "
-            "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
+            "another path to directory with backups (by 'remote_backups_dir')." % remote_backups_dir
         )
 
     for path in sorted(os.listdir(remote_backups_dir), reverse=True):
@@ -188,24 +208,24 @@ def get_backup_path(restore_backup_path, remote_backups_dir, instance_id):
         if not os.path.isfile(full_path):
             continue
 
-        if instance_id in full_path:
-            helpers.warn("Backup '%s' was selected from folder with backups to restore instance" % full_path)
+        if is_path_of_instance(full_path, instance_id):
+            helpers.warn("Backup '%s' from directory with backups is used to restore instance" % full_path)
             return full_path, None
 
     return None, (
-        "Impossible to find backup of current instance in folder with backups (%s). "
+        "Impossible to find backup of current instance in directory with backups (%s). "
         "Specify path to backup (by 'cartridge_restore_backup_path') or "
-        "another path to folder with backups (by 'remote_backups_dir')." % remote_backups_dir
+        "another path to directory with backups (by 'remote_backups_dir')." % remote_backups_dir
     )
 
 
 def get_specific_format_funcs(backup_path):
     if os.path.isdir(backup_path):
-        return get_folder_conflicting_files, move_files, None
+        return get_dir_conflicting_files, move_files, None
     elif backup_path.endswith('.tar.gz'):
         return get_tgz_conflicting_files, unpack_tgz, None
 
-    return None, None, 'Unknown format of backup, supported formats: TGZ, folder.'
+    return None, None, 'Unknown format of backup, supported formats: TGZ, directory.'
 
 
 def cleanup_files(paths_to_remove, paths_to_keep):
@@ -225,7 +245,8 @@ def restore_archive(
     paths_to_remove,
     paths_to_keep,
     force_restore,
-    ignore_alien_backups,
+    allow_alien_backups,
+    skip_cleanup_on_restore,
     app_user,
     app_group,
 ):
@@ -237,17 +258,17 @@ def restore_archive(
 
     conflicting_files, is_backup_of_correct_instance = get_conflicting_files_func(
         backup_path,
-        lambda path: is_path_to_remove(path, paths_to_remove, paths_to_keep),
+        lambda path: is_path_to_remove(path, paths_to_remove, paths_to_keep, skip_cleanup_on_restore),
         instance_id,
     )
 
     if not is_backup_of_correct_instance:
         msg = "Seems that selected backup of another instance. "
-        if ignore_alien_backups:
-            msg += "This error ignored, because the 'cartridge_ignore_alien_backups' flag is set."
+        if allow_alien_backups:
+            msg += "This error ignored, because the 'cartridge_allow_alien_backups' flag is set."
             helpers.warn(msg)
         else:
-            msg += "If you are sure that this backup is correct, set 'cartridge_ignore_alien_backups' flag."
+            msg += "If you are sure that this backup is correct, set 'cartridge_allow_alien_backups' flag."
             return None, msg
 
     if conflicting_files:
@@ -260,7 +281,8 @@ def restore_archive(
             msg += "Remove them or set 'cartridge_force_restore' flag to overwrite."
             return None, msg
 
-    cleanup_files(paths_to_remove, paths_to_keep)
+    if not skip_cleanup_on_restore:
+        cleanup_files(paths_to_remove, paths_to_keep)
 
     uid = pwd.getpwnam(app_user).pw_uid
     gid = grp.getgrnam(app_group).gr_gid
@@ -286,9 +308,10 @@ def call_restore(params):
         backup_path,
         instance_info['instance_id'],
         instance_info['paths_to_remove_on_expel'],
-        params['paths_to_keep_on_restore'],
+        params['paths_to_keep_before_restore'],
         params['force_restore'],
-        params['ignore_alien_backups'],
+        params['allow_alien_backups'],
+        params['skip_cleanup_on_restore'],
         params['app_user'],
         params['app_group'],
     )

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -157,6 +157,7 @@ SCHEMA = {
     'cartridge_remove_temporary_files': bool,
     'cartridge_ignore_split_brain': bool,
     'cartridge_paths_to_keep_on_cleanup': list,
+    'cartridge_paths_to_keep_on_restore': list,
     'zone': str,
     'cartridge_extra_env': dict,
     'cartridge_eval_body': str,
@@ -168,8 +169,9 @@ SCHEMA = {
     'cartridge_remote_backups_dir': str,
     'cartridge_fetch_backups': bool,
     'cartridge_fetch_backups_dir': str,
-    'cartridge_restore_archive_path': str,
+    'cartridge_restore_backup_path': str,
     'cartridge_force_restore': bool,
+    'cartridge_ignore_alien_backup': bool,
     'config': {
         'advertise_uri': str,
         'memtx_memory': int,

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -157,7 +157,7 @@ SCHEMA = {
     'cartridge_remove_temporary_files': bool,
     'cartridge_ignore_split_brain': bool,
     'cartridge_paths_to_keep_on_cleanup': list,
-    'cartridge_paths_to_keep_on_restore': list,
+    'cartridge_paths_to_keep_before_restore': list,
     'zone': str,
     'cartridge_extra_env': dict,
     'cartridge_eval_body': str,
@@ -171,7 +171,8 @@ SCHEMA = {
     'cartridge_fetch_backups_dir': str,
     'cartridge_restore_backup_path': str,
     'cartridge_force_restore': bool,
-    'cartridge_ignore_alien_backup': bool,
+    'cartridge_allow_alien_backup': bool,
+    'cartridge_skip_cleanup_on_restore': bool,
     'config': {
         'advertise_uri': str,
         'memtx_memory': int,

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -168,6 +168,8 @@ SCHEMA = {
     'cartridge_remote_backups_dir': str,
     'cartridge_fetch_backups': bool,
     'cartridge_fetch_backups_dir': str,
+    'cartridge_restore_archive_path': str,
+    'cartridge_force_restore': bool,
     'config': {
         'advertise_uri': str,
         'memtx_memory': int,

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import fnmatch
 import json
 import os
 import random
@@ -677,6 +677,17 @@ def get_topology_checksum(console_sock, stateboard):
     ''')
 
 
+def glob_list_match(path, glob_list):
+    for pattern in glob_list:
+        norm_path = os.path.normpath(path)
+        base_name = os.path.basename(path)
+
+        if fnmatch.fnmatch(norm_path, pattern) or fnmatch.fnmatch(base_name, pattern):
+            return True
+
+    return False
+
+
 class Helpers:
     DYNAMIC_BOX_CFG_PARAMS = DYNAMIC_BOX_CFG_PARAMS
     MEMORY_SIZE_BOX_CFG_PARAMS = MEMORY_SIZE_BOX_CFG_PARAMS
@@ -717,3 +728,4 @@ class Helpers:
     enrich_replicasets_with_leaders = staticmethod(enrich_replicasets_with_leaders)
     get_disabled_instances = staticmethod(get_disabled_instances)
     get_topology_checksum = staticmethod(get_topology_checksum)
+    glob_list_match = staticmethod(glob_list_match)

--- a/molecule/backup/converge.yml
+++ b/molecule/backup/converge.yml
@@ -20,7 +20,7 @@
   become_user: root
   gather_facts: false
   tasks:
-    - include_tasks: include/check_backup.yml
+    - import_tasks: include/check_backup.yml
 
     - name: Check that fetching archive was skipped
       assert:
@@ -40,7 +40,7 @@
   become_user: root
   gather_facts: false
   tasks:
-    - include_tasks: include/check_backup.yml
+    - import_tasks: include/check_backup.yml
       vars:
         cartridge_fetch_backups: true
 
@@ -64,9 +64,9 @@
   become_user: root
   gather_facts: false
   tasks:
-    - include_tasks: include/check_backup_start_stop.yml
+    - import_tasks: include/check_backup_start_stop.yml
 
-- name: 'Insert second tuple'
+- name: 'Insert second tuple and change clusterwide config'
   hosts: instance-2-joined
   become: true
   become_user: root
@@ -75,6 +75,16 @@
     cartridge_eval_body: |
       box.space.memtx_space:insert({54321})
       box.space.vinyl_space:insert({09876})
+
+      require('cartridge').config_patch_clusterwide({test='value'})
+
+      local tuples = box.space.memtx_space:select()
+      assert(#tuples == 2, "Space 'memtx_space' should contain two test tuples")
+
+      local tuples = box.space.vinyl_space:select()
+      assert(#tuples == 2, "Space 'vinyl_space' should contain two test tuples")
+
+      assert(require('cartridge').config_get_readonly().test ~= nil, "Section 'test' should exists")
     cartridge_scenario:
       - eval
   roles:
@@ -86,4 +96,89 @@
   become_user: root
   gather_facts: false
   tasks:
-    - include_tasks: include/check_restore.yml
+    - import_tasks: include/check_restore.yml
+
+- name: 'Change application config and cluster cookie file'
+  hosts: instance-2-joined,instance-3-joined
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Change application config'
+      copy:
+        content: "{{ {cartridge_app_name: {'test': 'value'}} | to_nice_yaml }}"
+        dest: '{{ instance_info.app_conf_file }}'
+        owner: 'tarantool'
+        group: 'tarantool'
+        mode: '644'
+
+    - name: 'Change cluster cookie file'
+      copy:
+        content: "my_new_cookie"
+        dest: "{{ (instance_info.work_dir, '.tarantool.cookie') | cartridge_path_join }}"
+        owner: 'tarantool'
+        group: 'tarantool'
+        mode: '644'
+
+- name: 'Restore joined instances with different application config and cluster cookie file'
+  hosts: instance-2-joined,instance-3-joined
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Call restore from last TGZ'
+      vars:
+        cartridge_force_restore: false
+        cartridge_scenario:
+          - stop_instance
+          - restore
+      import_role:
+        name: ansible-cartridge
+      ignore_errors: true
+
+    - name: 'Check restore error'
+      assert:
+        fail_msg: 'Restore error is incorrect'
+        success_msg: 'Restore error is correct'
+        that:
+          - cartridge_restore_instance_res is failed
+          - '"Some files already exist and have a different md5 sum" in cartridge_restore_instance_res.msg'
+          - '".tarantool.cookie" in cartridge_restore_instance_res.msg'
+          - '"myapp.yml" in cartridge_restore_instance_res.msg'
+
+    - name: 'Call restore from last TGZ'
+      vars:
+        cartridge_force_restore: true
+        cartridge_eval_args: '{{ check_restore_eval_args }}'
+        cartridge_eval_body: '{{ check_restore_eval_body }}'
+        cartridge_scenario:
+          - restore
+          - start_instance
+          - wait_instance_started
+          - eval
+      import_role:
+        name: ansible-cartridge
+
+- name: 'Restore instance with backup of another instance'
+  hosts: instance-3-joined
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Call restore from last TGZ'
+      vars:
+        cartridge_restore_backup_path: '/tmp/myapp-stateboard/'
+        cartridge_scenario:
+          - stop_instance
+          - restore
+      import_role:
+        name: ansible-cartridge
+      ignore_errors: true
+
+    - name: 'Check restore error'
+      assert:
+        fail_msg: 'Restore error is incorrect'
+        success_msg: 'Restore error is correct'
+        that:
+          - cartridge_restore_instance_res is failed
+          - '"Seems that selected backup of another instance" in cartridge_restore_instance_res.msg'

--- a/molecule/backup/converge.yml
+++ b/molecule/backup/converge.yml
@@ -65,3 +65,25 @@
   gather_facts: false
   tasks:
     - include_tasks: include/check_backup_start_stop.yml
+
+- name: 'Insert second tuple'
+  hosts: instance-2-joined
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_eval_body: |
+      box.space.memtx_space:insert({54321})
+      box.space.vinyl_space:insert({09876})
+    cartridge_scenario:
+      - eval
+  roles:
+    - ansible-cartridge
+
+- name: 'Restore joined instances and stateboard'
+  hosts: cluster:!instance-1-not-joined
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - include_tasks: include/check_restore.yml

--- a/molecule/backup/hosts.yml
+++ b/molecule/backup/hosts.yml
@@ -1,29 +1,31 @@
 ---
 cluster:
   vars:
-    # common connection opts
     ansible_user: root
     ansible_connection: docker
     become: true
     become_user: root
 
-    # common cartridge opts
     cartridge_app_name: myapp
-    cartridge_package_path: ./packages/myapp-1.0.0-0.tar.gz
-    cartridge_multiversion: true
 
-    cartridge_data_dir: /opt/data
-    cartridge_memtx_dir_parent: /opt/memtx
-    cartridge_vinyl_dir_parent: /opt/vinyl
-    cartridge_wal_dir_parent: /opt/wal
+    check_restore_eval_args:
+      - '{{ stateboard }}'
+    check_restore_eval_body: |
+      local is_stateboard = ...
+      if is_stateboard then
+        assert(box.space.leader ~= nil, "Space 'leader' should exists")
+      else
+        assert(box.space.memtx_space ~= nil, "Space 'memtx_space' should exists")
+        local tuples = box.space.memtx_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 12345, "Space 'memtx_space' should contain test tuple")
 
-    cartridge_run_dir: /opt/run
-    cartridge_conf_dir: /opt/conf.d
-    cartridge_app_install_dir: /opt/install
-    cartridge_app_instances_dir: /opt/instances
-    cartridge_systemd_dir: /etc/systemd/system
+        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
+        local tuples = box.space.vinyl_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 67890, "Space 'vinyl_space' should contain test tuple")
 
-  # instances
+        assert(require('cartridge').config_get_readonly().test == nil, "Section 'test' shouldn't exists")
+      end
+
   hosts:
     instance-1-not-joined:
       config:
@@ -47,10 +49,10 @@ cluster:
       stateboard: true
 
   children:
-    # group by hosts
     machine_1:
       vars:
         ansible_host: vm1
+        cartridge_package_path: ./packages/myapp-1.0.0-0.rpm
 
       hosts:
         instance-1-not-joined:
@@ -59,6 +61,20 @@ cluster:
     machine_2:
       vars:
         ansible_host: vm2
+
+        cartridge_package_path: ./packages/myapp-1.0.0-0.tar.gz
+        cartridge_multiversion: true
+
+        cartridge_data_dir: /opt/data
+        cartridge_memtx_dir_parent: /opt/memtx
+        cartridge_vinyl_dir_parent: /opt/vinyl
+        cartridge_wal_dir_parent: /opt/wal
+
+        cartridge_run_dir: /opt/run
+        cartridge_conf_dir: /opt/conf.d
+        cartridge_app_install_dir: /opt/install
+        cartridge_app_instances_dir: /opt/instances
+        cartridge_systemd_dir: /etc/systemd/system
 
       hosts:
         instance-3-joined:

--- a/molecule/backup/include/check_backup.yml
+++ b/molecule/backup/include/check_backup.yml
@@ -7,6 +7,10 @@
     cartridge_scenario:
       - backup
 
+- name: "Show 'instance_backup_files' fact"
+  debug:
+    var: instance_backup_files
+
 - name: 'Check "instance_backup_files" and "backup_files_from_machine"'
   check_backup_files_list:
     instance_info: '{{ instance_info }}'
@@ -16,12 +20,22 @@
     backup_files_from_machine: '{{ backup_files_from_machine }}'
     instances_from_machine: '{{ instances_from_same_machine[inventory_hostname] }}'
 
-- name: 'Unpack instance archive'
+- name: 'Remove directory with old backup'
+  file:
+    path: '/tmp/{{ instance_info.instance_id }}'
+    state: absent
+
+- name: 'Create directory to unpack new backup'
+  file:
+    path: '/tmp/{{ instance_info.instance_id }}'
+    state: directory
+
+- name: 'Unpack instance backup'
   unarchive:
     list_files: true
     src: '{{ backup_archive_path }}'
     remote_src: true
-    dest: /tmp/
+    dest: '/tmp/{{ instance_info.instance_id }}'
   register: backup_archive_res
 
 - name: 'Check backup archive files list'

--- a/molecule/backup/include/check_restore.yml
+++ b/molecule/backup/include/check_restore.yml
@@ -1,90 +1,38 @@
 ---
 
-- name: 'Cleanup instance'
-  vars:
-    cartridge_eval_args:
-      - '{{ stateboard }}'
-    cartridge_eval_body: |
-      local is_stateboard = ...
-      if is_stateboard then
-        assert(box.space.leader ~= nil, 'Space "leader" should exists')
-      else
-        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
-        local tuples = box.space.memtx_space:select()
-        assert(#tuples == 2, 'Space "memtx_space" should contain two tuples')
-
-        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
-        local tuples = box.space.vinyl_space:select()
-        assert(#tuples == 2, 'Space "memtx_space" should contain two tuples')
-      end
-    cartridge_scenario:
-      - eval
-      - stop_instance
-      - cleanup_instance_files
-  import_role:
-    name: ansible-cartridge
-
-- name: 'Remove memtx directory to test directories restoring'
+- name: 'Remove vinyl directory to test directories restoring'
   file:
-    path: '{{ cartridge_memtx_dir_parent }}'
+    path: '{{ cartridge_vinyl_dir_parent }}'
     state: 'absent'
   register: backup_archive_res
 
 - name: 'Call restore from last TGZ'
   vars:
-    cartridge_eval_args:
-      - '{{ stateboard }}'
-    cartridge_eval_body: |
-      local is_stateboard = ...
-      if is_stateboard then
-        assert(box.space.leader ~= nil, 'Space "leader" should exists')
-      else
-        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
-        local tuples = box.space.memtx_space:select()
-        assert(#tuples == 1 and tuples[1][1] == 12345, 'Space "memtx_space" should contain test tuple')
-
-        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
-        local tuples = box.space.vinyl_space:select()
-        assert(#tuples == 1 and tuples[1][1] == 67890, 'Space "memtx_space" should contain test tuple')
-      end
+    cartridge_restore_backup_path: null
+    cartridge_eval_args: '{{ check_restore_eval_args }}'
+    cartridge_eval_body: '{{ check_restore_eval_body }}'
     cartridge_scenario:
+      - stop_instance
       - restore
       - start_instance
       - wait_instance_started
       - eval
-      - stop_instance
-      - cleanup_instance_files
   import_role:
     name: ansible-cartridge
 
-- name: 'Remove memtx directory to test directories restoring'
+- name: 'Remove vinyl directory to test directories restoring'
   file:
-    path: '{{ cartridge_memtx_dir_parent }}'
+    path: '{{ cartridge_vinyl_dir_parent }}'
     state: 'absent'
   register: backup_archive_res
 
-- name: 'Set restore archive path to folder'
-  set_fact:
-    cartridge_restore_archive_path: '/tmp/{{ instance_info.instance_id }}/'
-
 - name: 'Call restore from folder'
   vars:
-    cartridge_eval_args:
-      - '{{ stateboard }}'
-    cartridge_eval_body: |
-      local is_stateboard = ...
-      if is_stateboard then
-        assert(box.space.leader ~= nil, 'Space "leader" should exists')
-      else
-        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
-        local tuples = box.space.memtx_space:select()
-        assert(#tuples == 1 and tuples[1][1] == 12345, 'Space "memtx_space" should contain test tuple')
-
-        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
-        local tuples = box.space.vinyl_space:select()
-        assert(#tuples == 1 and tuples[1][1] == 67890, 'Space "memtx_space" should contain test tuple')
-      end
+    cartridge_restore_backup_path: '/tmp/{{ instance_info.instance_id }}/'
+    cartridge_eval_args: '{{ check_restore_eval_args }}'
+    cartridge_eval_body: '{{ check_restore_eval_body }}'
     cartridge_scenario:
+      - stop_instance
       - restore
       - start_instance
       - wait_instance_started

--- a/molecule/backup/include/check_restore.yml
+++ b/molecule/backup/include/check_restore.yml
@@ -1,0 +1,93 @@
+---
+
+- name: 'Cleanup instance'
+  vars:
+    cartridge_eval_args:
+      - '{{ stateboard }}'
+    cartridge_eval_body: |
+      local is_stateboard = ...
+      if is_stateboard then
+        assert(box.space.leader ~= nil, 'Space "leader" should exists')
+      else
+        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
+        local tuples = box.space.memtx_space:select()
+        assert(#tuples == 2, 'Space "memtx_space" should contain two tuples')
+
+        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
+        local tuples = box.space.vinyl_space:select()
+        assert(#tuples == 2, 'Space "memtx_space" should contain two tuples')
+      end
+    cartridge_scenario:
+      - eval
+      - stop_instance
+      - cleanup_instance_files
+  import_role:
+    name: ansible-cartridge
+
+- name: 'Remove memtx directory to test directories restoring'
+  file:
+    path: '{{ cartridge_memtx_dir_parent }}'
+    state: 'absent'
+  register: backup_archive_res
+
+- name: 'Call restore from last TGZ'
+  vars:
+    cartridge_eval_args:
+      - '{{ stateboard }}'
+    cartridge_eval_body: |
+      local is_stateboard = ...
+      if is_stateboard then
+        assert(box.space.leader ~= nil, 'Space "leader" should exists')
+      else
+        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
+        local tuples = box.space.memtx_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 12345, 'Space "memtx_space" should contain test tuple')
+
+        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
+        local tuples = box.space.vinyl_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 67890, 'Space "memtx_space" should contain test tuple')
+      end
+    cartridge_scenario:
+      - restore
+      - start_instance
+      - wait_instance_started
+      - eval
+      - stop_instance
+      - cleanup_instance_files
+  import_role:
+    name: ansible-cartridge
+
+- name: 'Remove memtx directory to test directories restoring'
+  file:
+    path: '{{ cartridge_memtx_dir_parent }}'
+    state: 'absent'
+  register: backup_archive_res
+
+- name: 'Set restore archive path to folder'
+  set_fact:
+    cartridge_restore_archive_path: '/tmp/{{ instance_info.instance_id }}/'
+
+- name: 'Call restore from folder'
+  vars:
+    cartridge_eval_args:
+      - '{{ stateboard }}'
+    cartridge_eval_body: |
+      local is_stateboard = ...
+      if is_stateboard then
+        assert(box.space.leader ~= nil, 'Space "leader" should exists')
+      else
+        assert(box.space.memtx_space ~= nil, 'Space "memtx_space" should exists')
+        local tuples = box.space.memtx_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 12345, 'Space "memtx_space" should contain test tuple')
+
+        assert(box.space.vinyl_space ~= nil, 'Space "vinyl_space" should exists')
+        local tuples = box.space.vinyl_space:select()
+        assert(#tuples == 1 and tuples[1][1] == 67890, 'Space "memtx_space" should contain test tuple')
+      end
+    cartridge_scenario:
+      - restore
+      - start_instance
+      - wait_instance_started
+      - eval
+  import_role:
+    name: ansible-cartridge

--- a/molecule/backup/library/check_backup_files_list.py
+++ b/molecule/backup/library/check_backup_files_list.py
@@ -36,24 +36,29 @@ if __name__ == '__main__':
 
     if not stateboard:
         exp_files_list_regexps = [
-            os.path.join(instance_info['memtx_dir'], r"\d+\.snap"),
-            os.path.join(instance_info['vinyl_dir'], r"\d+\.vylog"),
-            os.path.join(instance_info['work_dir'], "config"),
             instance_info['conf_file'],
             instance_info['app_conf_file'],
+            os.path.join(instance_info['work_dir'], "config"),
+            os.path.join(instance_info['memtx_dir'], r"\d+\.snap"),
+            os.path.join(instance_info['vinyl_dir'], r"\d+\.vylog"),
+            os.path.join(instance_info['vinyl_dir'], r"\d+", r"\d+", r"\d+\.index"),
+            os.path.join(instance_info['vinyl_dir'], r"\d+", r"\d+", r"\d+\.run"),
         ]
     else:
         exp_files_list_regexps = [
-            os.path.join(instance_info['memtx_dir'], r"\d+.snap"),
             instance_info['conf_file'],
+            os.path.join(instance_info['memtx_dir'], r"\d+.snap"),
         ]
 
-    exp_files_list_regexps = list(sorted(map(lambda r: r.strip(os.path.sep), exp_files_list_regexps)))
+    exp_files_list_regexps = list(map(lambda r: r.strip(os.path.sep), exp_files_list_regexps))
 
-    files_list_is_ok = all([
-        re.match(exp_files_list_regexps[i], file_path)
-        for i, file_path in enumerate(files_list)
-    ])
+    if len(exp_files_list_regexps) != len(files_list):
+        files_list_is_ok = False
+    else:
+        files_list_is_ok = all([
+            re.match(exp_files_list_regexps[i], file_path)
+            for i, file_path in enumerate(files_list)
+        ])
 
     if not files_list_is_ok:
         module.fail_json(msg="Received bad backup files list. Expected %s, got %s" % (

--- a/molecule/backup/prepare.yml
+++ b/molecule/backup/prepare.yml
@@ -31,6 +31,7 @@
               parts = { {1, 'unsigned'} },
               if_not_exists = true,
           })
+          space:insert({12345})
 
           local space = box.schema.space.create('vinyl_space', {
               if_not_exists = true,
@@ -40,3 +41,4 @@
               parts = { {1, 'unsigned'} },
               if_not_exists = true,
           })
+          space:insert({67890})

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -12,6 +12,7 @@
       cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
       cartridge_ignore_split_brain: '{{ cartridge_ignore_split_brain }}'
       cartridge_paths_to_keep_on_cleanup: '{{ cartridge_paths_to_keep_on_cleanup }}'
+      cartridge_paths_to_keep_on_restore: '{{ cartridge_paths_to_keep_on_restore }}'
 
       # Role scenario configuration
 
@@ -164,8 +165,9 @@
       cartridge_remote_backups_dir: '{{ cartridge_remote_backups_dir }}'
       cartridge_fetch_backups: '{{ cartridge_fetch_backups }}'
       cartridge_fetch_backups_dir: '{{ cartridge_fetch_backups_dir }}'
-      cartridge_restore_archive_path: '{{ cartridge_restore_archive_path }}'
+      cartridge_restore_backup_path: '{{ cartridge_restore_backup_path }}'
       cartridge_force_restore: '{{ cartridge_force_restore }}'
+      cartridge_ignore_alien_backup: '{{ cartridge_ignore_alien_backup }}'
 
       # Edit topology check
 

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -164,6 +164,8 @@
       cartridge_remote_backups_dir: '{{ cartridge_remote_backups_dir }}'
       cartridge_fetch_backups: '{{ cartridge_fetch_backups }}'
       cartridge_fetch_backups_dir: '{{ cartridge_fetch_backups_dir }}'
+      cartridge_restore_archive_path: '{{ cartridge_restore_archive_path }}'
+      cartridge_force_restore: '{{ cartridge_force_restore }}'
 
       # Edit topology check
 

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -12,7 +12,6 @@
       cartridge_remove_temporary_files: '{{ cartridge_remove_temporary_files }}'
       cartridge_ignore_split_brain: '{{ cartridge_ignore_split_brain }}'
       cartridge_paths_to_keep_on_cleanup: '{{ cartridge_paths_to_keep_on_cleanup }}'
-      cartridge_paths_to_keep_on_restore: '{{ cartridge_paths_to_keep_on_restore }}'
 
       # Role scenario configuration
 
@@ -167,7 +166,9 @@
       cartridge_fetch_backups_dir: '{{ cartridge_fetch_backups_dir }}'
       cartridge_restore_backup_path: '{{ cartridge_restore_backup_path }}'
       cartridge_force_restore: '{{ cartridge_force_restore }}'
-      cartridge_ignore_alien_backup: '{{ cartridge_ignore_alien_backup }}'
+      cartridge_allow_alien_backup: '{{ cartridge_allow_alien_backup }}'
+      cartridge_skip_cleanup_on_restore: '{{ cartridge_skip_cleanup_on_restore }}'
+      cartridge_paths_to_keep_before_restore: '{{ cartridge_paths_to_keep_before_restore }}'
 
       # Edit topology check
 

--- a/tasks/step_restore.yml
+++ b/tasks/step_restore.yml
@@ -1,0 +1,9 @@
+---
+
+- import_tasks: 'prepare.yml'
+  tags:
+    - cartridge-instances
+    - cartridge-replicasets
+    - cartridge-config
+
+- import_tasks: 'steps/restore.yml'

--- a/tasks/steps/restore.yml
+++ b/tasks/steps/restore.yml
@@ -2,8 +2,12 @@
 
 - name: 'Restore instance from archive'
   cartridge_restore_instance:
-    console_sock: '{{ instance_info.console_sock }}'
-    restore_archive_path: '{{ cartridge_restore_archive_path }}'
+    instance_info: '{{ instance_info }}'
+    app_user: '{{ cartridge_app_user }}'
+    app_group: '{{ cartridge_app_group }}'
+    paths_to_keep_on_restore: '{{ cartridge_paths_to_keep_on_restore }}'
+    restore_backup_path: '{{ cartridge_restore_backup_path }}'
     remote_backups_dir: '{{ cartridge_remote_backups_dir }}'
-    instance_id: '{{ instance_info.instance_id }}'
     force_restore: '{{ cartridge_force_restore }}'
+    ignore_alien_backups: '{{ cartridge_ignore_alien_backup }}'
+  register: cartridge_restore_instance_res

--- a/tasks/steps/restore.yml
+++ b/tasks/steps/restore.yml
@@ -5,9 +5,10 @@
     instance_info: '{{ instance_info }}'
     app_user: '{{ cartridge_app_user }}'
     app_group: '{{ cartridge_app_group }}'
-    paths_to_keep_on_restore: '{{ cartridge_paths_to_keep_on_restore }}'
+    paths_to_keep_before_restore: '{{ cartridge_paths_to_keep_before_restore }}'
     restore_backup_path: '{{ cartridge_restore_backup_path }}'
     remote_backups_dir: '{{ cartridge_remote_backups_dir }}'
     force_restore: '{{ cartridge_force_restore }}'
-    ignore_alien_backups: '{{ cartridge_ignore_alien_backup }}'
+    allow_alien_backups: '{{ cartridge_allow_alien_backup }}'
+    skip_cleanup_on_restore: '{{ cartridge_skip_cleanup_on_restore }}'
   register: cartridge_restore_instance_res

--- a/tasks/steps/restore.yml
+++ b/tasks/steps/restore.yml
@@ -1,0 +1,9 @@
+---
+
+- name: 'Restore instance from archive'
+  cartridge_restore_instance:
+    console_sock: '{{ instance_info.console_sock }}'
+    restore_archive_path: '{{ cartridge_restore_archive_path }}'
+    remote_backups_dir: '{{ cartridge_remote_backups_dir }}'
+    instance_id: '{{ instance_info.instance_id }}'
+    force_restore: '{{ cartridge_force_restore }}'

--- a/unit/test_restore_instance.py
+++ b/unit/test_restore_instance.py
@@ -1,0 +1,25 @@
+import sys
+import unittest
+
+import module_utils.helpers as helpers
+
+sys.modules['ansible.module_utils.helpers'] = helpers
+from library.cartridge_restore_instance import is_path_of_instance
+
+
+class TestRestoreInstance(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_is_path_of_instance(self):
+        self.assertTrue(is_path_of_instance('/backups/myapp.i-1.tar.gz', 'myapp.i-1'))
+        self.assertTrue(is_path_of_instance('/backups/myapp.i-1.2020-01-01.tar.gz', 'myapp.i-1'))
+        self.assertTrue(is_path_of_instance('/backups/myapp.i-1.2020-01-01-010101.tar.gz', 'myapp.i-1'))
+        self.assertTrue(is_path_of_instance('/backups/myapp.i-1.1627650508.tar.gz', 'myapp.i-1'))
+        self.assertTrue(is_path_of_instance('/backups/backup.myapp.i-1.tar.gz', 'myapp.i-1'))
+        self.assertTrue(is_path_of_instance('/backups/myapp.i-1/', 'myapp.i-1'))
+
+        self.assertFalse(is_path_of_instance('/backups/myapp.i-11.tar.gz', 'myapp.i-1'))
+        self.assertFalse(is_path_of_instance('/backups/myapp.i-1.1.tar.gz', 'myapp.i-1'))
+        self.assertFalse(is_path_of_instance('/backups/myapp.i-1-1.tar.gz', 'myapp.i-1'))
+        self.assertFalse(is_path_of_instance('/backups/myapp.i-1-replica.tar.gz', 'myapp.i-1'))

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -94,7 +94,8 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_not_save_cookie_in_app_config',
                 'cartridge_fetch_backups',
                 'cartridge_force_restore',
-                'cartridge_ignore_alien_backup',
+                'cartridge_allow_alien_backup',
+                'cartridge_skip_cleanup_on_restore',
             },
             dict: {
                 'cartridge_defaults',
@@ -148,7 +149,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_custom_steps',
                 'cartridge_eval_args',
                 'cartridge_paths_to_keep_on_cleanup',
-                'cartridge_paths_to_keep_on_restore',
+                'cartridge_paths_to_keep_before_restore',
             }
         }
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -68,7 +68,7 @@ class TestValidateConfig(unittest.TestCase):
                 'allowed_members_states[0]',
                 'cartridge_remote_backups_dir',
                 'cartridge_fetch_backups_dir',
-                'cartridge_restore_archive_path',
+                'cartridge_restore_backup_path',
             },
             bool: {
                 'cartridge_bootstrap_vshard',
@@ -94,6 +94,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_not_save_cookie_in_app_config',
                 'cartridge_fetch_backups',
                 'cartridge_force_restore',
+                'cartridge_ignore_alien_backup',
             },
             dict: {
                 'cartridge_defaults',
@@ -147,6 +148,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_custom_steps',
                 'cartridge_eval_args',
                 'cartridge_paths_to_keep_on_cleanup',
+                'cartridge_paths_to_keep_on_restore',
             }
         }
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -65,7 +65,10 @@ class TestValidateConfig(unittest.TestCase):
                 'zone',
                 'cartridge_eval_body',
                 'cartridge_eval_file',
-                'allowed_members_states[0]'
+                'allowed_members_states[0]',
+                'cartridge_remote_backups_dir',
+                'cartridge_fetch_backups_dir',
+                'cartridge_restore_archive_path',
             },
             bool: {
                 'cartridge_bootstrap_vshard',
@@ -89,6 +92,8 @@ class TestValidateConfig(unittest.TestCase):
                 'show_issues',
                 'cartridge_eval_with_retries',
                 'cartridge_not_save_cookie_in_app_config',
+                'cartridge_fetch_backups',
+                'cartridge_force_restore',
             },
             dict: {
                 'cartridge_defaults',


### PR DESCRIPTION
Closes #148 

Before this patch, it was possible to backup instances, but it wasn't possible to restore instances from these backups.

Now it's possible to restore instance from the last or selected backup by the `restore` step. Backup should be in TGZ or directory format.