### PR TITLE
Add disabled instances to `single_instances_for_each_machine` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ README.md to use the newest tag with new release
 - Remove old app configurations before uploading a new one
 - Allow downgrading RPM and DEB packages
 - Ignore disabled instances when counting disabled instances
+- Add disabled instances to `single_instances_for_each_machine` variable
 
 ## [1.12.0] - 2022-03-03
 

--- a/library/cartridge_get_facts_for_machines.py
+++ b/library/cartridge_get_facts_for_machines.py
@@ -27,6 +27,7 @@ def get_facts_for_machines(params):
     play_hosts = params['play_hosts']
 
     single_instances_for_each_machine = {}
+    single_instances_for_each_machine_with_disabled = {}
     instances_by_machines = {}
     instances_from_same_machine = {}
 
@@ -41,12 +42,23 @@ def get_facts_for_machines(params):
         # Copy link to machine list
         instances_from_same_machine[instance_name] = instances_by_machines[machine_id]
 
-        # Calculate single not expelled instance for each machine
+        # Calculate single enabled instance for each machine
         if all([
             helpers.is_enabled(instance_vars),
             instance_name not in cluster_disabled_instances,
             machine_id not in single_instances_for_each_machine,
         ]):
+            single_instances_for_each_machine[machine_id] = instance_name
+        # Calculate single not expelled instance for each machine
+        elif all([
+            not helpers.is_expelled(instance_vars),
+            machine_id not in single_instances_for_each_machine_with_disabled,
+        ]):
+            single_instances_for_each_machine_with_disabled[machine_id] = instance_name
+
+    # If there is no enabled instance, then check for the presence of a disabled (not expelled) one
+    for machine_id, instance_name in single_instances_for_each_machine_with_disabled.items():
+        if machine_id not in single_instances_for_each_machine:
             single_instances_for_each_machine[machine_id] = instance_name
 
     return helpers.ModuleRes(

--- a/unit/test_get_facts_for_machines.py
+++ b/unit/test_get_facts_for_machines.py
@@ -33,6 +33,7 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
             },
             'instance-1-1': {
                 'ansible_host': 'host-1',
+                'disabled': True,
             },
             'instance-1-2': {
                 'ansible_host': 'host-1',
@@ -68,6 +69,10 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
             'instance-2-4': {
                 'ansible_host': 'host-2',
                 'ansible_port': 44,  # one more different port
+            },
+            'instance-3-1': {
+                'ansible_host': 'host-3',
+                'disabled': True,
             },
         }
 
@@ -105,13 +110,18 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
             'stateboard-1', 'stateboard-2',
             'instance-1-1', 'instance-1-2', 'instance-1-3', 'instance-1-4',
             'instance-2-1', 'instance-2-2', 'instance-2-3', 'instance-2-4',
+            'instance-3-1',
         ])
         self.assertFalse(res.failed, res.msg)
 
         single_instances_for_each_machine = res.kwargs['single_instances_for_each_machine']
         self.assertSetEqual(set(single_instances_for_each_machine), {
-            'instance-1-1', 'instance-1-3',
-            'instance-2-1', 'instance-2-3', 'instance-2-4',
+            'instance-1-2',  # host-1:22
+            'instance-1-3',  # host-1:33
+            'instance-2-1',  # host-2:22
+            'instance-2-3',  # host-2:33
+            'instance-2-4',  # host-2:44
+            'instance-3-1',  # host-3:22
         })
         self.assertEqual(res.kwargs['instances_from_same_machine'], {
             # host-1:22
@@ -131,4 +141,6 @@ class TestGetOneInstanceForMachine(unittest.TestCase):
             'instance-2-3': ['instance-2-3'],
             # host-2:44
             'instance-2-4': ['instance-2-4'],
+            # host-3:22
+            'instance-3-1': ['instance-3-1'],
         })


### PR DESCRIPTION
Before this patch, only enabled instances got into the `single_instances_for_each_machine` variable. This prevented updating instances that are disabled.

Now, if no enabled instance was found for a machine, a disabled instance is added to this list.