### PR TITLE
Allow to downgrade RPM and DEB install by `update_package` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ README.md to use the newest tag with new release
 ### Fixed
 
 - Remove old app configurations before uploading a new one
+- Allow to downgrade RPMs and DEBs
 
 ## [1.12.0] - 2022-03-03
 

--- a/tasks/steps/blocks/install_rpm_or_deb.yml
+++ b/tasks/steps/blocks/install_rpm_or_deb.yml
@@ -5,6 +5,7 @@
   yum:
     name: '{{ delivered_package_path }}'
     state: present
+    allow_downgrade: true
     update_cache: true
   register: install_rpm
   failed_when:
@@ -16,6 +17,8 @@
   any_errors_fatal: true
   apt:
     deb: '{{ delivered_package_path }}'
+    state: present
+    force: true  # `allow_downgrade` is supported in Ansible 2.12+ only
     update_cache: true
   when: package_info.type == 'deb'
 


### PR DESCRIPTION
Before this patch, it was not possible to downgrade the package.

Now the `update_package` step will also install the package with the old version.
