### PR TITLE
Ignore expelled instance in `cartridge_get_disabled_instances`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ README.md to use the newest tag with new release
 ### Fixed
 
 - Remove old app configurations before uploading a new one
-- Allow to downgrade RPMs and DEBs
+- Allow downgrading RPM and DEB packages
+- Ignore disabled instances when counting disabled instances
 
 ## [1.12.0] - 2022-03-03
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -332,6 +332,7 @@ cartridge_cached_fact_names_by_target:
   count_disabled_instances:
     - instance_info
     - disabled
+    - expelled
   facts_for_machines:
     - expelled
     - disabled

--- a/library/cartridge_get_disabled_instances.py
+++ b/library/cartridge_get_disabled_instances.py
@@ -38,6 +38,7 @@ def count_cluster_disabled_instances(module_hostvars, play_hosts, ignore_split_b
         lambda name: all([
             get_disabled_instances_from_instance_config(module_hostvars[name]) is not None,
             get_topology_checksum_from_instance_config(module_hostvars[name]) is not None,
+            not helpers.is_expelled(module_hostvars[name]),
         ]),
         play_hosts,
     ))

--- a/unit/test_get_cached_facts.py
+++ b/unit/test_get_cached_facts.py
@@ -69,6 +69,7 @@ class TestGetCachedFacts(unittest.TestCase):
             },
             'count_disabled_instances': {
                 'instance_1': {
+                    'expelled': True,
                     'instance_info': {
                         'disabled_instances': [],
                     },


### PR DESCRIPTION
Closes #412

Before the patch, if an expelled instance wasn't ignored in `cartridge_get_disabled_instances`.
So, check for `All instances in cluster has different topology configs` didn't work correctly.

Now, it possible to use the role, when an expelled instance has different config.