### PR TITLE
Add availability to configure log directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please update `ansible-galaxy install` command in
 README.md to use the newest tag with new release
 -->
 
+### Added
+
+- Add `cartridge_log_dir_parent` to configure directory of logs
+
 ### Fixed
 
 - Optimize `Set instance facts` step

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ cartridge_data_dir: /var/lib/tarantool
 cartridge_memtx_dir_parent: null
 cartridge_vinyl_dir_parent: null
 cartridge_wal_dir_parent: null
+cartridge_log_dir_parent: null
 cartridge_run_dir: /var/run/tarantool
 cartridge_conf_dir: /etc/tarantool/conf.d
 cartridge_app_install_dir: /usr/share/tarantool
@@ -269,6 +270,7 @@ cartridge_cached_fact_names_by_target:
     - cartridge_vinyl_dir_parent
     - cartridge_wait_buckets_discovery
     - cartridge_wal_dir_parent
+    - cartridge_log_dir_parent
     - config
     - twophase_netbox_call_timeout
     - twophase_upload_config_timeout

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -60,6 +60,7 @@ Some of useful variables always establishes during role preparation, so them can
   - `memtx_dir` - path to memtx directory of instance;
   - `vinyl_dir` - path to vinyl directory of instance;
   - `wal_dir` - path to wal directory of instance;
+  - `log_file` - path to log file of instance;
   - `systemd_service` - name to systemd service;
   - `systemd_service_dir` - path to directory of systemd service extensions;
   - `systemd_service_env_file` - path to file of systemd service environment extensions;
@@ -123,9 +124,10 @@ Input variables from config:
 - `cartridge_app_group` - group which will own the links;
 - `cartridge_run_dir` - path to directory of instances sockets;
 - `cartridge_data_dir` - path to directory of instance data;
-- `cartridge_memtx_dir` - path to memtx directory of instance;
-- `cartridge_vinyl_dir` - path to vinyl directory of instance;
-- `cartridge_wal_dir` - path to wal directory of instance;
+- `cartridge_memtx_dir_parent` - path to memtx directory of instances;
+- `cartridge_vinyl_dir_parent` - path to vinyl directory of instances;
+- `cartridge_wal_dir_parent` - path to wal directory of instances;
+- `cartridge_log_dir_parent` - path to log directory of instances;
 - `cartridge_conf_dir` - path to directory of instances application configs;
 - `cartridge_app_install_dir` - path to directory with application distributions;
 - `cartridge_app_instances_dir` - path to directory with instances links to

--- a/doc/tgz.md
+++ b/doc/tgz.md
@@ -40,6 +40,7 @@ To configure them use
 * `cartridge_memtx_dir_parent` - directory where instances memtx directories are placed;
 * `cartridge_vinyl_dir_parent` - directory where instances vinyl directories are placed;
 * `cartridge_wal_dir_parent` - directory where instances WAL directories are placed;
+* `cartridge_log_dir_parent` - directory where instances logs are placed;
 * `cartridge_run_dir` - directory where PID and socket files are stored;
 * `cartridge_conf_dir` - path to instances configuration;
 * `cartridge_app_install_dir` - directory where application distributions are placed;

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -57,6 +57,7 @@ For more details see [scenario documentation](/doc/scenario.md).
 - `cartridge_memtx_dir_parent` (`string`): directory where instances memtx directories are placed;
 - `cartridge_vinyl_dir_parent` (`string`): directory where instances vinyl directories are placed;
 - `cartridge_wal_dir_parent` (`string`): directory where instances WAL directories are placed;
+- `cartridge_log_dir_parent` (`string`): directory where instances logs are placed;
 - `cartridge_run_dir`(`string`, default: `/var/run/tarantool`): directory where PID and socket files
   are stored;
 - `cartridge_conf_dir` (`string`, default: `/etc/tarantool/conf.d`): path to instances

