### PR TITLE
Fix templates of systemd units for TGZ packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ README.md to use the newest tag with new release
 - Optimize facts caching
 - Fixed the ability to roll back to the previous TGZ package
 - Fixed backup folder permissions
+- Fixed templates of systemd units for TGZ packages
 
 ## [1.11.0] - 2021-07-30
 

--- a/templates/app-stateboard.service.j2
+++ b/templates/app-stateboard.service.j2
@@ -7,8 +7,8 @@ Type=simple
 ExecStart=/usr/bin/env {{ systemd_units_info.stateboard_tarantool_binary }} {{ systemd_units_info.stateboard_entrypoint }}
 Restart=on-failure
 RestartSec=2
-User=tarantool
-Group=tarantool
+User={{ cartridge_app_user }}
+Group={{ cartridge_app_group }}
 
 Environment=TARANTOOL_APP_NAME={{ systemd_units_info.stateboard_name }}
 Environment=TARANTOOL_CFG={{ cartridge_conf_dir }}

--- a/templates/app@.service.j2
+++ b/templates/app@.service.j2
@@ -7,8 +7,8 @@ Type=simple
 ExecStart=/usr/bin/env {{ systemd_units_info.instance_tarantool_binary }} {{ systemd_units_info.instance_entrypoint }}
 Restart=on-failure
 RestartSec=2
-User=tarantool
-Group=tarantool
+User={{ cartridge_app_user }}
+Group={{ cartridge_app_group }}
 
 Environment=TARANTOOL_APP_NAME={{ cartridge_app_name }}
 Environment=TARANTOOL_CFG={{ cartridge_conf_dir }}


### PR DESCRIPTION
Closes #391

Before the patch, systemd files used the `tarantool` user and the `tarantool` group.

Not, this uses the value of the `cartridge_app_user` and `cartridge_app_group` variables.