### PR TITLE
Add `cartridge_app_config_upload_http_timeout` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ README.md to use the newest tag with new release
 - Fixed backup folder permissions
 - Handle empty values in `helpers.py`
 - Fixed templates of systemd units for TGZ packages
+- The `upload_config_timeout` variable is used in the `upload_app_config` step
 
 ## [1.11.0] - 2021-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ README.md to use the newest tag with new release
 - Add `cartridge_log_dir_parent` to configure directory of logs
 - Add `cartridge_force_leader_control_instance` variable to choose a control
   instance among the leaders
+- Add `cartridge_app_config_upload_http_timeout` variable to configure timeout to
+  wait config upload in HTTP mode.
 
 ### Fixed
 
@@ -24,7 +26,7 @@ README.md to use the newest tag with new release
 - Fixed backup folder permissions
 - Handle empty values in `helpers.py`
 - Fixed templates of systemd units for TGZ packages
-- The `upload_config_timeout` variable is used in the `upload_app_config` step
+- The twophase timeouts is used in the `upload_app_config` step
 
 ## [1.11.0] - 2021-07-30
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,6 +102,7 @@ cartridge_app_config: null
 cartridge_app_config_path: null
 cartridge_app_config_upload_mode: null
 cartridge_app_config_upload_url: null
+cartridge_app_config_upload_http_timeout: 30
 cartridge_tdg_token: null
 
 cartridge_auth: null

--- a/doc/app_config.md
+++ b/doc/app_config.md
@@ -121,6 +121,9 @@ which is on the same machine as the control instance:
 cartridge_app_config_upload_url: 'http://10.0.0.102:8083/admin/config'
 ```
 
+If you have a large configuration or slow connection, you can increase
+the upload timeout with `cartridge_app_config_upload_http_timeout` variable.
+
 **Note** that directory uploading by HTTP mode is not yet supported.
 
 ### TDG mode

--- a/doc/app_config.md
+++ b/doc/app_config.md
@@ -122,7 +122,7 @@ cartridge_app_config_upload_url: 'http://10.0.0.102:8083/admin/config'
 ```
 
 If you have a large configuration or slow connection, you can increase
-the upload timeout with `cartridge_app_config_upload_http_timeout` variable.
+the upload timeout with `cartridge_app_config_upload_http_timeout` variable (default is `30`).
 
 **Note** that directory uploading by HTTP mode is not yet supported.
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -332,6 +332,7 @@ Input variables from config:
 - `cartridge_app_config_upload_url` - url of instance to upload config
   (`http://127.0.0.1:{control_instance.http_port}/admin/config` by default);
 - `cartridge_cluster_cookie` - cluster cookie for all cluster instances;
+- `cartridge_app_config_upload_http_timeout` - time in seconds to wait config upload in HTTP mode;
 - `cartridge_tdg_token` - token to upload config by HTTP in TDG.
 
 ## Step `configure_app_config`

--- a/doc/variables.md
+++ b/doc/variables.md
@@ -158,6 +158,7 @@ For more details see [scenario documentation](/doc/scenario.md).
 - `cartridge_app_config_upload_mode` (`string`): mode of config uploading (`lua`, `http` or `tdg`);
 - `cartridge_app_config_upload_url` (`string`): url of instance to upload
   config (`http://127.0.0.1:{control_instance.http_port}/admin/config` by default);
+- `cartridge_app_config_upload_http_timeout` (`number`, default: `30`): time in seconds to wait config upload in HTTP mode;
 - `cartridge_tdg_token` (`string`): token to upload config by HTTP in TDG;
 - `cartridge_auth`: (`dict`): [authorization configuration](/doc/auth.md);
 - `cartridge_failover_params` (`dict`): [failover](/doc/failover.md) parameters;

--- a/molecule/config_upload/converge.yml
+++ b/molecule/config_upload/converge.yml
@@ -27,6 +27,7 @@
         cartridge_app_config_path: './configs/config.yml'
         cartridge_app_config_upload_mode: null
         cartridge_app_config_upload_url: 'http://vm1:3301/admin/config'
+        cartridge_app_config_upload_http_timeout: 30
         expected_test_section: {config-file-key: yml}
 
     - name: 'Upload YAML config by Lua'
@@ -36,6 +37,7 @@
         cartridge_app_config_path: './configs/config.yaml'
         cartridge_app_config_upload_mode: null
         cartridge_app_config_upload_url: 'http://vm1:3302/admin/config'