--- a/library/cartridge_get_instance_info.py
+++ b/library/cartridge_get_instance_info.py
@@ -139,6 +139,16 @@ def get_instance_info(params):
         instance_info['paths_to_remove_on_expel'].add(instance_info['wal_dir'])
         instance_info['dirs_to_remove_on_cleanup'].add(instance_info['wal_dir'])
 
+    # instance log dir
+    instance_info['log_file'] = None
+    if instance_vars['cartridge_log_dir_parent']:
+        instance_info['log_file'] = helpers.get_instance_file(
+            instance_vars['cartridge_log_dir_parent'], app_name, instance_name,
+            instance_vars['stateboard'], extension='.log',
+        )
+        instance_info['paths_to_remove_on_expel'].add(instance_info['log_file'])
+        instance_info['files_to_remove_on_cleanup'].add(instance_info['log_file'])
+
     # systemd service name
     instance_info['systemd_service'] = get_instance_systemd_service(
         app_name, instance_name, instance_vars['stateboard']

--- a/library/cartridge_get_systemd_units_info.py
+++ b/library/cartridge_get_systemd_units_info.py
@@ -63,6 +63,16 @@ def get_systemd_units_info(params):
             instance_vars['cartridge_wal_dir_parent'], app_name, stateboard=True
         )
 
