### PR TITLE
Optimize `Set instance facts` step

### DIFF
--- a/consistency/test_facts.py
+++ b/consistency/test_facts.py
@@ -32,20 +32,7 @@ class TestFacts(unittest.TestCase):
             text = f.read()
             self.doc_facts = re.findall(r'\n[*-][^`]*`([^`]+)`', text)
 
-    # If someone added a variable to defaults, but forgot to set it in 'set_instance_facts' step
-    def test_set_instance_facts(self):
-        default_names = list(self.defaults.keys())
-        set_instance_facts_name = list(self.set_instance_facts[0]['set_fact']['role_facts'].keys())
-
-        self.assertEqual(
-            default_names, set_instance_facts_name,
-            'List of facts in defaults and in "set_instance_fact" step is different',
-        )
-
-    # If someone added a variable to defaults, but forgot to add it to doc
-    def test_doc_facts(self):
-        default_names = list(self.defaults.keys())
-        undocumented_facts = [
+        self.not_user_facts = [
             # Role defaults
             'cartridge_role_scenarios',
             # Cross-step facts
@@ -68,7 +55,21 @@ class TestFacts(unittest.TestCase):
             'instances_from_same_machine',
         ]
 
+    # If someone added a variable to defaults, but forgot to set it in 'set_instance_facts' step
+    def test_set_instance_facts(self):
+        default_names = list(self.defaults.keys())
+        set_instance_facts_name = list(self.set_instance_facts[0]['set_fact']['role_facts'].keys())
+
         self.assertEqual(
-            sorted(default_names), sorted(self.doc_facts + undocumented_facts),
+            sorted(default_names), sorted(set_instance_facts_name + self.not_user_facts),
+            'List of facts in defaults and in "set_instance_fact" step is different',
+        )
+
+    # If someone added a variable to defaults, but forgot to add it to doc
+    def test_doc_facts(self):
+        default_names = list(self.defaults.keys())
+
+        self.assertEqual(
+            sorted(default_names), sorted(self.doc_facts + self.not_user_facts),
             'List of facts in defaults and in documentation is different',
         )

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,8 +174,8 @@ delivered_package_path: null
 control_instance: null
 temporary_files: []
 needs_restart: null
-cluster_disabled_instances: {}
-inventory_disabled_instances: {}
+cluster_disabled_instances: []
+inventory_disabled_instances: []
 alive_not_expelled_instance: null
 instance_backup_files: null
 backup_archive_path: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,21 @@
 
 - name: 'Initialize cross-step facts'
   set_fact:
+    # Cross-step facts
     delivered_package_path: null
     control_instance: null
     temporary_files: []
     needs_restart: null
+    cluster_disabled_instances: []
+    inventory_disabled_instances: []
     alive_not_expelled_instance: null
     instance_backup_files: null
     backup_archive_path: null
     fetched_backup_archive_path: null
     backup_files_from_machine: []
+    # Temp facts that user can use after role import
+    single_instances_for_each_machine: null
+    instances_from_same_machine: null
   run_once: true
   delegate_to: localhost
   become: false

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -21,7 +21,6 @@
 
       cartridge_scenario_name: '{{ cartridge_scenario_name }}'
       cartridge_custom_scenarios: '{{ cartridge_custom_scenarios }}'
-      cartridge_role_scenarios: '{{ cartridge_role_scenarios }}'
 
       # Application package configuration
 
@@ -127,28 +126,6 @@
 
       cartridge_delivered_package_path: '{{ cartridge_delivered_package_path }}'
       cartridge_control_instance: '{{ cartridge_control_instance }}'
-
-      # Cross-step facts (for correct 'tasks_from' option usage)
-
-      delivered_package_path: '{{ delivered_package_path }}'
-      control_instance: '{{ control_instance }}'
-      temporary_files: '{{ temporary_files }}'
-      needs_restart: '{{ needs_restart }}'
-      cluster_disabled_instances: '{{ cluster_disabled_instances }}'
-      inventory_disabled_instances: '{{ inventory_disabled_instances }}'
-      alive_not_expelled_instance: '{{ alive_not_expelled_instance }}'
-      instance_backup_files: '{{ instance_backup_files }}'
-      backup_archive_path: '{{ backup_archive_path }}'
-      fetched_backup_archive_path: '{{ fetched_backup_archive_path }}'
-      backup_files_from_machine: '{{ backup_files_from_machine }}'
-
-      # Temp facts
-
-      cached_facts_res: '{{ cached_facts_res }}'
-      cached_facts: '{{ cached_facts }}'
-      facts_for_machines_res: '{{ facts_for_machines_res }}'
-      single_instances_for_each_machine: '{{ single_instances_for_each_machine }}'
-      instances_from_same_machine: '{{ instances_from_same_machine }}'
 
       # Eval params
 


### PR DESCRIPTION
Closes #385

Before the patch, the `Set instance facts` step used temporary role facts,
although this is not necessary. Therefore, in large clusters, it might take longer than necessary.

Now at this step, only those facts that can be specified by the user are established,
which speeds up the step.