### PR TITLE
Fix backup folder permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ README.md to use the newest tag with new release
 - Optimize `Set instance facts` step
 - Optimize facts caching
 - Fixed the ability to roll back to the previous TGZ package
+- Fixed backup folder permissions
 
 ## [1.11.0] - 2021-07-30
 

--- a/doc/backups.md
+++ b/doc/backups.md
@@ -188,7 +188,7 @@ Let's imagine that we want to archive backup files not for each instance, but fo
         owner: '{{ cartridge_app_user }}'
         group: '{{ cartridge_app_group }}'
         state: directory
-        mode: 0660
+        mode: 0750
 
     - name: 'Start backup'
       import_role:

--- a/tasks/steps/backup.yml
+++ b/tasks/steps/backup.yml
@@ -6,7 +6,7 @@
     owner: '{{ cartridge_app_user }}'
     group: '{{ cartridge_app_group }}'
     state: directory
-    mode: 0660
+    mode: 0750
   when: inventory_hostname in single_instances_for_each_machine
 
 - name: 'Create instance backup archive'


### PR DESCRIPTION
Before the patch, it was impossible to backup data by a non-root user,
because the backup folder had permissions 660, which did not allow the directory to be read.

Now 750 permissions are used, so the folder can be read by the owner user or owner group.