+    systemd_units_info['instance_log_file'] = None
+    systemd_units_info['stateboard_log_file'] = None
+    if instance_vars['cartridge_log_dir_parent']:
+        systemd_units_info['instance_log_file'] = helpers.get_instance_file(
+            instance_vars['cartridge_log_dir_parent'], app_name, instance_name="%i", extension='.log',
+        )
+        systemd_units_info['stateboard_log_file'] = helpers.get_instance_file(
+            instance_vars['cartridge_log_dir_parent'], app_name, stateboard=True, extension='.log',
+        )
+
     systemd_units_info['instance_pid_file'] = helpers.get_instance_pid_file(
         instance_vars['cartridge_run_dir'], app_name, instance_name="%i"
     )

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -148,6 +148,7 @@ SCHEMA = {
     'cartridge_memtx_dir_parent': str,
     'cartridge_vinyl_dir_parent': str,
     'cartridge_wal_dir_parent': str,
+    'cartridge_log_dir_parent': str,
     'cartridge_configure_systemd_unit_files': bool,
     'cartridge_systemd_dir': str,
     'cartridge_configure_tmpfiles': bool,

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -509,6 +509,11 @@ def get_instance_dir(data_dir, app_name, instance_name=None, stateboard=False):
     return os.path.join(data_dir, instance_id)
 
 
+def get_instance_file(data_dir, app_name, instance_name=None, stateboard=False, extension=''):
+    instance_id = get_instance_id(app_name, instance_name, stateboard)
+    return os.path.join(data_dir, instance_id + extension)
+
+
 def get_multiversion_instance_code_dir(instances_dir, app_name, instance_name=None, stateboard=False):
     instance_id = get_instance_id(app_name, instance_name, stateboard)
     return os.path.join(instances_dir, instance_id)
@@ -713,6 +718,7 @@ class Helpers:
     get_instance_console_sock = staticmethod(get_instance_console_sock)
     get_instance_pid_file = staticmethod(get_instance_pid_file)
     get_instance_dir = staticmethod(get_instance_dir)
+    get_instance_file = staticmethod(get_instance_file)
     get_multiversion_instance_code_dir = staticmethod(get_multiversion_instance_code_dir)
     box_cfg_was_called = staticmethod(box_cfg_was_called)
     get_box_cfg = staticmethod(get_box_cfg)

--- a/molecule/backup/hosts.yml
+++ b/molecule/backup/hosts.yml
@@ -69,6 +69,7 @@ cluster:
         cartridge_memtx_dir_parent: /opt/memtx
         cartridge_vinyl_dir_parent: /opt/vinyl
         cartridge_wal_dir_parent: /opt/wal
+        cartridge_log_dir_parent: /opt/log
 
         cartridge_run_dir: /opt/run
         cartridge_conf_dir: /opt/conf.d

--- a/molecule/cleanup_instance/hosts.yml
+++ b/molecule/cleanup_instance/hosts.yml
@@ -95,6 +95,7 @@ all:
             cartridge_memtx_dir_parent: /opt/memtx
             cartridge_vinyl_dir_parent: /opt/vinyl
             cartridge_wal_dir_parent: /opt/wal
+            cartridge_log_dir_parent: /opt/log
             cartridge_conf_dir: /opt/conf.d
             cartridge_app_install_dir: /opt/install
             cartridge_app_instances_dir: /opt/instances

--- a/molecule/default/hosts.yml
+++ b/molecule/default/hosts.yml
@@ -145,6 +145,7 @@ all:
             cartridge_memtx_dir_parent: /opt/memtx
             cartridge_vinyl_dir_parent: /opt/vinyl
             cartridge_wal_dir_parent: /opt/wal
+            cartridge_log_dir_parent: /opt/log
             cartridge_conf_dir: /opt/conf.d
             cartridge_app_install_dir: /opt/install
             cartridge_app_instances_dir: /opt/instances

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -43,6 +43,7 @@
       cartridge_memtx_dir_parent: '{{ cartridge_memtx_dir_parent }}'
       cartridge_vinyl_dir_parent: '{{ cartridge_vinyl_dir_parent }}'
       cartridge_wal_dir_parent: '{{ cartridge_wal_dir_parent }}'
+      cartridge_log_dir_parent: '{{ cartridge_log_dir_parent }}'
       cartridge_tmpfiles_dir: '{{ cartridge_tmpfiles_dir }}'
       cartridge_multiversion: '{{ cartridge_multiversion }}'
       stateboard: '{{ stateboard }}'

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -41,6 +41,7 @@
       cartridge_memtx_dir_parent: '{{ cartridge_memtx_dir_parent }}'
       cartridge_vinyl_dir_parent: '{{ cartridge_vinyl_dir_parent }}'
       cartridge_wal_dir_parent: '{{ cartridge_wal_dir_parent }}'
+      cartridge_log_dir_parent: '{{ cartridge_log_dir_parent }}'
       cartridge_run_dir: '{{ cartridge_run_dir }}'
       cartridge_conf_dir: '{{ cartridge_conf_dir }}'
       cartridge_app_install_dir: '{{ cartridge_app_install_dir }}'

--- a/tasks/steps/blocks/create_systemd_unit_files.yml
+++ b/tasks/steps/blocks/create_systemd_unit_files.yml
@@ -13,6 +13,7 @@
       cartridge_memtx_dir_parent: '{{ cartridge_memtx_dir_parent }}'
       cartridge_vinyl_dir_parent: '{{ cartridge_vinyl_dir_parent }}'
       cartridge_wal_dir_parent: '{{ cartridge_wal_dir_parent }}'
+      cartridge_log_dir_parent: '{{ cartridge_log_dir_parent }}'
   register: systemd_units_info_res
 
 - name: 'Set "systemd_units_info" fact'

--- a/tasks/steps/blocks/unpack_tgz.yml
+++ b/tasks/steps/blocks/unpack_tgz.yml
@@ -38,6 +38,7 @@
       cartridge_memtx_dir_parent,
       cartridge_vinyl_dir_parent,
       cartridge_wal_dir_parent,
+      cartridge_log_dir_parent,
       cartridge_conf_dir,
       cartridge_app_install_dir,
       cartridge_app_instances_dir,

--- a/templates/app-stateboard.service.j2
+++ b/templates/app-stateboard.service.j2
@@ -32,6 +32,11 @@ Environment=TARANTOOL_VINYL_DIR={{ systemd_units_info.stateboard_vinyl_dir }}
 ExecStartPre=/bin/sh -c 'mkdir -p {{ systemd_units_info.stateboard_wal_dir }}'
 Environment=TARANTOOL_WAL_DIR={{ systemd_units_info.stateboard_wal_dir }}
 {% endif %}
+{% if systemd_units_info.stateboard_log_file %}
+
+ExecStartPre=/bin/sh -c 'mkdir -p $(dirname {{ systemd_units_info.stateboard_log_file }})'
+Environment=TARANTOOL_LOG={{ systemd_units_info.stateboard_log_file }}
+{% endif %}
 
 # Unlimited cores size
 LimitCORE=infinity

--- a/templates/app@.service.j2
+++ b/templates/app@.service.j2
@@ -33,6 +33,11 @@ Environment=TARANTOOL_VINYL_DIR={{ systemd_units_info.instance_vinyl_dir }}
 ExecStartPre=/bin/sh -c 'mkdir -p {{ systemd_units_info.instance_wal_dir }}'
 Environment=TARANTOOL_WAL_DIR={{ systemd_units_info.instance_wal_dir }}
 {% endif %}
+{% if systemd_units_info.instance_log_file %}
+
+ExecStartPre=/bin/sh -c 'mkdir -p $(dirname {{ systemd_units_info.instance_log_file }})'
+Environment=TARANTOOL_LOG={{ systemd_units_info.instance_log_file }}
+{% endif %}
 
 # Unlimited cores size
 LimitCORE=infinity

--- a/unit/test_get_instance_info.py
+++ b/unit/test_get_instance_info.py
@@ -99,6 +99,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': 'some/memtx/dir',
             'cartridge_vinyl_dir_parent': 'some/vinyl/dir',
             'cartridge_wal_dir_parent': 'some/wal/dir',
+            'cartridge_log_dir_parent': 'some/log/dir',
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -118,6 +119,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'memtx_dir': 'some/memtx/dir/myapp.instance-1',
             'vinyl_dir': 'some/vinyl/dir/myapp.instance-1',
             'wal_dir': 'some/wal/dir/myapp.instance-1',
+            'log_file': 'some/log/dir/myapp.instance-1.log',
             'systemd_service': 'myapp@instance-1',
             'systemd_service_dir': 'some/systemd/dir/myapp@instance-1.service.d',
             'systemd_service_env_file': 'some/systemd/dir/myapp@instance-1.service.d/env.conf',
@@ -127,6 +129,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'paths_to_remove_on_expel': [
                 'some/conf/dir/myapp.instance-1.yml',
                 'some/data/dir/myapp.instance-1',
+                'some/log/dir/myapp.instance-1.log',
                 'some/memtx/dir/myapp.instance-1',
                 'some/run/dir/myapp.instance-1.control',
                 'some/run/dir/myapp.instance-1.pid',
@@ -134,6 +137,7 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/wal/dir/myapp.instance-1',
             ],
             'files_to_remove_on_cleanup': [
+                'some/log/dir/myapp.instance-1.log',
                 'some/run/dir/myapp.instance-1.control',
                 'some/run/dir/myapp.instance-1.pid',
             ],
@@ -159,6 +163,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': None,
             'cartridge_vinyl_dir_parent': None,
             'cartridge_wal_dir_parent': None,
+            'cartridge_log_dir_parent': None,
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -178,6 +183,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'memtx_dir': None,
             'vinyl_dir': None,
             'wal_dir': None,
+            'log_file': None,
             'systemd_service': 'myapp@instance-1',
             'systemd_service_dir': 'some/systemd/dir/myapp@instance-1.service.d',
             'systemd_service_env_file': 'some/systemd/dir/myapp@instance-1.service.d/env.conf',
@@ -210,6 +216,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': None,
             'cartridge_vinyl_dir_parent': None,
             'cartridge_wal_dir_parent': None,
+            'cartridge_log_dir_parent': None,
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -229,6 +236,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'memtx_dir': None,
             'vinyl_dir': None,
             'wal_dir': None,
+            'log_file': None,
             'systemd_service': 'myapp@instance-1',
             'systemd_service_dir': 'some/systemd/dir/myapp@instance-1.service.d',
             'systemd_service_env_file': 'some/systemd/dir/myapp@instance-1.service.d/env.conf',
@@ -264,6 +272,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': None,
             'cartridge_vinyl_dir_parent': None,
             'cartridge_wal_dir_parent': None,
+            'cartridge_log_dir_parent': None,
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -283,6 +292,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'memtx_dir': None,
             'vinyl_dir': None,
             'wal_dir': None,
+            'log_file': None,
             'systemd_service': 'myapp-stateboard',
             'systemd_service_dir': 'some/systemd/dir/myapp-stateboard.service.d',
             'systemd_service_env_file': 'some/systemd/dir/myapp-stateboard.service.d/env.conf',
@@ -318,6 +328,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': 'some/memtx/dir',
             'cartridge_vinyl_dir_parent': 'some/vinyl/dir',
             'cartridge_wal_dir_parent': 'some/wal/dir',
+            'cartridge_log_dir_parent': 'some/log/dir',
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -337,6 +348,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'memtx_dir': 'some/memtx/dir/myapp-stateboard',
             'vinyl_dir': 'some/vinyl/dir/myapp-stateboard',
             'wal_dir': 'some/wal/dir/myapp-stateboard',
+            'log_file': 'some/log/dir/myapp-stateboard.log',
             'systemd_service': 'myapp-stateboard',
             'systemd_service_dir': 'some/systemd/dir/myapp-stateboard.service.d',
             'systemd_service_env_file': 'some/systemd/dir/myapp-stateboard.service.d/env.conf',
@@ -346,6 +358,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'paths_to_remove_on_expel': [
                 'some/conf/dir/myapp-stateboard.yml',
                 'some/data/dir/myapp-stateboard',
+                'some/log/dir/myapp-stateboard.log',
                 'some/memtx/dir/myapp-stateboard',
                 'some/run/dir/myapp-stateboard.control',
                 'some/run/dir/myapp-stateboard.pid',
@@ -353,6 +366,7 @@ class TestGetInstanceInfo(unittest.TestCase):
                 'some/wal/dir/myapp-stateboard',
             ],
             'files_to_remove_on_cleanup': [
+                'some/log/dir/myapp-stateboard.log',
                 'some/run/dir/myapp-stateboard.control',
                 'some/run/dir/myapp-stateboard.pid',
             ],
@@ -378,6 +392,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': 'some/memtx/dir',
             'cartridge_vinyl_dir_parent': 'some/vinyl/dir',
             'cartridge_wal_dir_parent': 'some/wal/dir',
+            'cartridge_log_dir_parent': 'some/log/dir',
             'cartridge_app_install_dir': 'some/install/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
             'cartridge_tmpfiles_dir': '/some/tmpfiles/dir',
@@ -387,6 +402,7 @@ class TestGetInstanceInfo(unittest.TestCase):
 
         res = call_get_instance_info(app_name, instance_name, instance_vars)
         self.assertEqual(res.fact['files_to_remove_on_cleanup'], [
+            'some/log/dir/myapp.instance-1.log',
             'some/run/dir/myapp.instance-1.control',
             'some/run/dir/myapp.instance-1.pid',
         ])
@@ -404,7 +420,9 @@ class TestGetInstanceInfo(unittest.TestCase):
             r'*/vinyl/dir/*',
         ])
         self.assertFalse(res.failed)
