### PR TITLE
Add new `skip_error_on_change` option to failover_promote

### DIFF
--- a/doc/rolling_update.md
+++ b/doc/rolling_update.md
@@ -29,6 +29,7 @@ should be used. It's a dictionary with fields:
 and leaders aliases;
 * `force_inconsistency` (`bool`): make promotion forcefully, don't wait for the
 consistent switchover.
+* `skip_error_on_change` (`bool`): skip etcd error in specific cases.
 
 This playbook says: **Promote leaders directly to these instances**:
 
@@ -45,6 +46,7 @@ This playbook says: **Promote leaders directly to these instances**:
       - failover_promote
     cartridge_failover_promote_params:
       force_inconsistency: true
+      skip_error_on_change: false
       replicaset_leaders:
         storage-1: storage-1-replica
         storage-2: storage-2-replica
@@ -58,6 +60,7 @@ parameters:
 
 * `force_inconsistency` (`bool`): make promotion forcefully, don't wait for the
 consistent switchover.
+* `skip_error_on_change` (`bool`): skip etcd error in specific cases.
 
 For example, you want to switch all leaders to data center 1.
 You have group `DC1` in your inventory that describes which instances belong to
@@ -91,6 +94,7 @@ This playbook says: **Promote leaders to instances from "DC1" group**:
     # can be additionally specified:
     cartridge_failover_promote_params:
       force_inconsistency: true
+      skip_error_on_change: true
 ```
 
 ## Rolling update: Plan

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -471,7 +471,7 @@ More details in [rolling update doc](/doc/rolling_update.md).
 Input variables from config:
 
 - `cartridge_failover_promote_params` - promote leaders params.
-  In variable, only `force_inconsistency` parameter is used (leaders are got from specified play hosts).
+  Only `force_inconsistency` and `skip_error_on_change` parameters are used (leaders are retrieved from specified play hosts).
   More details in [rolling update doc](/doc/rolling_update.md).
 
 ## Step `eval`

--- a/library/cartridge_failover_promote.py
+++ b/library/cartridge_failover_promote.py
@@ -34,9 +34,10 @@ def check_leaders_promotion_is_possible(control_console):
     return None
 
 
-def call_failover_promote(control_console, replicaset_leaders, force_inconsistency):
+def call_failover_promote(control_console, replicaset_leaders, force_inconsistency, skip_error_on_change):
     opts = {
         'force_inconsistency': force_inconsistency,
+        'skip_error_on_change': skip_error_on_change,
     }
     return control_console.eval_res_err('''
         return require('cartridge').failover_promote(...)
@@ -172,13 +173,14 @@ def failover_promote(params):
         return helpers.ModuleRes(changed=False)
 
     force_inconsistency = failover_promote_params.get('force_inconsistency')
+    skip_error_on_change = failover_promote_params.get('skip_error_on_change')
 
     # set two-phase commit opts
     helpers.set_twophase_options_from_params(control_console, params)
 
     active_leaders, _ = helpers.get_active_leaders(control_console)
 
-    _, err = call_failover_promote(control_console, replicaset_leaders, force_inconsistency)
+    _, err = call_failover_promote(control_console, replicaset_leaders, force_inconsistency, skip_error_on_change)
     if err is not None:
         return helpers.ModuleRes(
             failed=True,

--- a/library/cartridge_validate_config.py
+++ b/library/cartridge_validate_config.py
@@ -226,6 +226,7 @@ SCHEMA = {
     'cartridge_failover_promote_params': {
         'replicaset_leaders': dict,
         'force_inconsistency': bool,
+        'skip_error_on_change': bool,
     },
     'allowed_members_states': [str],
     'wait_members_alive_retries': int,

--- a/unit/test_failover_promote.py
+++ b/unit/test_failover_promote.py
@@ -241,7 +241,7 @@ class TestFailoverPromote(unittest.TestCase):
             },
         }
         if force_inconsistency:
-            params.update({'force_inconsistency': True})
+            params.update({'force_inconsistency': True, 'skip_error_on_change': True})
 
         res = call_failover_promote(
             self.console_sock,
@@ -260,6 +260,7 @@ class TestFailoverPromote(unittest.TestCase):
 
         exp_opts = {
             'force_inconsistency': True if force_inconsistency is True else None,
+            'skip_error_on_change': True if force_inconsistency is True else None,
         }
         self.assertEqual(calls[0], [exp_replicaset_leaders_params, exp_opts])
 

--- a/unit/test_validate_config.py
+++ b/unit/test_validate_config.py
@@ -1096,6 +1096,7 @@ class TestValidateConfig(unittest.TestCase):
                 'cartridge_failover_promote_params': {
                     'replicaset_leaders': {'rpl-1': 'instance-2'},
                     'force_inconsistency': False,
+                    'skip_error_on_change': False,
                 },
             },
         })


### PR DESCRIPTION
**NOTE: merge only after next cartridge release -- 2.7.4 or 2.8**

See https://github.com/tarantool/cartridge/pull/1772 for details