+        cartridge_app_config_upload_http_timeout: 30
         expected_test_section: {config-file-key: yaml}
 
     # File config to Cartridge by HTTP
@@ -47,6 +49,7 @@
         cartridge_app_config_path: './configs/config.yml'
         cartridge_app_config_upload_mode: 'http'
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
         expected_test_section: {config-file-key: yml}
 
     - name: 'Upload YAML config by HTTP'
@@ -56,6 +59,7 @@
         cartridge_app_config_path: './configs/config.yaml'
         cartridge_app_config_upload_mode: 'http'
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
         expected_test_section: {config-file-key: yaml}
 
     ###############
@@ -72,6 +76,7 @@
         cartridge_app_config_path: './configs/config-yaml'
         cartridge_app_config_upload_mode: 'lua'
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
     - name: 'Check upload config failed'
       assert:
         fail_msg: 'Upload folder config by Lua should fail'
@@ -91,6 +96,7 @@
         cartridge_app_config_path: './configs/config-yml-json'
         cartridge_app_config_upload_mode: null
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
     - name: 'Check upload config failed'
       assert:
         fail_msg: 'Upload folder config by HTTP to Cartridge should fail'
@@ -110,6 +116,7 @@
         cartridge_app_config_path: './configs/config.yml'
         cartridge_app_config_upload_mode: 'tdg'
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
     - name: 'Check upload config failed'
       assert:
         fail_msg: 'Upload file config to Cartridge by TDG mode should fail'
@@ -129,9 +136,30 @@
         cartridge_app_config_path: './configs/config.zip'
         cartridge_app_config_upload_mode: 'tdg'
         cartridge_app_config_upload_url: null
+        cartridge_app_config_upload_http_timeout: 30
     - name: 'Check upload config failed'
       assert:
         fail_msg: 'Upload ZIP config to Cartridge by TDG mode should fail'
         success_msg: 'Upload ZIP config to Cartridge by TDG mode failed'
         that: apply_app_config_res.failed  # Here will be error from Cartridge
+      run_once: true
+
+    # HTTP timeout for upload
+
+    - name: 'Upload YML config by HTTP'
+      ignore_errors: true
+      import_role:
+        name: ansible-cartridge
+      vars:
+        cartridge_app_config_path: './configs/config.yml'
+        cartridge_app_config_upload_mode: 'http'
+        cartridge_app_config_upload_url: 'http://vm1:3301/admin/config'
+        cartridge_app_config_upload_http_timeout: 0
+    - name: 'Check upload config failed'
+      assert:
+        fail_msg: 'urlopen should raise error'
+        success_msg: 'urlopen raises error'
+        that:
+          - apply_app_config_res.failed
+          - '"urlopen error" in apply_app_config_res.msg'
       run_once: true

--- a/tasks/set_instance_facts.yml
+++ b/tasks/set_instance_facts.yml
@@ -104,6 +104,7 @@
       cartridge_app_config_path: '{{ cartridge_app_config_path }}'
       cartridge_app_config_upload_mode: '{{ cartridge_app_config_upload_mode }}'
       cartridge_app_config_upload_url: '{{ cartridge_app_config_upload_url }}'
+      cartridge_app_config_upload_http_timeout: '{{ cartridge_app_config_upload_http_timeout }}'
       cartridge_tdg_token: '{{ cartridge_tdg_token }}'
 
       cartridge_auth: '{{ cartridge_auth }}'

--- a/tasks/steps/upload_app_config.yml
+++ b/tasks/steps/upload_app_config.yml
@@ -28,6 +28,10 @@
         }}'
         cluster_cookie: '{{ cartridge_cluster_cookie }}'
         tdg_token: '{{ cartridge_tdg_token }}'
+        http_timeout: '{{ cartridge_app_config_upload_http_timeout }}'
+        netbox_call_timeout: '{{ twophase_netbox_call_timeout }}'
+        upload_config_timeout: '{{ twophase_upload_config_timeout }}'
+        apply_config_timeout: '{{ twophase_apply_config_timeout }}'
       register: apply_app_config_res
 
     - name: 'Add uploaded config to "temporary_files" fact'


### PR DESCRIPTION
Closes #401

Before the patch, in the `upload_app_config` step,
the default timeouts were used for the clusterwide config patch
and for uploading the config via HTTP.

Now, the `cartridge_app_config_upload_http_timeout` variable is used
as a config upload timeout for HTTP mode.

Also, the `upload_app_config` step currently uses `twophase_upload_config_timeout`,
`twophase_netbox_call_timeout` and `twophase_apply_config_timeout` variables.