### PR TITLE
Add the ability to choose a control instance among the leaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ README.md to use the newest tag with new release
 ### Added
 
 - Add `cartridge_log_dir_parent` to configure directory of logs
+- Add `cartridge_force_leader_control_instance` variable to choose a control
+  instance among the leaders
 
 ### Fixed
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
 cartridge_ignore_split_brain: false
 cartridge_paths_to_keep_on_cleanup: []
-cartridge_only_leader_controls: false
+cartridge_force_leader_control_instance: false
 
 # Role scenario configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ cartridge_not_save_cookie_in_app_config: false
 cartridge_remove_temporary_files: false
 cartridge_ignore_split_brain: false
 cartridge_paths_to_keep_on_cleanup: []
+cartridge_only_leader_controls: false
 
 # Role scenario configuration
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -236,7 +236,8 @@ This is instance that is:
   otherwise, any instance that should be joined during current play is chosen;
 * control instance should have minimal Cartridge version across all suitable
   instances (because Cartridge two-phase commit should be called by instance
-  that has lowest version).
+  that has lowest version);
+* control instance should be a leader if `cartridge_only_leader_controls` is set.
 
 Steps that require control instance (such as [`edit_topology`](#step-edit_topology))
 call `set_control_instance` implicitly if `control_instance` variable isn't set.
@@ -251,6 +252,7 @@ Input variables from config:
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `replicaset_alias` - replicaset alias, will be displayed in Web UI;
+- `cartridge_only_leader_controls` - indicates that only a leader can be selected as a control instance.
 
 Output variables:
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -237,7 +237,7 @@ This is instance that is:
 * control instance should have minimal Cartridge version across all suitable
   instances (because Cartridge two-phase commit should be called by instance
   that has lowest version);
-* control instance should be a leader if `cartridge_only_leader_controls` is set.
+* control instance is a leader if `cartridge_force_leader_control_instance` is set.
 
 Steps that require control instance (such as [`edit_topology`](#step-edit_topology))
 call `set_control_instance` implicitly if `control_instance` variable isn't set.
@@ -252,7 +252,7 @@ Input variables from config:
 - `expelled` - indicates if instance must be expelled from topology;
 - `stateboard` - indicates that the instance is a stateboard;
 - `replicaset_alias` - replicaset alias, will be displayed in Web UI;
-- `cartridge_only_leader_controls` - indicates that only a leader can be selected as a control instance.
+- `cartridge_force_leader_control_instance` - indicates that only a leader can be selected as a control instance.
 
 Output variables:
 

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -18,7 +18,7 @@ failover.
   absolute or relative to `work/memtx/vinyl/wal` directory that should be kept on instance
   cleanup (`config` and` .tarantool.cookie` will be kept independently of this variable); it's
   possible to use bash patterns, e.g. `*.control`;
-- `cartridge_only_leader_controls` (`boolean`, default: `false`): flag indicates that only a leader
+- `cartridge_force_leader_control_instance` (`boolean`, default: `false`): flag indicates that only a leader
   can be selected as a control instance.
 
 ## Role scenario configuration

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -17,7 +17,9 @@ failover.
 - `cartridge_paths_to_keep_on_cleanup` (`list-of-strings`, default: `[]`): list of paths that are
   absolute or relative to `work/memtx/vinyl/wal` directory that should be kept on instance
   cleanup (`config` and` .tarantool.cookie` will be kept independently of this variable); it's
-  possible to use bash patterns, e.g. `*.control`.
+  possible to use bash patterns, e.g. `*.control`;
+- `cartridge_only_leader_controls` (`boolean`, default: `false`): flag indicates that only a leader
+  can be selected as a control instance.
 
 ## Role scenario configuration
 

--- a/library/cartridge_failover_promote.py
+++ b/library/cartridge_failover_promote.py
@@ -34,14 +34,6 @@ def check_leaders_promotion_is_possible(control_console):
     return None
 
 
-def get_active_leaders(control_console):
-    active_leaders, _ = control_console.eval_res_err('''
-        return require('cartridge.failover').get_active_leaders()
-    ''')
-
-    return active_leaders
-
-
 def call_failover_promote(control_console, replicaset_leaders, force_inconsistency):
     opts = {
         'force_inconsistency': force_inconsistency,
@@ -184,7 +176,7 @@ def failover_promote(params):
     # set two-phase commit opts
     helpers.set_twophase_options_from_params(control_console, params)
 
-    active_leaders = get_active_leaders(control_console)
+    active_leaders, _ = helpers.get_active_leaders(control_console)
 
     _, err = call_failover_promote(control_console, replicaset_leaders, force_inconsistency)
     if err is not None:
@@ -194,7 +186,7 @@ def failover_promote(params):
             warnings=critical_warnings,
         )
 
-    new_active_leaders = get_active_leaders(control_console)
+    new_active_leaders, _ = helpers.get_active_leaders(control_console)
 
     if critical_warnings:
         return helpers.ModuleRes(

--- a/module_utils/helpers.py
+++ b/module_utils/helpers.py
@@ -647,10 +647,17 @@ def patch_clusterwide_config(control_console, new_sections):
     return True, None
 
 
-def enrich_replicasets_with_leaders(control_console, replicasets):
+def get_active_leaders(control_console):
     leaders, err = control_console.eval_res_err('''
         return require('cartridge.failover').get_active_leaders()
     ''')
+    if err is None and not leaders:
+        leaders = {}
+    return leaders, err
+
+
+def enrich_replicasets_with_leaders(control_console, replicasets):
+    leaders, err = get_active_leaders(control_console)
     if err:
         return err
 
@@ -754,6 +761,7 @@ class Helpers:
     read_yaml_file = staticmethod(read_yaml_file)
     get_clusterwide_config = staticmethod(get_clusterwide_config)
     patch_clusterwide_config = staticmethod(patch_clusterwide_config)
+    get_active_leaders = staticmethod(get_active_leaders)
     enrich_replicasets_with_leaders = staticmethod(enrich_replicasets_with_leaders)
     get_disabled_instances = staticmethod(get_disabled_instances)
     get_topology_checksum = staticmethod(get_topology_checksum)

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -150,6 +150,7 @@
 
       # Edit topology check
 
+      cartridge_only_leader_controls: '{{ cartridge_only_leader_controls }}'
       cartridge_force_advertise_uris_change: '{{ cartridge_force_advertise_uris_change }}'
       cartridge_ignore_extra_cluster_instances: '{{ cartridge_ignore_extra_cluster_instances }}'
       cartridge_ignore_extra_cluster_replicasets: '{{ cartridge_ignore_extra_cluster_replicasets }}'

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -150,7 +150,7 @@
 
       # Edit topology check
 
-      cartridge_only_leader_controls: '{{ cartridge_only_leader_controls }}'
+      cartridge_force_leader_control_instance: '{{ cartridge_force_leader_control_instance }}'
       cartridge_force_advertise_uris_change: '{{ cartridge_force_advertise_uris_change }}'
       cartridge_ignore_extra_cluster_instances: '{{ cartridge_ignore_extra_cluster_instances }}'
       cartridge_ignore_extra_cluster_replicasets: '{{ cartridge_ignore_extra_cluster_replicasets }}'

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -10,6 +10,7 @@
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ alive_not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'
+    leader_only: '{{ cartridge_only_leader_controls }}'
   run_once: true
   delegate_to: '{{ alive_not_expelled_instance.name }}'
   register: control_instance_res

--- a/tasks/steps/blocks/set_control_instance.yml
+++ b/tasks/steps/blocks/set_control_instance.yml
@@ -10,7 +10,7 @@
     play_hosts: '{{ play_hosts }}'
     console_sock: '{{ alive_not_expelled_instance.console_sock }}'
     app_name: '{{ cartridge_app_name }}'
-    leader_only: '{{ cartridge_only_leader_controls }}'
+    leader_only: '{{ cartridge_force_leader_control_instance }}'
   run_once: true
   delegate_to: '{{ alive_not_expelled_instance.name }}'
   register: control_instance_res

--- a/unit/test_get_control_instance.py
+++ b/unit/test_get_control_instance.py
@@ -501,7 +501,7 @@ class TestGetControlInstance(unittest.TestCase):
         ])
         res = call_get_control_instance('myapp', self.console_sock, hostvars, leader_only=True)
         self.assertTrue(res.failed)
-        self.assertIn("There is no alive instances in the cluster", res.msg)
+        self.assertIn("Not found any leader instance between the candidates: instance-1-uri, instance-3-uri", res.msg)
 
     def tearDown(self):
         self.instance.stop()


### PR DESCRIPTION
Closes #396

Before the patch, the control instance was chosen among all live instances.

Now added the ability to select a control instance only among leaders
using the `cartridge_force_leader_control_instance` flag