-        self.assertEqual(res.fact['files_to_remove_on_cleanup'], [])
+        self.assertEqual(res.fact['files_to_remove_on_cleanup'], [
+            'some/log/dir/myapp.instance-1.log',
+        ])
         self.assertEqual(res.fact['dirs_to_remove_on_cleanup'], [
             'some/memtx/dir/myapp.instance-1',
             'some/wal/dir/myapp.instance-1',
@@ -418,6 +436,7 @@ class TestGetInstanceInfo(unittest.TestCase):
         ])
         self.assertFalse(res.failed)
         self.assertEqual(res.fact['files_to_remove_on_cleanup'], [
+            'some/log/dir/myapp.instance-1.log',
             'some/run/dir/myapp.instance-1.control',
             'some/run/dir/myapp.instance-1.pid',
         ])

--- a/unit/test_get_systemd_units_info.py
+++ b/unit/test_get_systemd_units_info.py
@@ -29,6 +29,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': 'some/memtx/dir',
             'cartridge_vinyl_dir_parent': 'some/vinyl/dir',
             'cartridge_wal_dir_parent': 'some/wal/dir',
+            'cartridge_log_dir_parent': 'some/log/dir',
             'dist_dir': '/some/dist/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
         }
@@ -52,6 +53,9 @@ class TestGetInstanceInfo(unittest.TestCase):
 
             'instance_wal_dir': 'some/wal/dir/myapp.%i',
             'stateboard_wal_dir': 'some/wal/dir/myapp-stateboard',
