### PR TITLE
Use `os.lstat` instead of `os.path.getmtime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ README.md to use the newest tag with new release
 
 - Optimize `Set instance facts` step
 - Optimize facts caching
+- Fixed the ability to roll back to the previous TGZ package
 
 ## [1.11.0] - 2021-07-30
 

--- a/library/cartridge_get_dist_dirs_to_remove.py
+++ b/library/cartridge_get_dist_dirs_to_remove.py
@@ -35,7 +35,7 @@ def get_dist_dirs_to_remove(params):
 
     dists = sorted(
         dists,
-        key=lambda filename: os.path.getmtime(os.path.join(app_install_dir, filename)),
+        key=lambda filename: os.lstat(os.path.join(app_install_dir, filename)).st_mtime,
         reverse=True,
     )
 

--- a/library/cartridge_get_needs_restart.py
+++ b/library/cartridge_get_needs_restart.py
@@ -23,10 +23,10 @@ def check_needs_restart_to_update_package(params):
     console_sock = instance_info['console_sock']
     instance_dist_dir = instance_info['instance_dist_dir']
 
-    last_restart_time = os.path.getmtime(console_sock)
+    last_restart_time = os.lstat(console_sock).st_mtime
 
     # check if application code was updated
-    package_update_time = os.path.getmtime(instance_dist_dir)
+    package_update_time = os.lstat(instance_dist_dir).st_mtime
     if last_restart_time < package_update_time:
         return True, None
 

--- a/molecule/update_cartridge/converge.yml
+++ b/molecule/update_cartridge/converge.yml
@@ -1,5 +1,6 @@
 ---
-- name: Bootstrap cluster with Cartridge 2.1.2 on all instances
+
+- name: 'Bootstrap cluster with Cartridge 2.1.2 on all instances'
   hosts: cluster
   roles:
     - ansible-cartridge
@@ -13,7 +14,7 @@
     cartridge_install_tarantool_for_tgz: true
     cartridge_package_path: ./packages/myapp-1.0.0-0-with-c-2.1.2.tar.gz
 
-- name: Update storage-with-c-2.2.0 to Cartridge 2.2.0
+- name: 'Update storage-with-c-2.2.0 to Cartridge 2.2.0'
   hosts: storage-with-c-2.2.0
   roles:
     - ansible-cartridge
@@ -24,7 +25,7 @@
     cartridge_scenario_name: update_tgz
     cartridge_package_path: ./packages/myapp-2.0.0-0-with-c-2.2.0.tar.gz
 
-- name: Update storage-with-c-2.3.0 to Cartridge 2.3.0
+- name: 'Update storage-with-c-2.3.0 to Cartridge 2.3.0'
   hosts: storage-with-c-2.3.0
   roles:
     - ansible-cartridge
@@ -35,7 +36,7 @@
     cartridge_scenario_name: update_tgz
     cartridge_package_path: ./packages/myapp-3.0.0-0-with-c-2.3.0.tar.gz
 
-- name: Update storage-with-c-2.5.0 to Cartridge 2.5.0
+- name: 'Update storage-with-c-2.5.0 to Cartridge 2.5.0'
   hosts: storage-with-c-2.5.0
   roles:
     - ansible-cartridge
@@ -46,7 +47,7 @@
     cartridge_scenario_name: update_tgz
     cartridge_package_path: ./packages/myapp-4.0.0-0-with-c-2.5.0.tar.gz
 
-- name: Update storage-with-c-2.6.0 to Cartridge 2.6.0
+- name: 'Update storage-with-c-2.6.0 to Cartridge 2.6.0'
   hosts: storage-with-c-2.6.0
   roles:
     - ansible-cartridge
@@ -60,7 +61,7 @@
 # This play affects two-phase commmit
 # We need to be sure that role selects such control instance
 # that two-phase commit doesn't fail for that
-- name: Configure application
+- name: 'Configure application'
   hosts: cluster
   roles:
     - ansible-cartridge
@@ -79,7 +80,7 @@
       enabled: true
       cookie_max_age: 1000
 
-- name: Update all instances to Cartridge 2.6.0
+- name: 'Update all instances to Cartridge 2.6.0'
   hosts: cluster
   roles:
     - ansible-cartridge
@@ -89,3 +90,54 @@
   vars:
     cartridge_package_path: ./packages/myapp-5.0.0-0-with-c-2.6.0.tar.gz
     cartridge_scenario_name: update_tgz
+
+- name: 'Check Cartridge version'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Get Cartridge version'
+      import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_scenario:
+          - eval
+        cartridge_eval_body: return require('cartridge').VERSION
+
+    - name: 'Check that all instances were rolled back'
+      assert:
+        fail_msg: 'Should use Cartridge 2.6.0, not {{ eval_res[0] }}'
+        success_msg: 'Uses Cartridge 2.6.0'
+        that: eval_res[0] == '2.6.0'
+
+- name: 'Roll back all instances to Cartridge 2.5.0'
+  hosts: cluster
+  roles:
+    - ansible-cartridge
+  become: true
+  become_user: root
+  gather_facts: false
+  vars:
+    cartridge_package_path: ./packages/myapp-4.0.0-0-with-c-2.5.0.tar.gz
+    cartridge_scenario_name: update_tgz
+
+- name: 'Check Cartridge version'
+  hosts: cluster
+  become: true
+  become_user: root
+  gather_facts: false
+  tasks:
+    - name: 'Get Cartridge version'
+      import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_scenario:
+          - eval
+        cartridge_eval_body: return require('cartridge').VERSION
+
+    - name: 'Check that all instances were rolled back'
+      assert:
+        fail_msg: 'Should use Cartridge 2.5.0, not {{ eval_res[0] }}'
+        success_msg: 'Uses Cartridge 2.5.0'
+        that: eval_res[0] == '2.5.0'

--- a/unit/instance.py
+++ b/unit/instance.py
@@ -8,7 +8,7 @@ from subprocess import Popen
 
 import tenacity
 
-from unit.os_mock import OsPathExistsMock, OsPathGetMTimeMock
+from unit.os_mock import OsPathExistsMock, OsLstatMock
 
 instance_app_dir = os.path.realpath(
     os.path.join(
@@ -41,16 +41,16 @@ class Instance:
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         self.__original_exists = os.path.exists
-        self.__original_getmtime = os.path.getmtime
+        self.__original_lstat = os.lstat
 
         os.path.exists = OsPathExistsMock()
-        os.path.getmtime = OsPathGetMTimeMock()
+        os.lstat = OsLstatMock()
 
     def __del__(self):
         self.stop()
 
         os.path.exists = self.__original_exists
-        os.path.getmtime = self.__original_getmtime
+        os.lstat = self.__original_lstat
 
         if os.path.exists(self.console_sock):
             os.remove(self.console_sock)
@@ -234,7 +234,7 @@ class Instance:
 
     @staticmethod
     def set_path_m_time(path, m_time):
-        os.path.getmtime.set_m_time(path, m_time)
+        os.lstat.set_m_time(path, m_time)
 
     def set_box_cfg_function(self, value=True):
         self.eval_res_err('''

--- a/unit/os_mock.py
+++ b/unit/os_mock.py
@@ -1,3 +1,8 @@
+class StatResult:
+    def __init__(self, st_mtime=0):
+        self.st_mtime = st_mtime
+
+
 class OsPathExistsMock:
     def __init__(self):
         self.existent_paths = set()
@@ -12,7 +17,7 @@ class OsPathExistsMock:
         self.existent_paths.discard(path)
 
 
-class OsPathGetMTimeMock:
+class OsLstatMock:
     def __init__(self):
         self.known_mtimes = dict()
 
@@ -20,4 +25,6 @@ class OsPathGetMTimeMock:
         return self.known_mtimes[path]
 
     def set_m_time(self, path, m_time):
-        self.known_mtimes.update({path: m_time})
+        if not self.known_mtimes.get(path):
+            self.known_mtimes[path] = StatResult()
+        self.known_mtimes[path].st_mtime = m_time


### PR DESCRIPTION
Closes #383

Sometimes a situation arises that it is necessary to roll back an instance
to an old version of the TGZ package. After updating the package link,
the instance should be rebooted.

Before this patch, the `os.path.getmtime` function was used, which did
not check the modification time of the link, but the modification time of the package,
so the instance did not reboot (since the package is older than the restart time).

Now the `os.lstat` function is used, which does not follow symbolic links and
looks at the attributes of the link itself.