+
+            'instance_log_file': 'some/log/dir/myapp.%i.log',
+            'stateboard_log_file': 'some/log/dir/myapp-stateboard.log',
 
             'instance_pid_file': 'some/run/dir/myapp.%i.pid',
             'stateboard_pid_file': 'some/run/dir/myapp-stateboard.pid',
@@ -75,6 +79,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': None,
             'cartridge_vinyl_dir_parent': None,
             'cartridge_wal_dir_parent': None,
+            'cartridge_log_dir_parent': None,
             'dist_dir': '/some/dist/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
         }
@@ -99,6 +104,9 @@ class TestGetInstanceInfo(unittest.TestCase):
             'instance_wal_dir': None,
             'stateboard_wal_dir': None,
 
+            'instance_log_file': None,
+            'stateboard_log_file': None,
+
             'instance_pid_file': 'some/run/dir/myapp.%i.pid',
             'stateboard_pid_file': 'some/run/dir/myapp-stateboard.pid',
             'instance_console_sock': 'some/run/dir/myapp.%i.control',
@@ -121,6 +129,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': 'some/memtx/dir',
             'cartridge_vinyl_dir_parent': 'some/vinyl/dir',
             'cartridge_wal_dir_parent': 'some/wal/dir',
+            'cartridge_log_dir_parent': 'some/log/dir',
             'dist_dir': 'some/dist/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
         }
@@ -145,6 +154,9 @@ class TestGetInstanceInfo(unittest.TestCase):
             'instance_wal_dir': 'some/wal/dir/myapp.%i',
             'stateboard_wal_dir': 'some/wal/dir/myapp-stateboard',
 
+            'instance_log_file': 'some/log/dir/myapp.%i.log',
+            'stateboard_log_file': 'some/log/dir/myapp-stateboard.log',
+
             'instance_pid_file': 'some/run/dir/myapp.%i.pid',
             'stateboard_pid_file': 'some/run/dir/myapp-stateboard.pid',
             'instance_console_sock': 'some/run/dir/myapp.%i.control',
@@ -167,6 +179,7 @@ class TestGetInstanceInfo(unittest.TestCase):
             'cartridge_memtx_dir_parent': None,
             'cartridge_vinyl_dir_parent': None,
             'cartridge_wal_dir_parent': None,
+            'cartridge_log_dir_parent': None,
             'dist_dir': 'some/dist/dir',
             'cartridge_app_instances_dir': 'some/instances/dir',
         }
@@ -190,6 +203,9 @@ class TestGetInstanceInfo(unittest.TestCase):
 
             'instance_wal_dir': None,
             'stateboard_wal_dir': None,
+
+            'instance_log_file': None,
+            'stateboard_log_file': None,
 
             'instance_pid_file': 'some/run/dir/myapp.%i.pid',
             'stateboard_pid_file': 'some/run/dir/myapp-stateboard.pid',

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -61,6 +61,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_memtx_dir_parent',
                 'cartridge_vinyl_dir_parent',
                 'cartridge_wal_dir_parent',
+                'cartridge_log_dir_parent',
                 'cartridge_systemd_dir',
                 'cartridge_tmpfiles_dir',
                 'zone',


### PR DESCRIPTION
Closes #378

Before this patch, it was not possible to specify a directory for storing instance logs.

Now you can specify the parent directory for logs, it will be automatically created,
and inside it there will be log files for all instances from current machine.